### PR TITLE
fix(perf): désactive animations sur mobile, réduit charge GPU iOS WKWebView

### DIFF
--- a/src/components/home/AboutSection.tsx
+++ b/src/components/home/AboutSection.tsx
@@ -1,8 +1,6 @@
 import { motion } from "framer-motion";
 import { useMotionVariants } from "../../hooks/useMotionVariants";
 
-const getRandomNumber = () => Math.floor(Math.random() * 2) + 1;
-
 const AboutSection = () => {
   const { fadeInUp, fadeInLeft, fadeInRight } = useMotionVariants();
 
@@ -20,7 +18,7 @@ const AboutSection = () => {
         <div className="grid md:grid-cols-2 gap-12 items-center mb-8">
           <motion.div {...fadeInLeft()}>
             <img
-              src={`assets/about/oriane-montabonnet-${getRandomNumber()}.webp`}
+              src="assets/about/oriane-montabonnet-1.webp"
               alt="Oriane Montabonnet - Thérapeute"
               className="rounded-lg shadow-lg w-full"
               sizes="100vw"

--- a/src/components/home/IntroSection.tsx
+++ b/src/components/home/IntroSection.tsx
@@ -41,7 +41,7 @@ export const IntroSection = () => {
 
         <div className="mt-5 md:mt-10 grid md:grid-cols-3 gap-6 md:gap-8">
           {features.map((feature, index) => (
-            <FeatureCard key={index} feature={feature} index={index} />
+            <FeatureCard key={index} feature={feature} />
           ))}
         </div>
       </div>
@@ -51,20 +51,15 @@ export const IntroSection = () => {
 
 interface FeatureCardProps {
   feature: IntroFeature;
-  index: number;
 }
 
-const FeatureCard = ({ feature, index }: FeatureCardProps) => {
-  const { fadeInUp } = useMotionVariants();
+const FeatureCard = ({ feature }: FeatureCardProps) => {
   return (
-    <motion.div
-      {...fadeInUp({ duration: 0.5, delay: index * 0.2 })}
-      className="bg-sage-50 p-8 rounded-lg"
-    >
+    <div className="bg-sage-50 p-8 rounded-lg">
       <h3 className="text-3xl font-serif font-semibold text-sage-800 mb-4">
         {feature.title}
       </h3>
       <p className="text-sage-600">{feature.description}</p>
-    </motion.div>
+    </div>
   );
 };

--- a/src/components/home/ProcessSection.tsx
+++ b/src/components/home/ProcessSection.tsx
@@ -3,7 +3,7 @@ import { Clock, MessageCircle, Sparkles, Target } from "lucide-react";
 import { useMotionVariants } from "../../hooks/useMotionVariants";
 
 const ProcessSection = () => {
-  const { fadeInUp, fadeInRight, fadeInLeft, fadeIn } = useMotionVariants();
+  const { fadeInUp, fadeIn } = useMotionVariants();
   const steps = [
     {
       icon: MessageCircle,
@@ -49,9 +49,8 @@ const ProcessSection = () => {
 
           <div className="space-y-8 relative">
             {steps.map((step, index) => (
-              <motion.div
+              <div
                 key={index}
-                {...(index % 2 === 0 ? fadeInLeft() : fadeInRight())}
                 className={`flex flex-col md:flex-row gap-8 ${
                   index % 2 === 0
                     ? "md:pr-1/2"
@@ -72,7 +71,7 @@ const ProcessSection = () => {
                     {index + 1}
                   </div>
                 </div>
-              </motion.div>
+              </div>
             ))}
           </div>
         </div>

--- a/src/components/home/QualificationsSection.tsx
+++ b/src/components/home/QualificationsSection.tsx
@@ -50,9 +50,8 @@ const QualificationsSection = () => {
             </div>
             <div className="space-y-8 ">
               {qualifications.map((qual, index) => (
-                <motion.div
+                <div
                   key={index}
-                  {...fadeInUp({ duration: 0.5, delay: index * 0.1 })}
                   className="bg-white p-6 rounded-lg shadow-sm"
                 >
                   <div className="text-mint-600 font-medium mb-2">
@@ -63,7 +62,7 @@ const QualificationsSection = () => {
                   </h4>
                   <div className="text-sage-600 mb-2">{qual.institution}</div>
                   <p className="text-sage-600 text-sm">{qual.description}</p>
-                </motion.div>
+                </div>
               ))}
             </div>
           </motion.div>

--- a/src/components/home/ServicesSection.tsx
+++ b/src/components/home/ServicesSection.tsx
@@ -76,9 +76,8 @@ const ServicesSection = () => {
 
         <div className="grid md:grid-cols-2 gap-6 md:gap-8">
           {services.map((service, index) => (
-            <motion.div
+            <div
               key={index}
-              {...fadeInUp({ duration: 0.5, delay: index * 0.1 })}
               className="bg-white p-8 rounded-lg shadow-sm hover:shadow-md transition-shadow"
             >
               <service.icon className="h-12 w-12 text-mint-600 mb-6" />
@@ -98,7 +97,7 @@ const ServicesSection = () => {
               >
                 En savoir plus →
               </a>
-            </motion.div>
+            </div>
           ))}
         </div>
 

--- a/src/components/pricing/PriceCard.tsx
+++ b/src/components/pricing/PriceCard.tsx
@@ -1,7 +1,5 @@
-import { motion } from "framer-motion";
 import parse from "html-react-parser";
 import { Check } from "lucide-react";
-import { useMotionVariants } from "../../hooks/useMotionVariants";
 
 interface PriceCardProps {
   title: string;
@@ -16,13 +14,8 @@ export const PriceCard = ({
   features,
   index,
 }: PriceCardProps) => {
-  const { fadeInUp } = useMotionVariants();
-
   return (
-    <motion.div
-      {...fadeInUp({ delay: index * 0.1, duration: 0.5 })}
-      className="bg-white p-8 rounded-lg shadow-sm hover:shadow-md transition-shadow"
-    >
+    <div className="bg-white p-8 rounded-lg shadow-sm hover:shadow-md transition-shadow">
       <h3 className="text-3xl font-serif font-semibold text-sage-800 mb-4">
         {title}
       </h3>
@@ -55,6 +48,6 @@ export const PriceCard = ({
           </li>
         ))}
       </ul>
-    </motion.div>
+    </div>
   );
 };

--- a/src/hooks/useMotionVariants.ts
+++ b/src/hooks/useMotionVariants.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import type { MotionProps } from "framer-motion";
 
 interface MotionVariantOptions {
@@ -6,20 +7,28 @@ interface MotionVariantOptions {
   distance?: number;
 }
 
-const reducedMotionProps: MotionProps = {
-  initial: {},
-  viewport: { once: true },
-  transition: { duration: 0 },
+// Renders the element with its final appearance immediately — no observer,
+// no will-change layer, no WAAPI animation scheduled.
+const staticProps: MotionProps = {
+  initial: false,
 };
 
+function shouldDisableAnimations(): boolean {
+  if (typeof window === "undefined") return false;
+  if (typeof window.matchMedia !== "function") return false;
+  // Touch-primary devices (phones/tablets): limited GPU memory in WKWebView.
+  if (window.matchMedia("(hover: none) and (pointer: coarse)").matches)
+    return true;
+  // Explicit accessibility preference.
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return true;
+  return false;
+}
+
 export const useMotionVariants = () => {
-  const prefersReducedMotion =
-    typeof window !== "undefined" &&
-    typeof window.matchMedia === "function" &&
-    window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  const noMotion = useMemo(() => shouldDisableAnimations(), []);
 
   const fadeInUp = (options: MotionVariantOptions = {}): MotionProps => {
-    if (prefersReducedMotion) return reducedMotionProps;
+    if (noMotion) return staticProps;
     return {
       initial: { opacity: 0, y: options.distance ?? 20 },
       whileInView: { opacity: 1, y: 0 },
@@ -32,7 +41,7 @@ export const useMotionVariants = () => {
   };
 
   const fadeIn = (options: MotionVariantOptions = {}): MotionProps => {
-    if (prefersReducedMotion) return reducedMotionProps;
+    if (noMotion) return staticProps;
     return {
       initial: { opacity: 0 },
       whileInView: { opacity: 1 },
@@ -45,7 +54,7 @@ export const useMotionVariants = () => {
   };
 
   const fadeInLeft = (options: MotionVariantOptions = {}): MotionProps => {
-    if (prefersReducedMotion) return reducedMotionProps;
+    if (noMotion) return staticProps;
     return {
       initial: { opacity: 0, x: -(options.distance ?? 20) },
       whileInView: { opacity: 1, x: 0 },
@@ -58,7 +67,7 @@ export const useMotionVariants = () => {
   };
 
   const fadeInRight = (options: MotionVariantOptions = {}): MotionProps => {
-    if (prefersReducedMotion) return reducedMotionProps;
+    if (noMotion) return staticProps;
     return {
       initial: { opacity: 0, x: options.distance ?? 20 },
       whileInView: { opacity: 1, x: 0 },
@@ -71,7 +80,7 @@ export const useMotionVariants = () => {
   };
 
   const staggerChildren = (options: MotionVariantOptions = {}): MotionProps => {
-    if (prefersReducedMotion) return reducedMotionProps;
+    if (noMotion) return staticProps;
     return {
       initial: { opacity: 0 },
       whileInView: { opacity: 1 },

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -53,7 +53,7 @@ const jsonLd = [
       <ProcessSection client:visible />
     </section>
 
-    <LocalAreaSection client:visible />
+    <LocalAreaSection />
 
     <section id="qualifications" aria-label="Formations et qualifications">
       <QualificationsSection client:visible />
@@ -63,7 +63,7 @@ const jsonLd = [
       <PricingSection client:visible />
     </section>
 
-    <FAQSection faqs={FAQ_ITEMS} client:visible />
+    <FAQSection faqs={FAQ_ITEMS} />
   </main>
 
   <Footer />


### PR DESCRIPTION
## Problème

Ferme #16

Sur iPhone (iOS), l'ouverture du site depuis un lien SMS (navigateur intégré dans Messages = WKWebView) provoquait des animations extrêmement lentes puis un crash de l'application Messages.

## Cause racine

La page d'accueil contenait 34+ éléments `motion.*` Framer Motion sur 7 islands React. Dans un WKWebView partagé avec l'app Messages :
1. Chaque `motion.div whileInView` = 1 IntersectionObserver + couche GPU (`will-change: transform`)
2. 34+ couches simultanées → mémoire GPU épuisée → crash
3. `LocalAreaSection` et `FAQSection` hydratées inutilement (`client:visible` sur des composants 100% statiques)

## Changements

### 1. `useMotionVariants.ts` — détection des appareils mobiles
- Détecte les appareils tactiles via `(hover: none) and (pointer: coarse)` (standard CSS, plus fiable que le UA)
- Retourne `{ initial: false }` → zéro IntersectionObserver, zéro `will-change`, zéro animation
- `useMemo` pour éviter de recalculer à chaque rendu

### 2. `index.astro` — suppression d'hydrations inutiles
- `<LocalAreaSection />` : retiré `client:visible` (composant 100% statique)
- `<FAQSection />` : retiré `client:visible` (composant 100% statique, `<details>` natif)

### 3. Réduction cardinalité des animations (−18 `motion.div`)
- `IntroSection/FeatureCard`, `ServicesSection`, `ProcessSection`, `QualificationsSection`, `PriceCard` : cartes individuelles → `div` plain
- Les conteneurs de section gardent leurs animations sur desktop

### 4. Fix `AboutSection` — mismatch d'hydration React
- Supprimé `getRandomNumber()` (valeurs différentes SSR vs client)

## Impact

| | Avant | Après |
|---|---|---|
| `motion.*` home | ~34 | ~16 |
| Hydrations inutiles | 2 | 0 |
| Animations mobile | ✅ actives ( désactivées (stable) |crash) | 
| `will-change` layers mobiles | 34+ | 0 |