### PR TITLE
feat(legal): pages réglementaires françaises et européennes

### DIFF
--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -220,15 +220,26 @@ const mapsUrl = `https://www.google.com/maps/search/${encodeURIComponent(COMPANY
     </div>
 
     <!-- Bas de pied de page -->
-    <div class="mt-8 pt-4 border-t border-sage-700 text-center text-sage-300 text-sm flex flex-col md:flex-row items-center justify-center gap-2">
-      <span>©{currentYear} Oriane Montabonnet. Tous droits réservés.</span>
-      <a
-        href="/accessibilite"
-        class="hover:text-mint-400 hover:underline transition-colors"
-        aria-label="Page accessibilité — non conforme"
-      >
-        Accessibilité : non conforme
-      </a>
+    <div class="mt-8 pt-4 border-t border-sage-700 text-center text-sage-300 text-sm space-y-2">
+      <p>©{currentYear} Oriane Montabonnet. Tous droits réservés.</p>
+      <nav aria-label="Liens légaux" class="flex flex-wrap justify-center gap-x-4 gap-y-1">
+        <a href="/mentions-legales" class="hover:text-mint-400 hover:underline transition-colors">
+          Mentions légales
+        </a>
+        <a href="/confidentialite" class="hover:text-mint-400 hover:underline transition-colors">
+          Confidentialité
+        </a>
+        <a href="/cgv" class="hover:text-mint-400 hover:underline transition-colors">
+          CGV
+        </a>
+        <a
+          href="/accessibilite"
+          class="hover:text-mint-400 hover:underline transition-colors"
+          aria-label="Page accessibilité — non conforme"
+        >
+          Accessibilité : non conforme
+        </a>
+      </nav>
     </div>
   </div>
 </footer>

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -23,7 +23,7 @@ export interface PricingResult {
 // ---------------------------------------------------------------------------
 
 /** Prix de base par type × durée (en euros) */
-const PRICE_GRID: Record<AppointmentType, Record<AppointmentDuration, number>> = {
+export const PRICE_GRID: Record<AppointmentType, Record<AppointmentDuration, number>> = {
   individual: { 60: 50, 90: 65 },
   couple:     { 60: 75, 90: 90 },
   family:     { 60: 85, 90: 100 },

--- a/src/pages/cgv.astro
+++ b/src/pages/cgv.astro
@@ -3,6 +3,7 @@ import Layout from '../layouts/Layout.astro';
 import Navbar from '../components/islands/Navbar';
 import Footer from '../components/layout/Footer.astro';
 import { PRICE_GRID, FIRST_SESSION_DISCOUNT, SOLIDARITY_DISCOUNT } from '../lib/pricing';
+import { COMPANY_NAME, CONTACT_INFO } from '../config/global.config';
 ---
 
 <Layout
@@ -36,7 +37,7 @@ import { PRICE_GRID, FIRST_SESSION_DISCOUNT, SOLIDARITY_DISCOUNT } from '../lib/
     <section class="max-w-3xl mx-auto px-4 py-8 md:py-10">
       <p class="text-sage-700 mb-8">
         Les présentes Conditions Générales de Vente (CGV) régissent les
-        relations contractuelles entre <strong>Oriane Montabonnet</strong>,
+        relations contractuelles entre <strong>{COMPANY_NAME}</strong>,
         psychopraticienne, ci-après dénommée «&nbsp;le prestataire&nbsp;», et
         toute personne physique majeure souhaitant bénéficier de ses services
         thérapeutiques, ci-après dénommée «&nbsp;le client&nbsp;».
@@ -61,21 +62,21 @@ import { PRICE_GRID, FIRST_SESSION_DISCOUNT, SOLIDARITY_DISCOUNT } from '../lib/
       </h2>
       <div class="h-px bg-sage-200 mb-6" aria-hidden="true"></div>
       <address class="not-italic mb-8 space-y-1">
-        <p><strong>Oriane Montabonnet</strong>, psychopraticienne</p>
-        <p>1086 Av. Albert Einstein, 34000 Montpellier</p>
+        <p><strong>{COMPANY_NAME}</strong>, psychopraticienne</p>
+        <p>{CONTACT_INFO.address}</p>
         <p>
           Téléphone :
-          <a href="tel:+33650331853" class="text-mint-600 underline hover:text-mint-700">
-            06 50 33 18 53
+          <a href={`tel:${CONTACT_INFO.phoneE164}`} class="text-mint-600 underline hover:text-mint-700">
+            {CONTACT_INFO.phone}
           </a>
         </p>
         <p>
           E-mail :
           <a
-            href="mailto:contact@omf-therapie.fr"
+            href={`mailto:${CONTACT_INFO.email}`}
             class="text-mint-600 underline hover:text-mint-700"
           >
-            contact@omf-therapie.fr
+            {CONTACT_INFO.email}
           </a>
         </p>
         <p>SIRET : 90763504900022</p>
@@ -138,8 +139,7 @@ import { PRICE_GRID, FIRST_SESSION_DISCOUNT, SOLIDARITY_DISCOUNT } from '../lib/
         Modalités de prestation
       </h3>
       <p class="mb-8">
-        Les séances peuvent se dérouler en cabinet à Montpellier (1086 Av.
-        Albert Einstein, 34000 Montpellier) ou en téléconsultation par
+        Les séances peuvent se dérouler en cabinet à Montpellier ({CONTACT_INFO.address}) ou en téléconsultation par
         visioconférence sécurisée. Les prix s'entendent toutes taxes comprises
         (TVA non applicable — art. 293 B du Code général des impôts).
       </p>
@@ -161,17 +161,17 @@ import { PRICE_GRID, FIRST_SESSION_DISCOUNT, SOLIDARITY_DISCOUNT } from '../lib/
         </li>
         <li>
           Par téléphone au
-          <a href="tel:+33650331853" class="text-mint-600 underline hover:text-mint-700">
-            06 50 33 18 53
+          <a href={`tel:${CONTACT_INFO.phoneE164}`} class="text-mint-600 underline hover:text-mint-700">
+            {CONTACT_INFO.phone}
           </a>
         </li>
         <li>
           Par e-mail à
           <a
-            href="mailto:contact@omf-therapie.fr"
+            href={`mailto:${CONTACT_INFO.email}`}
             class="text-mint-600 underline hover:text-mint-700"
           >
-            contact@omf-therapie.fr
+            {CONTACT_INFO.email}
           </a>
         </li>
       </ul>

--- a/src/pages/cgv.astro
+++ b/src/pages/cgv.astro
@@ -10,14 +10,29 @@ import Footer from '../components/layout/Footer.astro';
   canonical="https://omf-therapie.fr/cgv"
   noindex={false}
 >
+  <a href="#main-content" class="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-mint-600 focus:text-white focus:rounded">
+    Aller au contenu principal
+  </a>
+
   <Navbar client:load isHomePage={false} />
 
   <main id="main-content" class="pt-20" tabindex="-1">
-    <section class="max-w-3xl mx-auto px-4 py-8 md:py-10">
-      <h1 class="text-3xl md:text-4xl font-serif font-semibold text-sage-800 mb-6">
-        Conditions Générales de Vente
-      </h1>
+    <div class="bg-sage-50 py-8 px-4">
+      <div class="max-w-3xl mx-auto">
+        <nav class="mb-4 text-sm text-sage-500" aria-label="Fil d'Ariane">
+          <ol class="flex items-center gap-2 flex-wrap" role="list">
+            <li role="listitem"><a href="/" class="hover:text-mint-600 transition-colors">Accueil</a></li>
+            <li role="listitem" aria-hidden="true">›</li>
+            <li role="listitem" aria-current="page" class="text-sage-700 font-medium">Conditions Générales de Vente</li>
+          </ol>
+        </nav>
+        <h1 class="text-3xl md:text-4xl font-serif font-semibold text-sage-800">
+          Conditions Générales de Vente
+        </h1>
+      </div>
+    </div>
 
+    <section class="max-w-3xl mx-auto px-4 py-8 md:py-10">
       <p class="text-sage-700 mb-8">
         Les présentes Conditions Générales de Vente (CGV) régissent les
         relations contractuelles entre <strong>Oriane Montabonnet</strong>,

--- a/src/pages/cgv.astro
+++ b/src/pages/cgv.astro
@@ -62,8 +62,7 @@ import Footer from '../components/layout/Footer.astro';
             contact@omf-therapie.fr
           </a>
         </p>
-        <p>SIRET : [À COMPLÉTER]</p>
-        <p>Numéro ADELI : [À COMPLÉTER]</p>
+        <p>SIRET : 90763504900022</p>
       </address>
 
       <!-- 3. Services proposés -->

--- a/src/pages/cgv.astro
+++ b/src/pages/cgv.astro
@@ -2,6 +2,7 @@
 import Layout from '../layouts/Layout.astro';
 import Navbar from '../components/islands/Navbar';
 import Footer from '../components/layout/Footer.astro';
+import { PRICE_GRID, FIRST_SESSION_DISCOUNT, SOLIDARITY_DISCOUNT } from '../lib/pricing';
 ---
 
 <Layout
@@ -101,18 +102,18 @@ import Footer from '../components/layout/Footer.astro';
           <tbody>
             <tr>
               <td class="p-3 border border-sage-200">Thérapie individuelle</td>
-              <td class="p-3 border border-sage-200">50&nbsp;€</td>
-              <td class="p-3 border border-sage-200">65&nbsp;€</td>
+              <td class="p-3 border border-sage-200">{PRICE_GRID.individual[60]}&nbsp;€</td>
+              <td class="p-3 border border-sage-200">{PRICE_GRID.individual[90]}&nbsp;€</td>
             </tr>
             <tr class="bg-sage-50">
               <td class="p-3 border border-sage-200">Thérapie de couple</td>
-              <td class="p-3 border border-sage-200">75&nbsp;€</td>
-              <td class="p-3 border border-sage-200">90&nbsp;€</td>
+              <td class="p-3 border border-sage-200">{PRICE_GRID.couple[60]}&nbsp;€</td>
+              <td class="p-3 border border-sage-200">{PRICE_GRID.couple[90]}&nbsp;€</td>
             </tr>
             <tr>
               <td class="p-3 border border-sage-200">Thérapie familiale</td>
-              <td class="p-3 border border-sage-200">85&nbsp;€</td>
-              <td class="p-3 border border-sage-200">100&nbsp;€</td>
+              <td class="p-3 border border-sage-200">{PRICE_GRID.family[60]}&nbsp;€</td>
+              <td class="p-3 border border-sage-200">{PRICE_GRID.family[90]}&nbsp;€</td>
             </tr>
           </tbody>
         </table>
@@ -123,12 +124,12 @@ import Footer from '../components/layout/Footer.astro';
       </h3>
       <ul class="list-disc pl-6 space-y-2 mb-6">
         <li>
-          <strong>Première séance</strong> : réduction de <strong>15&nbsp;€</strong>
+          <strong>Première séance</strong> : réduction de <strong>{FIRST_SESSION_DISCOUNT}&nbsp;€</strong>
           sur le tarif standard.
         </li>
         <li>
           <strong>Tarif solidaire</strong> (sur justificatif) : réduction de
-          <strong>10&nbsp;€</strong> pour les bénéficiaires du RSA, de
+          <strong>{SOLIDARITY_DISCOUNT}&nbsp;€</strong> pour les bénéficiaires du RSA, de
           l'Allocation de Solidarité Spécifique (ASS) ou les étudiants.
         </li>
       </ul>
@@ -201,7 +202,7 @@ import Footer from '../components/layout/Footer.astro';
       </h3>
       <p class="mb-6">
         Le règlement s'effectue en fin de séance par l'un des moyens suivants :
-        espèces, chèque ou virement bancaire.
+        espèces ou carte bancaire.
       </p>
 
       <h3 class="text-xl font-serif font-semibold text-sage-800 mt-6 mb-3">
@@ -228,8 +229,8 @@ import Footer from '../components/layout/Footer.astro';
         </li>
         <li>
           <strong>Annulation moins de 24 heures avant ou absence non signalée</strong> :
-          la séance est facturée à <strong>50 % du tarif</strong>. Pour les
-          séances en téléconsultation prépayées, 50 % du montant est conservé.
+          la séance est due dans son intégralité. Pour les séances en
+          téléconsultation prépayées, aucun remboursement n'est effectué.
         </li>
         <li>
           <strong>Cas de force majeure ou urgence avérée</strong> (maladie

--- a/src/pages/cgv.astro
+++ b/src/pages/cgv.astro
@@ -1,0 +1,318 @@
+---
+import Layout from '../layouts/Layout.astro';
+import Navbar from '../components/islands/Navbar';
+import Footer from '../components/layout/Footer.astro';
+---
+
+<Layout
+  title="Conditions Générales de Vente — OMF Thérapie"
+  description="Conditions Générales de Vente d'OMF Thérapie pour les prestations de psychothérapie et d'accompagnement thérapeutique."
+  canonical="https://omf-therapie.fr/cgv"
+  noindex={false}
+>
+  <Navbar client:load isHomePage={false} />
+
+  <main id="main-content" class="pt-20" tabindex="-1">
+    <section class="max-w-3xl mx-auto px-4 py-8 md:py-10">
+      <h1 class="text-3xl md:text-4xl font-serif font-semibold text-sage-800 mb-6">
+        Conditions Générales de Vente
+      </h1>
+
+      <p class="text-sage-700 mb-8">
+        Les présentes Conditions Générales de Vente (CGV) régissent les
+        relations contractuelles entre <strong>Oriane Montabonnet</strong>,
+        psychopraticienne, ci-après dénommée «&nbsp;le prestataire&nbsp;», et
+        toute personne physique majeure souhaitant bénéficier de ses services
+        thérapeutiques, ci-après dénommée «&nbsp;le client&nbsp;».
+      </p>
+
+      <!-- 1. Objet -->
+      <h2 class="text-2xl font-serif font-semibold text-sage-800 mt-8 mb-3">
+        1. Objet
+      </h2>
+      <div class="h-px bg-sage-200 mb-6" aria-hidden="true"></div>
+      <p class="mb-8">
+        Les présentes CGV définissent les conditions dans lesquelles le
+        prestataire fournit des prestations de psychothérapie et
+        d'accompagnement thérapeutique au client ayant passé commande via le
+        site <strong>omf-therapie.fr</strong> ou par téléphone. Toute prise de
+        rendez-vous implique l'acceptation pleine et entière des présentes CGV.
+      </p>
+
+      <!-- 2. Prestataire -->
+      <h2 class="text-2xl font-serif font-semibold text-sage-800 mt-8 mb-3">
+        2. Prestataire
+      </h2>
+      <div class="h-px bg-sage-200 mb-6" aria-hidden="true"></div>
+      <address class="not-italic mb-8 space-y-1">
+        <p><strong>Oriane Montabonnet</strong>, psychopraticienne</p>
+        <p>1086 Av. Albert Einstein, 34000 Montpellier</p>
+        <p>
+          Téléphone :
+          <a href="tel:+33650331853" class="text-mint-600 underline hover:text-mint-700">
+            06 50 33 18 53
+          </a>
+        </p>
+        <p>
+          E-mail :
+          <a
+            href="mailto:contact@omf-therapie.fr"
+            class="text-mint-600 underline hover:text-mint-700"
+          >
+            contact@omf-therapie.fr
+          </a>
+        </p>
+        <p>SIRET : [À COMPLÉTER]</p>
+        <p>Numéro ADELI : [À COMPLÉTER]</p>
+      </address>
+
+      <!-- 3. Services proposés -->
+      <h2 class="text-2xl font-serif font-semibold text-sage-800 mt-8 mb-3">
+        3. Services proposés et tarifs
+      </h2>
+      <div class="h-px bg-sage-200 mb-6" aria-hidden="true"></div>
+
+      <h3 class="text-xl font-serif font-semibold text-sage-800 mt-6 mb-3">
+        Types de consultation
+      </h3>
+      <div class="overflow-x-auto mb-6">
+        <table class="w-full text-sm border-collapse">
+          <thead>
+            <tr class="bg-sage-100 text-sage-800">
+              <th class="text-left p-3 border border-sage-200 font-semibold">Prestation</th>
+              <th class="text-left p-3 border border-sage-200 font-semibold">60 minutes</th>
+              <th class="text-left p-3 border border-sage-200 font-semibold">90 minutes</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td class="p-3 border border-sage-200">Thérapie individuelle</td>
+              <td class="p-3 border border-sage-200">50&nbsp;€</td>
+              <td class="p-3 border border-sage-200">65&nbsp;€</td>
+            </tr>
+            <tr class="bg-sage-50">
+              <td class="p-3 border border-sage-200">Thérapie de couple</td>
+              <td class="p-3 border border-sage-200">75&nbsp;€</td>
+              <td class="p-3 border border-sage-200">90&nbsp;€</td>
+            </tr>
+            <tr>
+              <td class="p-3 border border-sage-200">Thérapie familiale</td>
+              <td class="p-3 border border-sage-200">85&nbsp;€</td>
+              <td class="p-3 border border-sage-200">100&nbsp;€</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h3 class="text-xl font-serif font-semibold text-sage-800 mt-6 mb-3">
+        Réductions applicables
+      </h3>
+      <ul class="list-disc pl-6 space-y-2 mb-6">
+        <li>
+          <strong>Première séance</strong> : réduction de <strong>15&nbsp;€</strong>
+          sur le tarif standard.
+        </li>
+        <li>
+          <strong>Tarif solidaire</strong> (sur justificatif) : réduction de
+          <strong>10&nbsp;€</strong> pour les bénéficiaires du RSA, de
+          l'Allocation de Solidarité Spécifique (ASS) ou les étudiants.
+        </li>
+      </ul>
+
+      <h3 class="text-xl font-serif font-semibold text-sage-800 mt-6 mb-3">
+        Modalités de prestation
+      </h3>
+      <p class="mb-8">
+        Les séances peuvent se dérouler en cabinet à Montpellier (1086 Av.
+        Albert Einstein, 34000 Montpellier) ou en téléconsultation par
+        visioconférence sécurisée. Les prix s'entendent toutes taxes comprises
+        (TVA non applicable — art. 293 B du Code général des impôts).
+      </p>
+
+      <!-- 4. Prise de rendez-vous -->
+      <h2 class="text-2xl font-serif font-semibold text-sage-800 mt-8 mb-3">
+        4. Modalités de prise de rendez-vous
+      </h2>
+      <div class="h-px bg-sage-200 mb-6" aria-hidden="true"></div>
+      <p class="mb-4">
+        La prise de rendez-vous s'effectue :
+      </p>
+      <ul class="list-disc pl-6 space-y-2 mb-6">
+        <li>
+          Via le formulaire de réservation en ligne sur
+          <a href="https://omf-therapie.fr" class="text-mint-600 underline hover:text-mint-700">
+            omf-therapie.fr
+          </a>
+        </li>
+        <li>
+          Par téléphone au
+          <a href="tel:+33650331853" class="text-mint-600 underline hover:text-mint-700">
+            06 50 33 18 53
+          </a>
+        </li>
+        <li>
+          Par e-mail à
+          <a
+            href="mailto:contact@omf-therapie.fr"
+            class="text-mint-600 underline hover:text-mint-700"
+          >
+            contact@omf-therapie.fr
+          </a>
+        </li>
+      </ul>
+      <p class="mb-8">
+        Une confirmation de rendez-vous est adressée par e-mail après validation
+        de la réservation. Ce courriel constitue l'accusé de réception de la
+        commande au sens de l'article L221-19 du Code de la consommation.
+      </p>
+
+      <!-- 5. Paiement -->
+      <h2 class="text-2xl font-serif font-semibold text-sage-800 mt-8 mb-3">
+        5. Modalités de paiement
+      </h2>
+      <div class="h-px bg-sage-200 mb-6" aria-hidden="true"></div>
+
+      <h3 class="text-xl font-serif font-semibold text-sage-800 mt-6 mb-3">
+        Téléconsultation
+      </h3>
+      <p class="mb-6">
+        Les séances en téléconsultation font l'objet d'un prépaiement sécurisé
+        par carte bancaire via la plateforme <strong>Stripe</strong>. Le
+        paiement est débité au moment de la confirmation de la réservation. Les
+        données bancaires ne transitent jamais par nos serveurs.
+      </p>
+
+      <h3 class="text-xl font-serif font-semibold text-sage-800 mt-6 mb-3">
+        Séances en cabinet
+      </h3>
+      <p class="mb-6">
+        Le règlement s'effectue en fin de séance par l'un des moyens suivants :
+        espèces, chèque ou virement bancaire.
+      </p>
+
+      <h3 class="text-xl font-serif font-semibold text-sage-800 mt-6 mb-3">
+        Remboursement par la Sécurité Sociale
+      </h3>
+      <p class="mb-8">
+        Les séances de psychothérapie ne sont <strong>pas remboursées par
+        l'Assurance Maladie</strong>. Certaines mutuelles et complémentaires
+        santé proposent une prise en charge partielle. Nous vous conseillons de
+        vous renseigner directement auprès de votre organisme complémentaire.
+        Une facture peut être fournie sur demande.
+      </p>
+
+      <!-- 6. Annulation et report -->
+      <h2 class="text-2xl font-serif font-semibold text-sage-800 mt-8 mb-3">
+        6. Annulation et report de séance
+      </h2>
+      <div class="h-px bg-sage-200 mb-6" aria-hidden="true"></div>
+      <ul class="list-disc pl-6 space-y-2 mb-6">
+        <li>
+          <strong>Annulation jusqu'à 24 heures avant la séance</strong> :
+          gratuite. La séance prépayée est intégralement remboursée ou reportée
+          sans frais.
+        </li>
+        <li>
+          <strong>Annulation moins de 24 heures avant ou absence non signalée</strong> :
+          la séance est facturée à <strong>50 % du tarif</strong>. Pour les
+          séances en téléconsultation prépayées, 50 % du montant est conservé.
+        </li>
+        <li>
+          <strong>Cas de force majeure ou urgence avérée</strong> (maladie
+          soudaine, accident, hospitalisation…) : aucune facturation ne sera
+          appliquée sur justificatif.
+        </li>
+      </ul>
+      <p class="mb-8">
+        Pour annuler ou reporter un rendez-vous, contactez-nous par téléphone ou
+        par e-mail dans les meilleurs délais.
+      </p>
+
+      <!-- 7. Droit de rétractation -->
+      <h2 class="text-2xl font-serif font-semibold text-sage-800 mt-8 mb-3">
+        7. Droit de rétractation
+      </h2>
+      <div class="h-px bg-sage-200 mb-6" aria-hidden="true"></div>
+      <p class="mb-4">
+        Conformément à l'article L221-28 du Code de la consommation, le droit
+        de rétractation de 14 jours ne s'applique pas aux contrats de prestations
+        de services pleinement exécutés avant la fin du délai de rétractation,
+        ni aux soins relatifs à la santé mentale fournis par un professionnel de
+        santé.
+      </p>
+      <p class="mb-8">
+        Pour les séances réservées en ligne et non encore tenues, l'annulation
+        est possible selon les conditions définies à l'article 6 ci-dessus.
+      </p>
+
+      <!-- 8. Confidentialité -->
+      <h2 class="text-2xl font-serif font-semibold text-sage-800 mt-8 mb-3">
+        8. Confidentialité et secret professionnel
+      </h2>
+      <div class="h-px bg-sage-200 mb-6" aria-hidden="true"></div>
+      <p class="mb-4">
+        Le prestataire est soumis au secret professionnel absolu. Toutes les
+        informations partagées lors des séances sont strictement confidentielles
+        et ne peuvent être divulguées à des tiers, sauf obligations légales
+        (signalement de danger immédiat, réquisition judiciaire).
+      </p>
+      <p class="mb-8">
+        Les données personnelles collectées dans le cadre de la prise de
+        rendez-vous sont traitées conformément à notre
+        <a href="/confidentialite" class="text-mint-600 underline hover:text-mint-700">
+          politique de confidentialité
+        </a>.
+      </p>
+
+      <!-- 9. Responsabilité -->
+      <h2 class="text-2xl font-serif font-semibold text-sage-800 mt-8 mb-3">
+        9. Responsabilité
+      </h2>
+      <div class="h-px bg-sage-200 mb-6" aria-hidden="true"></div>
+      <p class="mb-4">
+        L'accompagnement thérapeutique proposé ne se substitue en aucun cas à
+        un traitement médical ou psychiatrique. En cas de symptômes médicaux ou
+        psychiatriques, le client est invité à consulter un médecin ou un
+        psychiatre.
+      </p>
+      <p class="mb-8">
+        Le prestataire s'engage à une <strong>obligation de moyens</strong> et
+        non de résultat. Les progrès thérapeutiques dépendent de nombreux
+        facteurs propres à chaque individu et ne peuvent être garantis.
+      </p>
+
+      <!-- 10. Droit applicable -->
+      <h2 class="text-2xl font-serif font-semibold text-sage-800 mt-8 mb-3">
+        10. Droit applicable et juridiction compétente
+      </h2>
+      <div class="h-px bg-sage-200 mb-6" aria-hidden="true"></div>
+      <p class="mb-4">
+        Les présentes CGV sont soumises au droit français. En cas de litige, les
+        parties s'efforceront de trouver une solution amiable. À défaut d'accord
+        amiable, les tribunaux de Montpellier seront seuls compétents.
+      </p>
+      <p class="mb-8">
+        Conformément à l'article L612-1 du Code de la consommation, le client
+        peut recourir gratuitement à un médiateur de la consommation. Pour tout
+        litige non résolu, vous pouvez accéder à la plateforme européenne de
+        résolution des litiges en ligne :
+        <a
+          href="https://ec.europa.eu/consumers/odr"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-mint-600 underline hover:text-mint-700"
+        >
+          https://ec.europa.eu/consumers/odr
+        </a>.
+      </p>
+
+      <hr class="my-8 border-sage-200" />
+
+      <p class="text-sage-600 text-sm">
+        <time datetime="2026-05-18">Mise à jour : 18 mai 2026</time>
+      </p>
+    </section>
+  </main>
+
+  <Footer />
+</Layout>

--- a/src/pages/confidentialite.astro
+++ b/src/pages/confidentialite.astro
@@ -1,0 +1,306 @@
+---
+import Layout from '../layouts/Layout.astro';
+import Navbar from '../components/islands/Navbar';
+import Footer from '../components/layout/Footer.astro';
+---
+
+<Layout
+  title="Politique de confidentialité — OMF Thérapie"
+  description="Politique de confidentialité d'OMF Thérapie conforme au RGPD (règlement UE 2016/679) et aux recommandations CNIL 2024."
+  canonical="https://omf-therapie.fr/confidentialite"
+  noindex={false}
+>
+  <Navbar client:load isHomePage={false} />
+
+  <main id="main-content" class="pt-20" tabindex="-1">
+    <section class="max-w-3xl mx-auto px-4 py-8 md:py-10">
+      <h1 class="text-3xl md:text-4xl font-serif font-semibold text-sage-800 mb-6">
+        Politique de confidentialité
+      </h1>
+
+      <p class="text-sage-700 mb-8">
+        La présente politique de confidentialité décrit la façon dont
+        <strong>Oriane Montabonnet</strong> (ci-après «&nbsp;nous&nbsp;» ou
+        «&nbsp;le responsable du traitement&nbsp;») collecte, utilise et protège
+        vos données personnelles, conformément au règlement (UE) 2016/679 du
+        Parlement européen et du Conseil du 27 avril 2016 (RGPD) et à la loi
+        n°78-17 du 6 janvier 1978 modifiée (loi Informatique et Libertés).
+      </p>
+
+      <!-- 1. Responsable du traitement -->
+      <h2 class="text-2xl font-serif font-semibold text-sage-800 mt-8 mb-3">
+        1. Responsable du traitement
+      </h2>
+      <div class="h-px bg-sage-200 mb-6" aria-hidden="true"></div>
+      <address class="not-italic mb-8 space-y-1">
+        <p><strong>Oriane Montabonnet</strong>, psychopraticienne</p>
+        <p>1086 Av. Albert Einstein, 34000 Montpellier</p>
+        <p>
+          E-mail :
+          <a
+            href="mailto:contact@omf-therapie.fr"
+            class="text-mint-600 underline hover:text-mint-700"
+          >
+            contact@omf-therapie.fr
+          </a>
+        </p>
+        <p>
+          Téléphone :
+          <a href="tel:+33650331853" class="text-mint-600 underline hover:text-mint-700">
+            06 50 33 18 53
+          </a>
+        </p>
+      </address>
+
+      <!-- 2. Données collectées -->
+      <h2 class="text-2xl font-serif font-semibold text-sage-800 mt-8 mb-3">
+        2. Données collectées
+      </h2>
+      <div class="h-px bg-sage-200 mb-6" aria-hidden="true"></div>
+
+      <h3 class="text-xl font-serif font-semibold text-sage-800 mt-6 mb-3">
+        Formulaire de contact
+      </h3>
+      <p class="mb-4">
+        Lorsque vous utilisez notre formulaire de contact, nous collectons les
+        informations suivantes :
+      </p>
+      <ul class="list-disc pl-6 space-y-2 mb-6">
+        <li>Nom et prénom</li>
+        <li>Adresse e-mail</li>
+        <li>Numéro de téléphone</li>
+        <li>Contenu de votre message</li>
+      </ul>
+
+      <h3 class="text-xl font-serif font-semibold text-sage-800 mt-6 mb-3">
+        Formulaire de prise de rendez-vous
+      </h3>
+      <p class="mb-4">
+        Lors de la réservation d'une séance en ligne, nous collectons :
+      </p>
+      <ul class="list-disc pl-6 space-y-2 mb-6">
+        <li>Nom et prénom</li>
+        <li>Adresse e-mail</li>
+        <li>Numéro de téléphone</li>
+        <li>Type de consultation souhaité (individuelle, de couple, familiale)</li>
+        <li>Durée souhaitée (60 ou 90 minutes)</li>
+        <li>Motif de consultation (facultatif)</li>
+      </ul>
+
+      <h3 class="text-xl font-serif font-semibold text-sage-800 mt-6 mb-3">
+        Cookie de session administrateur
+      </h3>
+      <p class="mb-8">
+        Un cookie de session technique (httpOnly, sécurisé) est utilisé
+        exclusivement pour l'authentification à l'espace d'administration du site.
+        Ce cookie n'effectue aucun suivi de navigation, n'est pas accessible via
+        JavaScript et n'est déposé que lors d'une connexion à l'interface
+        d'administration. <strong>Aucune donnée de navigation n'est collectée.</strong>
+        Nous n'utilisons pas d'outil d'analyse d'audience (pas de Google Analytics,
+        pas de Matomo, etc.).
+      </p>
+
+      <!-- 3. Finalités et bases légales -->
+      <h2 class="text-2xl font-serif font-semibold text-sage-800 mt-8 mb-3">
+        3. Finalités et bases légales des traitements
+      </h2>
+      <div class="h-px bg-sage-200 mb-6" aria-hidden="true"></div>
+      <div class="overflow-x-auto mb-8">
+        <table class="w-full text-sm border-collapse">
+          <thead>
+            <tr class="bg-sage-100 text-sage-800">
+              <th class="text-left p-3 border border-sage-200 font-semibold">Finalité</th>
+              <th class="text-left p-3 border border-sage-200 font-semibold">Base légale (RGPD)</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td class="p-3 border border-sage-200">Répondre à vos demandes de contact</td>
+              <td class="p-3 border border-sage-200">Consentement — art. 6-1-a</td>
+            </tr>
+            <tr class="bg-sage-50">
+              <td class="p-3 border border-sage-200">Gestion des rendez-vous et facturation</td>
+              <td class="p-3 border border-sage-200">Exécution d'un contrat — art. 6-1-b</td>
+            </tr>
+            <tr>
+              <td class="p-3 border border-sage-200">Administration et sécurité du site</td>
+              <td class="p-3 border border-sage-200">Intérêt légitime — art. 6-1-f</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- 4. Durée de conservation -->
+      <h2 class="text-2xl font-serif font-semibold text-sage-800 mt-8 mb-3">
+        4. Durée de conservation
+      </h2>
+      <div class="h-px bg-sage-200 mb-6" aria-hidden="true"></div>
+      <ul class="list-disc pl-6 space-y-2 mb-8">
+        <li>
+          <strong>Données de contact</strong> : 3 ans à compter du dernier contact,
+          conformément aux recommandations CNIL.
+        </li>
+        <li>
+          <strong>Données de rendez-vous</strong> : 5 ans à compter de la séance,
+          correspondant au délai de prescription civile (art. 2224 du Code civil).
+        </li>
+        <li>
+          <strong>Données de paiement</strong> : gérées directement par Stripe.
+          Les données comptables sont conservées 10 ans conformément aux obligations
+          légales (art. L123-22 du Code de commerce).
+        </li>
+        <li>
+          <strong>Cookie de session</strong> : supprimé à la fermeture de la session
+          ou à la déconnexion.
+        </li>
+      </ul>
+
+      <!-- 5. Destinataires et sous-traitants -->
+      <h2 class="text-2xl font-serif font-semibold text-sage-800 mt-8 mb-3">
+        5. Destinataires et sous-traitants
+      </h2>
+      <div class="h-px bg-sage-200 mb-6" aria-hidden="true"></div>
+      <p class="mb-4">
+        Vos données peuvent être transmises aux sous-traitants techniques
+        suivants, dans le strict cadre des finalités décrites ci-dessus. Ces
+        transferts hors Union européenne sont encadrés par des garanties
+        appropriées (clauses contractuelles types approuvées par la Commission
+        européenne) :
+      </p>
+      <ul class="list-disc pl-6 space-y-2 mb-8">
+        <li>
+          <strong>Supabase</strong> (Supabase, Inc., USA) — base de données et
+          stockage sécurisé des données de rendez-vous et de contact.
+        </li>
+        <li>
+          <strong>Resend</strong> (Resend, Inc., USA) — envoi des e-mails
+          transactionnels (confirmation de rendez-vous, accusé de réception de
+          contact).
+        </li>
+        <li>
+          <strong>Stripe</strong> (Stripe, Inc., USA) — traitement sécurisé des
+          paiements pour les téléconsultations. Les données de carte bancaire ne
+          transitent pas par nos serveurs.
+        </li>
+        <li>
+          <strong>Google</strong> (Google LLC, USA) — gestion du calendrier des
+          rendez-vous via Google Calendar.
+        </li>
+        <li>
+          <strong>Netlify</strong> (Netlify, Inc., USA) — hébergement du site web.
+        </li>
+      </ul>
+
+      <!-- 6. Vos droits -->
+      <h2 class="text-2xl font-serif font-semibold text-sage-800 mt-8 mb-3">
+        6. Vos droits
+      </h2>
+      <div class="h-px bg-sage-200 mb-6" aria-hidden="true"></div>
+      <p class="mb-4">
+        Conformément au RGPD, vous disposez des droits suivants concernant vos
+        données personnelles :
+      </p>
+      <ul class="list-disc pl-6 space-y-2 mb-6">
+        <li><strong>Droit d'accès</strong> (art. 15 RGPD) : obtenir la confirmation que vos données sont traitées et en recevoir une copie.</li>
+        <li><strong>Droit de rectification</strong> (art. 16 RGPD) : faire corriger des données inexactes ou incomplètes.</li>
+        <li><strong>Droit à l'effacement</strong> (art. 17 RGPD) : obtenir la suppression de vos données dans les conditions prévues par le RGPD.</li>
+        <li><strong>Droit à la portabilité</strong> (art. 20 RGPD) : recevoir vos données dans un format structuré et lisible par machine.</li>
+        <li><strong>Droit d'opposition</strong> (art. 21 RGPD) : vous opposer au traitement de vos données pour des motifs légitimes.</li>
+        <li><strong>Droit à la limitation</strong> (art. 18 RGPD) : demander la suspension temporaire du traitement de vos données.</li>
+      </ul>
+      <p class="mb-4">
+        Pour exercer vos droits, contactez-nous :
+      </p>
+      <ul class="list-disc pl-6 space-y-2 mb-6">
+        <li>
+          Par e-mail :
+          <a
+            href="mailto:contact@omf-therapie.fr"
+            class="text-mint-600 underline hover:text-mint-700"
+          >
+            contact@omf-therapie.fr
+          </a>
+        </li>
+        <li>
+          Via notre formulaire de contact :
+          <a href="/contact" class="text-mint-600 underline hover:text-mint-700">
+            Nous contacter
+          </a>
+        </li>
+      </ul>
+      <p class="mb-8">
+        Nous nous engageons à répondre dans un délai d'un mois à compter de la
+        réception de votre demande. En cas de réponse insatisfaisante, vous pouvez
+        adresser une réclamation à la
+        <a
+          href="https://www.cnil.fr/fr/plaintes"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-mint-600 underline hover:text-mint-700"
+        >
+          Commission Nationale de l'Informatique et des Libertés (CNIL)
+        </a>.
+      </p>
+
+      <!-- 7. Cookies -->
+      <h2 class="text-2xl font-serif font-semibold text-sage-800 mt-8 mb-3">
+        7. Cookies
+      </h2>
+      <div class="h-px bg-sage-200 mb-6" aria-hidden="true"></div>
+      <p class="mb-4">
+        Ce site utilise un seul cookie, de nature strictement technique :
+      </p>
+      <ul class="list-disc pl-6 space-y-2 mb-4">
+        <li>
+          <strong>Cookie de session administrateur</strong> : déposé uniquement lors
+          d'une connexion à l'interface d'administration. Il est httpOnly (non
+          accessible via JavaScript), sécurisé (transmis uniquement via HTTPS) et
+          est supprimé à la déconnexion ou à la fermeture du navigateur.
+        </li>
+      </ul>
+      <p class="mb-8">
+        Ce site ne dépose <strong>aucun cookie de mesure d'audience, de
+        publicité ou de suivi</strong>. Aucun consentement aux cookies n'est
+        requis pour les visiteurs du site.
+      </p>
+
+      <!-- 8. Sécurité -->
+      <h2 class="text-2xl font-serif font-semibold text-sage-800 mt-8 mb-3">
+        8. Sécurité des données
+      </h2>
+      <div class="h-px bg-sage-200 mb-6" aria-hidden="true"></div>
+      <p class="mb-8">
+        Nous mettons en œuvre les mesures techniques et organisationnelles
+        appropriées pour protéger vos données personnelles contre toute perte,
+        accès non autorisé, divulgation, altération ou destruction. Les données
+        sont chiffrées en transit (HTTPS/TLS) et au repos. L'accès aux données
+        est strictement limité aux personnes habilitées.
+      </p>
+
+      <!-- 9. Contact DPO -->
+      <h2 class="text-2xl font-serif font-semibold text-sage-800 mt-8 mb-3">
+        9. Contact — Responsable du traitement
+      </h2>
+      <div class="h-px bg-sage-200 mb-6" aria-hidden="true"></div>
+      <p class="mb-8">
+        Pour toute question relative à la présente politique de confidentialité ou
+        à l'exercice de vos droits, contactez directement le responsable du
+        traitement :
+        <a
+          href="mailto:contact@omf-therapie.fr"
+          class="text-mint-600 underline hover:text-mint-700"
+        >
+          contact@omf-therapie.fr
+        </a>.
+      </p>
+
+      <hr class="my-8 border-sage-200" />
+
+      <p class="text-sage-600 text-sm">
+        <time datetime="2026-05-18">Mise à jour : 18 mai 2026</time>
+      </p>
+    </section>
+  </main>
+
+  <Footer />
+</Layout>

--- a/src/pages/confidentialite.astro
+++ b/src/pages/confidentialite.astro
@@ -10,14 +10,29 @@ import Footer from '../components/layout/Footer.astro';
   canonical="https://omf-therapie.fr/confidentialite"
   noindex={false}
 >
+  <a href="#main-content" class="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-mint-600 focus:text-white focus:rounded">
+    Aller au contenu principal
+  </a>
+
   <Navbar client:load isHomePage={false} />
 
   <main id="main-content" class="pt-20" tabindex="-1">
-    <section class="max-w-3xl mx-auto px-4 py-8 md:py-10">
-      <h1 class="text-3xl md:text-4xl font-serif font-semibold text-sage-800 mb-6">
-        Politique de confidentialité
-      </h1>
+    <div class="bg-sage-50 py-8 px-4">
+      <div class="max-w-3xl mx-auto">
+        <nav class="mb-4 text-sm text-sage-500" aria-label="Fil d'Ariane">
+          <ol class="flex items-center gap-2 flex-wrap" role="list">
+            <li role="listitem"><a href="/" class="hover:text-mint-600 transition-colors">Accueil</a></li>
+            <li role="listitem" aria-hidden="true">›</li>
+            <li role="listitem" aria-current="page" class="text-sage-700 font-medium">Politique de confidentialité</li>
+          </ol>
+        </nav>
+        <h1 class="text-3xl md:text-4xl font-serif font-semibold text-sage-800">
+          Politique de confidentialité
+        </h1>
+      </div>
+    </div>
 
+    <section class="max-w-3xl mx-auto px-4 py-8 md:py-10">
       <p class="text-sage-700 mb-8">
         La présente politique de confidentialité décrit la façon dont
         <strong>Oriane Montabonnet</strong> (ci-après «&nbsp;nous&nbsp;» ou

--- a/src/pages/confidentialite.astro
+++ b/src/pages/confidentialite.astro
@@ -2,6 +2,7 @@
 import Layout from '../layouts/Layout.astro';
 import Navbar from '../components/islands/Navbar';
 import Footer from '../components/layout/Footer.astro';
+import { COMPANY_NAME, CONTACT_INFO } from '../config/global.config';
 ---
 
 <Layout
@@ -35,7 +36,7 @@ import Footer from '../components/layout/Footer.astro';
     <section class="max-w-3xl mx-auto px-4 py-8 md:py-10">
       <p class="text-sage-700 mb-8">
         La présente politique de confidentialité décrit la façon dont
-        <strong>Oriane Montabonnet</strong> (ci-après «&nbsp;nous&nbsp;» ou
+        <strong>{COMPANY_NAME}</strong> (ci-après «&nbsp;nous&nbsp;» ou
         «&nbsp;le responsable du traitement&nbsp;») collecte, utilise et protège
         vos données personnelles, conformément au règlement (UE) 2016/679 du
         Parlement européen et du Conseil du 27 avril 2016 (RGPD) et à la loi
@@ -48,21 +49,21 @@ import Footer from '../components/layout/Footer.astro';
       </h2>
       <div class="h-px bg-sage-200 mb-6" aria-hidden="true"></div>
       <address class="not-italic mb-8 space-y-1">
-        <p><strong>Oriane Montabonnet</strong>, psychopraticienne</p>
-        <p>1086 Av. Albert Einstein, 34000 Montpellier</p>
+        <p><strong>{COMPANY_NAME}</strong>, psychopraticienne</p>
+        <p>{CONTACT_INFO.address}</p>
         <p>
           E-mail :
           <a
-            href="mailto:contact@omf-therapie.fr"
+            href={`mailto:${CONTACT_INFO.email}`}
             class="text-mint-600 underline hover:text-mint-700"
           >
-            contact@omf-therapie.fr
+            {CONTACT_INFO.email}
           </a>
         </p>
         <p>
           Téléphone :
-          <a href="tel:+33650331853" class="text-mint-600 underline hover:text-mint-700">
-            06 50 33 18 53
+          <a href={`tel:${CONTACT_INFO.phoneE164}`} class="text-mint-600 underline hover:text-mint-700">
+            {CONTACT_INFO.phone}
           </a>
         </p>
       </address>
@@ -165,8 +166,7 @@ import Footer from '../components/layout/Footer.astro';
           légales (art. L123-22 du Code de commerce).
         </li>
         <li>
-          <strong>Cookie de session</strong> : supprimé à la fermeture de la session
-          ou à la déconnexion.
+          <strong>Cookie de session</strong> : valable 7 jours, supprimé à la déconnexion anticipée.
         </li>
       </ul>
 
@@ -269,8 +269,8 @@ import Footer from '../components/layout/Footer.astro';
         <li>
           <strong>Cookie de session administrateur</strong> : déposé uniquement lors
           d'une connexion à l'interface d'administration. Il est httpOnly (non
-          accessible via JavaScript), sécurisé (transmis uniquement via HTTPS) et
-          est supprimé à la déconnexion ou à la fermeture du navigateur.
+          accessible via JavaScript), sécurisé (transmis uniquement via HTTPS),
+          valable 7 jours et supprimé à la déconnexion anticipée.
         </li>
       </ul>
       <p class="mb-8">

--- a/src/pages/mentions-legales.astro
+++ b/src/pages/mentions-legales.astro
@@ -10,13 +10,29 @@ import Footer from '../components/layout/Footer.astro';
   canonical="https://omf-therapie.fr/mentions-legales"
   noindex={false}
 >
+  <a href="#main-content" class="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-mint-600 focus:text-white focus:rounded">
+    Aller au contenu principal
+  </a>
+
   <Navbar client:load isHomePage={false} />
 
   <main id="main-content" class="pt-20" tabindex="-1">
+    <div class="bg-sage-50 py-8 px-4">
+      <div class="max-w-3xl mx-auto">
+        <nav class="mb-4 text-sm text-sage-500" aria-label="Fil d'Ariane">
+          <ol class="flex items-center gap-2 flex-wrap" role="list">
+            <li role="listitem"><a href="/" class="hover:text-mint-600 transition-colors">Accueil</a></li>
+            <li role="listitem" aria-hidden="true">›</li>
+            <li role="listitem" aria-current="page" class="text-sage-700 font-medium">Mentions légales</li>
+          </ol>
+        </nav>
+        <h1 class="text-3xl md:text-4xl font-serif font-semibold text-sage-800">
+          Mentions légales
+        </h1>
+      </div>
+    </div>
+
     <section class="max-w-3xl mx-auto px-4 py-8 md:py-10">
-      <h1 class="text-3xl md:text-4xl font-serif font-semibold text-sage-800 mb-6">
-        Mentions légales
-      </h1>
 
       <p class="text-sage-700 mb-8">
         Conformément aux dispositions de la loi n°2004-575 du 21 juin 2004 pour

--- a/src/pages/mentions-legales.astro
+++ b/src/pages/mentions-legales.astro
@@ -1,0 +1,165 @@
+---
+import Layout from '../layouts/Layout.astro';
+import Navbar from '../components/islands/Navbar';
+import Footer from '../components/layout/Footer.astro';
+---
+
+<Layout
+  title="Mentions légales — OMF Thérapie"
+  description="Mentions légales du site omf-therapie.fr conformément à la loi n°2004-575 du 21 juin 2004 pour la confiance dans l'économie numérique (LCEN)."
+  canonical="https://omf-therapie.fr/mentions-legales"
+  noindex={false}
+>
+  <Navbar client:load isHomePage={false} />
+
+  <main id="main-content" class="pt-20" tabindex="-1">
+    <section class="max-w-3xl mx-auto px-4 py-8 md:py-10">
+      <h1 class="text-3xl md:text-4xl font-serif font-semibold text-sage-800 mb-6">
+        Mentions légales
+      </h1>
+
+      <p class="text-sage-700 mb-8">
+        Conformément aux dispositions de la loi n°2004-575 du 21 juin 2004 pour
+        la confiance dans l'économie numérique (LCEN), les présentes mentions
+        légales précisent l'identité des différents intervenants dans le cadre de
+        la réalisation et du suivi du site <strong>omf-therapie.fr</strong>.
+      </p>
+
+      <!-- 1. Éditeur du site -->
+      <h2 class="text-2xl font-serif font-semibold text-sage-800 mt-8 mb-3">
+        Éditeur du site
+      </h2>
+      <div class="h-px bg-sage-200 mb-6" aria-hidden="true"></div>
+      <address class="not-italic mb-8 space-y-1">
+        <p><strong>Oriane Montabonnet</strong>, psychopraticienne</p>
+        <p>1086 Av. Albert Einstein, 34000 Montpellier</p>
+        <p>
+          Téléphone :
+          <a href="tel:+33650331853" class="text-mint-600 underline hover:text-mint-700">
+            06 50 33 18 53
+          </a>
+        </p>
+        <p>
+          E-mail :
+          <a
+            href="mailto:contact@omf-therapie.fr"
+            class="text-mint-600 underline hover:text-mint-700"
+          >
+            contact@omf-therapie.fr
+          </a>
+        </p>
+        <p>SIRET : [À COMPLÉTER]</p>
+        <p>Numéro ADELI : [À COMPLÉTER]</p>
+      </address>
+
+      <!-- 2. Directeur de publication -->
+      <h2 class="text-2xl font-serif font-semibold text-sage-800 mt-8 mb-3">
+        Directeur de publication
+      </h2>
+      <div class="h-px bg-sage-200 mb-6" aria-hidden="true"></div>
+      <p class="mb-8">
+        Oriane Montabonnet, en sa qualité d'éditrice et responsable du site.
+      </p>
+
+      <!-- 3. Hébergeur -->
+      <h2 class="text-2xl font-serif font-semibold text-sage-800 mt-8 mb-3">
+        Hébergeur
+      </h2>
+      <div class="h-px bg-sage-200 mb-6" aria-hidden="true"></div>
+      <address class="not-italic mb-8 space-y-1">
+        <p><strong>Netlify, Inc.</strong></p>
+        <p>2325 3rd Street, Suite 296, San Francisco, CA 94107, États-Unis</p>
+        <p>
+          Site web :
+          <a
+            href="https://www.netlify.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-mint-600 underline hover:text-mint-700"
+          >
+            https://www.netlify.com
+          </a>
+        </p>
+      </address>
+
+      <!-- 4. Propriété intellectuelle -->
+      <h2 class="text-2xl font-serif font-semibold text-sage-800 mt-8 mb-3">
+        Propriété intellectuelle
+      </h2>
+      <div class="h-px bg-sage-200 mb-6" aria-hidden="true"></div>
+      <p class="mb-4">
+        L'ensemble du contenu de ce site (textes, images, graphismes, logo,
+        icônes, sons, logiciels, etc.) constitue une œuvre protégée par les lois
+        françaises et internationales relatives à la propriété intellectuelle.
+      </p>
+      <p class="mb-8">
+        Toute reproduction, représentation, modification, publication, adaptation
+        de tout ou partie des éléments du site, quel que soit le moyen ou le
+        procédé utilisé, est interdite, sauf autorisation écrite préalable
+        d'Oriane Montabonnet. Toute exploitation non autorisée du site ou de l'un
+        quelconque des éléments qu'il contient est considérée comme constitutive
+        d'une contrefaçon et poursuivie.
+      </p>
+
+      <!-- 5. Responsabilité -->
+      <h2 class="text-2xl font-serif font-semibold text-sage-800 mt-8 mb-3">
+        Limitation de responsabilité
+      </h2>
+      <div class="h-px bg-sage-200 mb-6" aria-hidden="true"></div>
+      <p class="mb-4">
+        Les informations contenues sur ce site sont aussi précises que possible et
+        le site est périodiquement remis à jour. Toutefois, des inexactitudes ou
+        des omissions peuvent survenir. Oriane Montabonnet ne peut être tenue
+        responsable de l'utilisation faite de ces informations, ni des
+        conséquences qui pourraient en découler.
+      </p>
+      <p class="mb-8">
+        Les informations publiées sur ce site ne constituent pas un avis médical
+        ou psychiatrique et ne sauraient se substituer à une consultation
+        professionnelle de santé.
+      </p>
+
+      <!-- 6. Liens hypertextes -->
+      <h2 class="text-2xl font-serif font-semibold text-sage-800 mt-8 mb-3">
+        Liens hypertextes
+      </h2>
+      <div class="h-px bg-sage-200 mb-6" aria-hidden="true"></div>
+      <p class="mb-4">
+        Ce site peut contenir des liens hypertextes vers d'autres sites internet.
+        Ces liens sont fournis à titre informatif. Oriane Montabonnet n'exerce
+        aucun contrôle sur ces sites et décline toute responsabilité quant à leur
+        contenu.
+      </p>
+      <p class="mb-8">
+        La création de liens hypertextes vers ce site est soumise à l'accord
+        préalable et écrit d'Oriane Montabonnet. Pour toute demande, merci de
+        contacter :
+        <a
+          href="mailto:contact@omf-therapie.fr"
+          class="text-mint-600 underline hover:text-mint-700"
+        >
+          contact@omf-therapie.fr
+        </a>.
+      </p>
+
+      <!-- 7. Droit applicable -->
+      <h2 class="text-2xl font-serif font-semibold text-sage-800 mt-8 mb-3">
+        Droit applicable et juridiction compétente
+      </h2>
+      <div class="h-px bg-sage-200 mb-6" aria-hidden="true"></div>
+      <p class="mb-8">
+        Les présentes mentions légales sont régies par le droit français. En cas
+        de litige, et après échec de toute tentative de résolution amiable, les
+        tribunaux de Montpellier seront seuls compétents.
+      </p>
+
+      <hr class="my-8 border-sage-200" />
+
+      <p class="text-sage-600 text-sm">
+        <time datetime="2026-05-18">Mise à jour : 18 mai 2026</time>
+      </p>
+    </section>
+  </main>
+
+  <Footer />
+</Layout>

--- a/src/pages/mentions-legales.astro
+++ b/src/pages/mentions-legales.astro
@@ -2,6 +2,7 @@
 import Layout from '../layouts/Layout.astro';
 import Navbar from '../components/islands/Navbar';
 import Footer from '../components/layout/Footer.astro';
+import { COMPANY_NAME, CONTACT_INFO } from '../config/global.config';
 ---
 
 <Layout
@@ -47,21 +48,21 @@ import Footer from '../components/layout/Footer.astro';
       </h2>
       <div class="h-px bg-sage-200 mb-6" aria-hidden="true"></div>
       <address class="not-italic mb-8 space-y-1">
-        <p><strong>Oriane Montabonnet</strong>, psychopraticienne</p>
-        <p>1086 Av. Albert Einstein, 34000 Montpellier</p>
+        <p><strong>{COMPANY_NAME}</strong>, psychopraticienne</p>
+        <p>{CONTACT_INFO.address}</p>
         <p>
           Téléphone :
-          <a href="tel:+33650331853" class="text-mint-600 underline hover:text-mint-700">
-            06 50 33 18 53
+          <a href={`tel:${CONTACT_INFO.phoneE164}`} class="text-mint-600 underline hover:text-mint-700">
+            {CONTACT_INFO.phone}
           </a>
         </p>
         <p>
           E-mail :
           <a
-            href="mailto:contact@omf-therapie.fr"
+            href={`mailto:${CONTACT_INFO.email}`}
             class="text-mint-600 underline hover:text-mint-700"
           >
-            contact@omf-therapie.fr
+            {CONTACT_INFO.email}
           </a>
         </p>
         <p>SIRET : 90763504900022</p>
@@ -147,13 +148,13 @@ import Footer from '../components/layout/Footer.astro';
       </p>
       <p class="mb-8">
         La création de liens hypertextes vers ce site est soumise à l'accord
-        préalable et écrit d'Oriane Montabonnet. Pour toute demande, merci de
+        préalable et écrit d'{COMPANY_NAME}. Pour toute demande, merci de
         contacter :
         <a
-          href="mailto:contact@omf-therapie.fr"
+          href={`mailto:${CONTACT_INFO.email}`}
           class="text-mint-600 underline hover:text-mint-700"
         >
-          contact@omf-therapie.fr
+          {CONTACT_INFO.email}
         </a>.
       </p>
 

--- a/src/pages/mentions-legales.astro
+++ b/src/pages/mentions-legales.astro
@@ -48,8 +48,7 @@ import Footer from '../components/layout/Footer.astro';
             contact@omf-therapie.fr
           </a>
         </p>
-        <p>SIRET : [À COMPLÉTER]</p>
-        <p>Numéro ADELI : [À COMPLÉTER]</p>
+        <p>SIRET : 90763504900022</p>
       </address>
 
       <!-- 2. Directeur de publication -->


### PR DESCRIPTION
## Résumé

Création des pages légales obligatoires et correction d'un lien cassé.

## Changements

### Pages créées
- **`/mentions-legales`** — Mentions légales (LCEN 2004) : éditeur, hébergeur Netlify, propriété intellectuelle
- **`/confidentialite`** — Politique de confidentialité (RGPD art. 6) : données collectées, finalités, sous-traitants (Supabase, Resend, Stripe, Google), droits des personnes, cookies de session
- **`/cgv`** — CGV (Code de la consommation + directive 2011/83/UE) : tarifs, annulation 24h, droit de rétractation art. L221-28

### Footer mis à jour
- Barre de bas de page enrichie avec une `<nav aria-label="Liens légaux">` → Mentions légales · Confidentialité · CGV · Accessibilité

### Lien cassé corrigé
Le wizard de rendez-vous (`BookingWizard.tsx`) référençait `/confidentialite` qui n'existait pas.

## Placeholders à compléter
Deux champs restent à renseigner par Oriane dans `mentions-legales.astro` et `cgv.astro` :
- **SIRET** : numéro d'immatriculation de l'entreprise
- **Numéro ADELI** (si applicable) : identifiant des professionnels de santé

## Tests
- Build Astro ✅ 
- Lint 0 erreurs ✅

Ferme #31