### PR TITLE
feat(calendar): intégration Google Calendar production-ready (#36)

### DIFF
--- a/artifacts/analyses/38-feat-amelioration-flow-invitation-rdv-therapeute-analysis.md
+++ b/artifacts/analyses/38-feat-amelioration-flow-invitation-rdv-therapeute-analysis.md
@@ -1,0 +1,143 @@
+---
+issue: 38
+title: "feat: amélioration du flow d'invitation RDV par le thérapeute — durée/tarif flexibles + création immédiate du calendrier"
+type: feature
+complexity: L
+tier: F-full
+---
+
+## Problem
+
+3 limitations dans le flow d'invitation admin :
+
+1. **Durées figées** : `AppointmentDuration = 60 | 90` (union TypeScript stricte), `VALID_DURATIONS = new Set([60, 90])` dans l'API admin. Pas de support de durées comme 45, 75, 120 min.
+2. **Prix non-override** : `calculatePrice()` nécessite un type/durée valide et ne dispose pas de mécanisme d'override. Les configurations hors-grille produisent des tarifs incorrects ou bloquent la création.
+3. **Calendrier bloqué sur le paiement** : les RDV vidéo admin sont insérés avec `status: 'payment_pending'`. L'événement Google Calendar est créé **uniquement** dans `stripe-webhook.ts → handlePaymentSucceeded()`. Si le patient ne paie pas via Stripe, l'événement n'est jamais créé. De plus, le webhook ne vérifie pas `google_calendar_event_id` — un doublon serait créé si on fixait l'admin sans corriger le webhook.
+
+## Current State (technique)
+
+### Chaîne de dépendances de type
+
+```
+src/lib/pricing.ts
+  → AppointmentDuration = 60 | 90
+  → calculatePrice(type, duration: AppointmentDuration, ...) 
+
+src/types/appointment.ts
+  → re-exporte AppointmentDuration
+  → Appointment.duration: 60 | 90  (mais DB stocke un INTEGER sans contrainte)
+
+src/pages/api/admin/appointments/index.ts
+  → VALID_DURATIONS = new Set<number>([60, 90])
+  → calculatePrice(... Number(duration) as AppointmentDuration ...)
+  → crée événement calendrier pour in-person uniquement (lignes 184–211)
+  → pas d'événement calendrier pour video (statut payment_pending → délégué au webhook)
+
+src/pages/api/stripe-webhook.ts → handlePaymentSucceeded()
+  → crée événement calendrier pour video APRÈS paiement (lignes 225–317)
+  → idempotence basée sur stripe_event_id uniquement — google_calendar_event_id non vérifié
+```
+
+### Gaps identifiés
+
+| Gap | Fichier(s) | Impact |
+|-----|-----------|--------|
+| Durée contrainte 60/90 | `pricing.ts`, `admin/appointments/index.ts` | Impossible créer RDV 45 min |
+| Calcul prix sans override | `pricing.ts`, `AdminCreateButton.tsx` | Pas de tarif custom |
+| Calendrier vidéo après paiement | `admin/appointments/index.ts` | RDV invisible si pas de Stripe |
+| Pas de déduplication calendrier | `stripe-webhook.ts` | Doublons si on corrige l'admin |
+| Type `Appointment.duration: 60 \| 90` | `types/appointment.ts` | TypeScript casse sur durée custom |
+
+## Impact
+
+- **Users affected:** Thérapeute (admin) — uniquement le flow d'invitation. Patients non affectés.
+- **Severity:** medium (workaround manuel existant — Google Calendar ouvert séparément)
+- **Files affected:**
+  - `src/lib/pricing.ts`
+  - `src/types/appointment.ts`
+  - `src/components/admin/AdminCreateButton.tsx`
+  - `src/pages/api/admin/appointments/index.ts`
+  - `src/pages/api/stripe-webhook.ts`
+  - `src/pages/api/appointments/index.ts` — **lecture seule, aucune modification** (flow patient, validation stricte maintenue)
+
+## Approach Options
+
+### Option A — Type étendu + override déclaratif (recommandée)
+
+**Principe :** `AppointmentDuration` reste `60 | 90` pour le flow patient. On ajoute un type `AdminDuration = number` dans le scope admin + un paramètre `overridePrice?: number` à `calculatePrice`.
+
+**Durée :**
+- `pricing.ts` : ajouter `type AdminDuration = number` (admin-only alias)
+- `admin/appointments/index.ts` : remplacer `VALID_DURATIONS.has()` par `Number.isInteger(d) && d >= 15 && d <= 240`
+- `AdminCreateButton.tsx` : `duration` dans `FormState` devient `number` ; UI = select avec option "Personnalisée" + champ `<input type="number">` conditionnel
+- `types/appointment.ts` : `Appointment.duration: number` (reflète la réalité DB — `INTEGER` sans contrainte de valeur)
+
+**Prix :**
+- `pricing.ts` : `calculatePrice(..., overridePrice?: number)` — quand fourni, court-circuite le grid lookup et retourne directement `{ basePrice: overridePrice, discount: 0, finalPrice: overridePrice }`
+- `AdminCreateButton.tsx` : checkbox "Tarif manuel" + `<input type="number">` conditionnel ; quand activé, passe `override_price` dans le payload
+- `admin/appointments/index.ts` : si `override_price` présent dans le body, l'utiliser directement au lieu de `calculatePrice`
+
+**Calendrier immédiat :**
+- `admin/appointments/index.ts` : déplacer la création d'événement calendrier (actuellement in-person only) pour couvrir aussi `video`. Créer l'événement avec `withMeet: true` pour auto-générer le lien Google Meet ou utiliser `video_link` si fourni. Faire en parallèle de l'envoi Stripe.
+- `stripe-webhook.ts` : avant de créer l'événement, lire `google_calendar_event_id` du RDV ; si non nul → skip la création (l'admin a déjà créé).
+
+```
+Pros: 
+  - Séparation claire patient (strict 60/90) vs admin (flexible)
+  - Pas de rupture du flow patient
+  - Minimal : ~5 lignes dans pricing.ts, validation localisée dans admin API
+  - DB déjà en INTEGER, pas de migration
+Cons:
+  - Deux types pour représenter "durée" (AppointmentDuration vs number) — légère incohérence documentaire
+Risk: low
+```
+
+### Option B — Champs séparés `override_duration` + `override_price`
+
+**Principe :** `duration` reste toujours 60 ou 90 dans le payload. On ajoute `override_duration` et `override_price` comme champs distincts.
+
+```
+Pros: AppointmentDuration inchangé dans tous les types
+Cons: 
+  - Deux champs pour une seule donnée sémantique
+  - DB stocke `duration` = 60|90 même si réellement 45 min — incohérent
+  - Logique de résolution ("use override_duration if present, else duration") plus complexe
+  - Calendrier utilise la mauvaise durée sans précautions
+Risk: medium (bugs de cohérence)
+```
+
+### Option C — Relâcher `AppointmentDuration` globalement à `number`
+
+**Principe :** `AppointmentDuration = number` partout, supprimer `VALID_DURATIONS` dans les deux APIs.
+
+```
+Pros: Simple
+Cons:
+  - Supprime la validation stricte côté patient (risque sécurité : payload forgé)
+  - Casse la grille tarifaire pour les durées non définies dans PRICE_GRID (KeyError)
+  - Trop large
+Risk: high
+```
+
+## Recommendation
+
+**Option A** — type étendu + override déclaratif.
+
+Justification : le flow patient garde sa validation stricte (sécurité), le flow admin gagne la flexibilité nécessaire via des modifications localisées. L'idempotence du webhook est corrigée comme effet de bord direct et obligatoire (évite un bug de doublon si on ne le fait pas).
+
+**Séquence d'implémentation recommandée :**
+1. `pricing.ts` — `AdminDuration`, `overridePrice` param dans `calculatePrice`
+2. `types/appointment.ts` — `duration: number` (reflect DB)
+3. `admin/appointments/index.ts` — validation flexible + calendrier immédiat pour video
+4. `stripe-webhook.ts` — check `google_calendar_event_id` avant création
+5. `AdminCreateButton.tsx` — UI durée custom + prix override
+
+## Appetite
+
+Estimated tier: F-full (~3 jours)
+- 5 fichiers modifiés
+- 3 domaines (UI React, API serverless, Google Calendar)
+- Nouveau pattern : calendrier découplé du paiement avec idempotence
+- Risque principal : webhook `handlePaymentSucceeded` doit être mis à jour atomiquement avec l'admin API pour éviter les doublons
+
+Spike: non requis — approche claire, pas de dépendances externes nouvelles.

--- a/artifacts/frames/36-google-calendar-production-ready-frame.md
+++ b/artifacts/frames/36-google-calendar-production-ready-frame.md
@@ -1,0 +1,116 @@
+---
+issue: 36
+title: "feat: Google Calendar production-ready — OAuth token rotation, event lifecycle, Meet async, cache, error handling"
+status: approved
+tier: F-full
+created: 2026-05-22
+---
+
+## Problem Statement
+
+L'intégration Google Calendar actuelle fonctionne pour le développement mais présente 5 défauts
+structurels qui la rendent fragile en production :
+
+1. **Token OAuth statique** — le `refresh_token` stocké en env var expire (7 jours en mode Test,
+   6 mois sans usage). Quand il expire, toute génération de Meet et toute création d'événement
+   échoue silencieusement (fallback Jitsi), sans alerte.
+
+2. **Événements orphelins** — l'`eventId` Google Calendar n'est pas persisté. Quand un rdv est
+   reporté ou annulé, l'événement reste dans l'agenda de la thérapeute, créant une désynchronisation
+   permanente.
+
+3. **Polling 15s dans le chemin critique** — `pollMeetLink()` tourne jusqu'à 10 × 1,5s = 15s dans
+   le handler HTTP. Netlify Functions ont un timeout de 10s par défaut. Le polling peut tuer la
+   requête en production.
+
+4. **Aucun cache sur /api/availability** — chaque patient qui ouvre la page de prise de rdv déclenche
+   un appel Google Calendar Freebusy. L'API Google impose un quota de 1 000 000 unités/jour
+   (chaque requête Freebusy = 1 unité). Sur un pic de trafic ou un robot, ce quota est facilement
+   épuisé.
+
+5. **Gestion d'erreur monolithique** — toutes les erreurs Google tombent dans `GoogleCalendarError`.
+   Impossible de distinguer un token expiré (→ re-auth) d'un quota dépassé (→ retry) d'une
+   permission manquante (→ alerte) sans parser les messages d'erreur manuellement.
+
+## Why This Matters
+
+- **Fiabilité perçue** : une thérapeute dont les séances vidéo n'ont pas de lien Meet ou dont
+  l'agenda est désynchronisé perd confiance dans l'outil et doit gérer manuellement.
+- **Expérience patient** : recevoir un lien Jitsi de fallback au lieu d'un vrai Meet est sous-optimal
+  et peut surprendre des patients attendant Google Meet.
+- **Maintenance** : sans alertes, le token peut expirer silencieusement des semaines avant qu'on
+  s'en aperçoive.
+
+## Success Criteria
+
+1. Le refresh token OAuth ne provoque plus jamais d'échec silencieux — rotation automatique,
+   alerte email si `invalid_grant` (re-auth manuelle requise).
+2. Chaque rdv confirmé a un `google_calendar_event_id` non-nul ; un report met à jour l'événement ;
+   une annulation/déclinaison supprime l'événement.
+3. La confirmation d'un rdv vidéo retourne une réponse HTTP < 5s — le polling Meet est réduit
+   à 3 tentatives max dans le chemin critique ; le meetLink arrivera si disponible, sinon fallback
+   immédiat.
+4. `GET /api/availability` sert les réponses depuis le cache (`@netlify/blobs`) pendant 10 min ;
+   le cache est invalidé à chaque mutation de rdv.
+5. Les erreurs Google sont typées : `CalendarAuthError`, `CalendarPermissionError`,
+   `CalendarQuotaError`, `CalendarNetworkError` — chacune avec stratégie de retry adaptée.
+
+## Constraints
+
+- **Plateforme** : Netlify SSG + serverless functions. Pas de Redis disponible nativement.
+  → Cache via `@netlify/blobs` (KV natif Netlify, déjà inclus dans `@astrojs/netlify`).
+- **DB** : Supabase (PostgreSQL). Toutes les données persistées passent par Supabase.
+- **Async jobs** : Netlify Background Functions existent mais nécessitent une configuration
+  spécifique. Pour éviter la complexité, le polling Meet est simplement réduit (3 tentatives max)
+  plutôt que délégué à un job séparé.
+- **OAuth** : compte Google personnel de la thérapeute (pas Workspace). Le Service Account reste
+  en fallback pour les événements sans Meet (in-person).
+- **Single user** : une seule thérapeute = un seul set de credentials Google. Pas de multi-tenant.
+- **Pas de breaking change** : les API routes existantes (`PATCH /api/appointments/[id]`,
+  `POST /api/admin/appointments`) conservent leur interface.
+
+## Out of Scope
+
+- Migration vers Google Workspace (implique changement d'abonnement)
+- Notifications push temps-réel (webhook Google Calendar → Netlify)
+- Support multi-thérapeute / multi-calendrier
+- Interface UI de ré-autorisation OAuth (la re-auth reste manuelle via `scripts/`)
+- Chiffrement at-rest des tokens OAuth dans Supabase (RLS + service_role = suffisant)
+
+## Stakeholders
+
+- **Oriane Montabonnet (thérapeute)** — utilisatrice directe : agenda synchronisé, liens Meet fiables
+- **Patients** — reçoivent un vrai lien Meet dans l'email de confirmation
+- **Développeur** — maintenance simplifiée grâce aux erreurs typées et aux alertes
+
+## Appetite
+
+Tier: **F-full**
+Reasoning: 3 domaines touchés (auth, calendar API, cache infrastructure), migration Supabase
+requise, nouveaux patterns (token rotation, error taxonomy, KV cache), 6 fichiers modifiés
+dont 2 nouveaux modules (`calendar-cache.ts`, migration SQL). Estimation : 2-3 jours.
+
+## Approach Options
+
+### Option A — Supabase tokens + @netlify/blobs cache (recommandée)
+- Token OAuth stocké en Supabase (`google_oauth_tokens`)
+- Cache availability via `@netlify/blobs` (TTL 10 min, invalidation explicite)
+- Polling Meet réduit à 3 tentatives (max ~4,5s) dans le chemin sync
+- **Avantages** : pas de nouvelle infra, cohérent avec l'existant, `@netlify/blobs` déjà inclus
+- **Inconvénients** : cache non partagé entre instances Netlify dans la même région lors de pics
+
+### Option B — Upstash Redis
+- Token + cache dans Redis (Upstash free tier, edge-compatible)
+- **Avantages** : vrai cache distribué, adapté au rate limiting aussi
+- **Inconvénients** : nouvelle dépendance externe, coût potentiel, over-engineered pour ce volume
+
+ **Option A retenue** : volume trafic faible (cabinet 1 thérapeute), `@netlify/blobs` suffisant.
+
+## Open Questions
+
+- L'email d'alerte `invalid_grant` doit-il aller vers `ADMIN_EMAIL` (env var existant) ou une
+  adresse dédiée ? → supposé `ADMIN_EMAIL` (cohérent avec les autres alertes).
+- La suppression d'événement Calendar lors d'un `decline` doit-elle être best-effort (non-bloquant)
+  ou bloquer la réponse ? → non-bloquant (même pattern que l'existant).
+- Faut-il aussi synchroniser l'événement Calendar lors d'un `cancel` initié par le patient (via
+  token signé) ? → oui, inclus dans le scope si `google_calendar_event_id` est présent.

--- a/artifacts/frames/38-feat-amelioration-flow-invitation-rdv-therapeute-frame.md
+++ b/artifacts/frames/38-feat-amelioration-flow-invitation-rdv-therapeute-frame.md
@@ -1,0 +1,81 @@
+---
+issue: 38
+title: "feat: amélioration du flow d'invitation RDV par le thérapeute — durée/tarif flexibles + création immédiate du calendrier"
+status: approved
+tier: F-full
+created: 2026-05-26
+---
+
+## Problem Statement
+
+Le flow d'invitation de rendez-vous par le thérapeute est trop rigide pour couvrir la totalité des cas réels de sa pratique :
+
+1. **Durée contrainte** : seules 60 min et 90 min sont proposées. Certaines séances (ex: 45 min, 75 min) ne rentrent pas dans ces standards.
+2. **Tarif non modifiable** : le tarif est calculé automatiquement selon type × durée, sans possibilité de saisie manuelle pour des configurations hors-grille.
+3. **Événement calendrier bloqué sur le paiement** : pour les RDV en téléconsultation créés par l'admin, l'événement Google Calendar n'est créé qu'après réception du paiement Stripe (`stripe-webhook.ts`). Si le patient ne paie pas via Stripe (paiement manuel, virement, etc.), le RDV n'apparaît jamais dans l'agenda du thérapeute.
+
+## Current State (analyse codebase)
+
+- `AppointmentDuration = 60 | 90` — type union strict dans `src/lib/pricing.ts`
+- `VALID_DURATIONS = new Set<number>([60, 90])` — validation stricte dans `src/pages/api/admin/appointments/index.ts`
+- `calculatePrice()` requiert une `AppointmentDuration` valide (60|90) — pas d'entrée pour durées arbitraires
+- Pour les RDV en présentiel créés par l'admin : événement calendrier créé immédiatement ✓
+- Pour les RDV en téléconsultation créés par l'admin : événement calendrier créé **uniquement** dans `stripe-webhook.ts` après paiement ✗
+
+## Why This Matters
+
+La thérapeute gère des cas réels où :
+- Des séances non-standards (45 min de suivi, 75 min première séance couple) doivent être planifiées
+- Certains patients ne peuvent pas payer via Stripe ; la thérapeute leur envoie manuellement un lien de paiement bancaire
+- Sans événement calendrier immédiat, elle doit dupliquer la création manuellement dans Google Calendar — friction inutile et risque d'oubli
+
+## Success Criteria
+
+- [ ] La thérapeute peut créer un RDV admin avec une durée personnalisée saisie en minutes (min: 15, max: 240)
+- [ ] La durée personnalisée est proposée en complément des choix standards (60 min, 90 min)
+- [ ] La thérapeute peut saisir un tarif manuel en euros quand la configuration est hors-grille
+- [ ] Quand un tarif manuel est saisi, le calcul automatique est désactivé (overrides `calculatePrice`)
+- [ ] L'événement Google Calendar est créé immédiatement lors de la soumission du formulaire admin, pour les RDV téléconsultation comme présentiel
+- [ ] Le patient est invité comme participant Google Calendar en parallèle de l'envoi du lien Stripe
+- [ ] Si Stripe échoue ou `send_email=false`, l'événement calendrier est quand même créé
+- [ ] Le webhook Stripe ne recrée pas un doublon si l'événement existe déjà (`google_calendar_event_id` non nul)
+- [ ] Les cas standards (durée 60/90, tarif calculé auto) continuent de fonctionner à l'identique
+- [ ] Le flow patient (`/api/appointments`) reste inchangé (validation stricte maintenue)
+
+## Constraints
+
+- **TypeScript strict** : le type `AppointmentDuration` utilisé partout doit être étendu sans casser les consommateurs existants
+- **Idempotence webhook** : `handlePaymentSucceeded` doit vérifier `google_calendar_event_id` avant de créer l'événement pour éviter les doublons
+- **Pas de migration DB** : `duration` est stocké en `integer` dans Supabase — les durées arbitraires sont déjà supportées
+- **Rétrocompatibilité** : le flow patient (`/api/appointments`) n'est pas modifié ; la flexibilité est strictement côté admin
+- **Validation** : les durées personnalisées doivent être des entiers positifs entre 15 et 240 minutes
+
+## Out of Scope
+
+- Modification du flow de prise de RDV par le patient (`/rendez-vous.astro`, `/api/appointments`)
+- Mise à jour de la grille tarifaire `PRICE_GRID` (les tarifs standards ne changent pas)
+- Gestion des durées personnalisées dans la vérification de disponibilité patient (toujours basée sur 60/90)
+- Support de durées décimales (ex: 1h30 = 90 min, pas 1.5h)
+
+## Stakeholders
+
+- **Thérapeute (Oriane)** — utilisatrice principale du dashboard admin
+- **Patients** — reçoivent l'invitation calendrier et le lien de paiement
+
+## Appetite
+
+Tier: F-full
+Reasoning: 3 domaines touchés (UI React admin, API Node/Astro, Google Calendar), nouveau pattern (découplage calendrier/paiement), ~8 fichiers, ~3 jours de travail
+
+## Open Questions
+
+- La durée personnalisée doit-elle être proposée via un champ séparé (texte) ou via une option "Autre…" dans le `<select>` qui révèle un champ numérique ? → Choix UX : option "Personnalisée" + champ numérique conditionnel (meilleure accessibilité)
+- Le tarif manuel doit-il remplacer complètement l'affichage du prix calculé, ou coexister ? → Remplacement total quand override activé, avec indication visuelle claire
+
+## Premise Validity
+
+**Success in 6 months:** La thérapeute peut créer 100% de ses RDV directement depuis le dashboard sans jamais ouvrir Google Calendar manuellement. Zéro RDV en téléconsultation absent de l'agenda pour cause de paiement Stripe non reçu.
+
+**Failure in 6 months:** La thérapeute doit encore créer manuellement >1 événement/semaine dans Google Calendar car le tool ne couvre pas ses configurations non-standard (durée hors 60/90, patient sans Stripe). Condition observable : elle mentionne encore ces workarounds lors d'un retour utilisateur.
+
+**Simplest alternative:** Autoriser la thérapeute à saisir une note dans le champ "motif" avec la durée réelle, et créer l'événement via le webhook. Pourquoi insuffisant : (1) n'automatise pas la création calendrier pour les patients sans Stripe — le RDV reste invisible jusqu'au paiement, (2) ne permet pas de facturer un tarif non-standard via le système, (3) crée une incohérence entre la durée de l'événement calendrier et la durée réelle de la séance.

--- a/artifacts/frames/activation-page-rendez-vous-frame.md
+++ b/artifacts/frames/activation-page-rendez-vous-frame.md
@@ -1,0 +1,80 @@
+---
+issue: ~
+title: "Activation page rendez-vous — navigation & CTAs"
+status: approved
+tier: F-lite
+created: 2026-05-26
+---
+
+## Problem Statement
+
+La page `/rendez-vous` existe et fonctionne (booking wizard complet), mais le site continue de router les utilisateurs vers `/contact` ou vers des liens externes `psychologue.net` quand ils veulent prendre rendez-vous. Le lien "Contact" reste dans la navbar alors que "Prendre rendez-vous" y est déjà — doublon confus. Les CTAs des pages de service, d'À propos, du blog et de la 404 pointent tous vers `/contact` avec le texte "Prendre rendez-vous".
+
+## Why This Matters
+
+- Les patients qui cliquent "Prendre rendez-vous" atterrissent sur un formulaire de contact générique au lieu du wizard de booking → friction inutile, perte de conversions.
+- La navbar affiche deux liens à finalité similaire ("Prendre rendez-vous" + "Contact") → confusion UX.
+- Les liens vers psychologue.net (page booking externe) en CTA de conversion font fuir les visiteurs hors du site.
+
+## Success Criteria
+
+- [ ] "Contact" retiré de la navbar desktop et mobile
+- [ ] Tous les CTAs "Prendre rendez-vous" / "Prenez rendez-vous" pointent vers `/rendez-vous/`
+- [ ] Le lien psychologue.net utilisé en CTA de conversion sur `/contact` pointe vers `/rendez-vous/` (les badges footer restent inchangés — certification légitime)
+- [ ] La page `/rendez-vous` est toujours accessible et fonctionnelle après les changements
+- [ ] Aucune erreur de lint, aucune régression de navigation
+
+## Scope — Files to Change
+
+| File | Change |
+|------|--------|
+| `src/components/navigation/NavigationItems.tsx` | Supprimer l'entrée "Contact" |
+| `src/components/islands/Navbar.tsx` | Supprimer le cas spécial `isActive` pour `/contact` ; ajouter cas pour `/rendez-vous` |
+| `src/pages/services/therapie-individuelle.astro` | 2 occurrences `/contact` → `/rendez-vous/` |
+| `src/pages/services/therapie-de-couple.astro` | 2 occurrences `/contact` → `/rendez-vous/` |
+| `src/pages/services/therapie-familiale.astro` | 2 occurrences `/contact` → `/rendez-vous/` |
+| `src/pages/services/troubles-alimentaires.astro` | 2 occurrences `/contact` → `/rendez-vous/` |
+| `src/pages/a-propos.astro` | 1 CTA `/contact` → `/rendez-vous/` |
+| `src/pages/blog/[slug].astro` | 1 CTA `/contact` → `/rendez-vous/` |
+| `src/pages/rendez-vous.astro` | 1 lien interne `/contact/` → `/rendez-vous/` |
+| `src/pages/contact.astro` | Lien psychologue.net (CTA booking) → `/rendez-vous/` — psychologue.net sera entièrement supprimé dans une tâche suivante |
+| `src/pages/404.astro` | CTA `/contact` → `/rendez-vous/` |
+
+## Out of Scope
+
+- La page `/contact` elle-même (elle reste accessible, juste dé-priorisée en nav)
+- Le badge/widget psychologue.net dans le footer (`FooterHours.tsx`, `Footer.astro`) — sera supprimé dans une tâche dédiée dans les prochaines semaines (coût devenu inadapté)
+- Les liens `mailto:contact@omf-therapie.fr` (emails transactionnels, non concernés)
+- `accessibilite.astro` → lien `/contact` légitime dans ce contexte (contact pour problèmes d'accessibilité)
+- `rdv/accepter-report.astro` → liens `/contact/` dans un contexte de report de RDV (hors scope de cette tâche)
+- Footer config "Contact" — le footer reste avec le lien Contact (navigation secondaire)
+
+## Constraints
+
+- Pas de changement de comportement fonctionnel (pas de nouvelle feature)
+- Tailwind uniquement, pas de CSS custom
+- Lint doit passer (0 erreurs)
+
+## Stakeholders
+
+- Visiteurs patients : principale cible de conversion
+- Praticienne (Oriane Montabonnet) : réduit les contacts informels non-structurés
+
+## Appetite
+
+Tier: F-lite
+Reasoning: Modifications de navigation/liens sur ~11 fichiers, un seul domaine (routing UX). Pas de logique métier ni d'architecture.
+
+## Open Questions
+
+- Faut-il aussi mettre à jour `rdv/accepter-report.astro` (2 liens `/contact/`) ? Hors scope pour l'instant.
+- **psychologue.net (footer badges)** — `FooterHours.tsx` et `Footer.astro` contiennent le widget/badge de certification. À supprimer dans une tâche dédiée prochainement (abandon du service pour raisons de coût).
+
+## Premise Validity
+
+**Success in 6 months:** 100% des CTAs "Prendre rendez-vous" du site pointent vers `/rendez-vous/`, la navbar ne comporte plus de lien "Contact", et aucune régression fonctionnelle signalée.
+
+**Failure in 6 months:** Des liens `/contact` persistent dans les CTAs de conversion (vérifiable par grep), ou la navbar affiche encore "Contact" comme entrée principale.
+
+**Simplest alternative:** Redirection 301 `/contact` → `/rendez-vous/` côté Netlify.
+**Why not simplest:** La page contact a un usage légitime (formulaire de contact libre) ; une redirection casse ce cas d'usage. Il faut cibler chirurgicalement les CTAs de conversion, pas toute la page.

--- a/artifacts/plans/36-google-calendar-production-ready-plan.md
+++ b/artifacts/plans/36-google-calendar-production-ready-plan.md
@@ -1,0 +1,396 @@
+---
+issue: 36
+tier: F-full
+spec: artifacts/specs/36-google-calendar-production-ready-spec.md
+status: draft
+---
+
+# Plan — #36 Google Calendar Production-Ready Integration
+
+## Overview
+
+5 slices of work, all backend. Agents: `backend-dev` (primary), `security-auditor` (T2), `tester` (final).
+
+---
+
+## Tasks
+
+| ID | Description | Agent | Files | Dependencies | Parallel? |
+|----|-------------|-------|-------|--------------|-----------|
+| T1 | Migration SQL + TypeScript types | backend-dev | `supabase/migrations/004_google_calendar.sql`, `src/types/appointment.ts` | — | Y |
+| T2 | Auth: persisted OAuth token rotation | backend-dev | `src/lib/google-calendar.ts` | T1 | N |
+| T3 | Typed errors + retry helper | backend-dev | `src/lib/google-calendar.ts` | — | Y (with T1) |
+| T4 | Event lifecycle functions (update/delete, reduce poll) | backend-dev | `src/lib/google-calendar.ts` | T3 | N |
+| T5 | Call sites: store eventId + patch/delete on actions | backend-dev | `src/pages/api/appointments/[id].ts`, `src/pages/api/admin/appointments/index.ts` | T1, T4 | N |
+| T6 | Cache module + integrate in availability + invalidate | backend-dev | `src/lib/calendar-cache.ts` (new), `src/pages/api/availability.ts`, `src/pages/api/appointments/[id].ts`, `src/pages/api/admin/appointments/index.ts` | T5 | N |
+| T7 | Security audit (token storage, auth flow) | security-auditor | `src/lib/google-calendar.ts`, `src/pages/api/` | T2, T3 | Y (with T6) |
+| T8 | Tests | tester | `src/lib/google-calendar.ts`, `src/pages/api/` | T6, T7 | N |
+
+---
+
+## Agent Slices
+
+**backend-dev:** T1 → T2+T3 (T2 after T1; T3 parallel with T1) → T4 → T5 → T6
+**security-auditor:** T7 (after T2, T3)
+**tester:** T8 (after all)
+
+---
+
+## Detailed Task Specs
+
+### T1 — Migration SQL + Types
+
+**File: `supabase/migrations/004_google_calendar.sql`**
+```sql
+-- Token storage for OAuth rotation
+CREATE TABLE IF NOT EXISTS google_oauth_tokens (
+  id TEXT PRIMARY KEY DEFAULT 'therapist',
+  access_token TEXT NOT NULL,
+  refresh_token TEXT NOT NULL,
+  expiry_date BIGINT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- RLS: only service role can access
+ALTER TABLE google_oauth_tokens ENABLE ROW LEVEL SECURITY;
+
+-- Link calendar events to appointments
+ALTER TABLE appointments
+  ADD COLUMN IF NOT EXISTS google_calendar_event_id TEXT;
+```
+
+**File: `src/types/appointment.ts`**
+- Add `google_calendar_event_id?: string | null` to the `Appointment` interface
+
+---
+
+### T2 — Auth: Persisted OAuth Token Rotation
+
+**Location:** `src/lib/google-calendar.ts`
+
+Replace `buildOAuthClient()` with `getPersistedOAuthClient()`:
+
+```typescript
+async function getPersistedOAuthClient(): Promise<OAuth2Client> {
+  const oauth2Client = new google.auth.OAuth2(
+    process.env.GOOGLE_CLIENT_ID,
+    process.env.GOOGLE_CLIENT_SECRET,
+    process.env.GOOGLE_REDIRECT_URI
+  );
+
+  // 1. Load from DB
+  const { data, error } = await supabaseAdmin
+    .from('google_oauth_tokens')
+    .select('*')
+    .eq('id', 'therapist')
+    .single();
+
+  let tokens = data;
+
+  if (error || !tokens) {
+    // 2. Bootstrap from env vars (first run)
+    tokens = {
+      id: 'therapist',
+      access_token: process.env.GOOGLE_OAUTH_ACCESS_TOKEN ?? '',
+      refresh_token: process.env.GOOGLE_OAUTH_REFRESH_TOKEN!,
+      expiry_date: Date.now(),
+    };
+    await supabaseAdmin.from('google_oauth_tokens').upsert(tokens);
+  }
+
+  // 3. Proactive refresh: 5 min buffer
+  if (tokens.expiry_date < Date.now() + 5 * 60 * 1000) {
+    oauth2Client.setCredentials({ refresh_token: tokens.refresh_token });
+    try {
+      const { credentials } = await oauth2Client.refreshAccessToken();
+      const updated = {
+        access_token: credentials.access_token!,
+        // Persist rotated refresh_token if Google returns one (rotation policy)
+        refresh_token: credentials.refresh_token ?? tokens.refresh_token,
+        expiry_date: credentials.expiry_date ?? (Date.now() + 3600 * 1000),
+        updated_at: new Date().toISOString(),
+      };
+      await supabaseAdmin.from('google_oauth_tokens')
+        .update(updated)
+        .eq('id', 'therapist');
+      oauth2Client.setCredentials(credentials);
+      return oauth2Client;
+    } catch (err) {
+      // invalid_grant = consent revoked — alert admin
+      if ((err as any)?.response?.data?.error === 'invalid_grant') {
+        // TODO: send admin alert email
+        throw new CalendarAuthError('OAuth consent revoked — re-authorize in Google Cloud Console');
+      }
+      throw new CalendarNetworkError('Token refresh failed', err);
+    }
+  }
+
+  oauth2Client.setCredentials({
+    access_token: tokens.access_token,
+    refresh_token: tokens.refresh_token,
+    expiry_date: tokens.expiry_date,
+  });
+  return oauth2Client;
+}
+```
+
+**Notes:**
+- `resolveCalendarAuth()` calls `getPersistedOAuthClient()` as primary strategy
+- No race condition mitigation in V1 (single therapist, concurrency is minimal; TODO comment for future DB lock)
+- Keep `buildServiceAccountClient()` unchanged as fallback
+
+---
+
+### T3 — Typed Errors + Retry
+
+**Location:** `src/lib/google-calendar.ts`
+
+Keep `GoogleCalendarError` as **base class** (preserves all existing `instanceof` checks in availability.ts and google-calendar.ts). Typed subclasses extend it:
+
+```typescript
+// Keep existing class, add cause
+export class GoogleCalendarError extends Error {
+  constructor(message: string, public cause?: unknown) { super(message); this.name = 'GoogleCalendarError'; }
+}
+
+export class CalendarAuthError extends GoogleCalendarError {
+  readonly type = 'CalendarAuthError';
+  constructor(message: string, cause?: unknown) { super(message, cause); this.name = 'CalendarAuthError'; }
+}
+
+export class CalendarPermissionError extends GoogleCalendarError {
+  readonly type = 'CalendarPermissionError';
+  constructor(message: string, cause?: unknown) { super(message, cause); this.name = 'CalendarPermissionError'; }
+}
+
+export class CalendarQuotaError extends GoogleCalendarError {
+  readonly type = 'CalendarQuotaError';
+  constructor(message: string, cause?: unknown) { super(message, cause); this.name = 'CalendarQuotaError'; }
+}
+
+export class CalendarNetworkError extends GoogleCalendarError {
+  readonly type = 'CalendarNetworkError';
+  constructor(message: string, cause?: unknown) { super(message, cause); this.name = 'CalendarNetworkError'; }
+}
+
+function parseGoogleError(err: unknown): Error {
+  const status = (err as any)?.response?.status ?? (err as any)?.code;
+  if (status === 401) return new CalendarAuthError('Authentication failed', err);
+  if (status === 403) return new CalendarPermissionError('Calendar access denied', err);
+  if (status === 429) return new CalendarQuotaError('Google API quota exceeded', err);
+  return new CalendarNetworkError('Calendar API error', err);
+}
+
+async function withCalendarRetry<T>(fn: () => Promise<T>, maxAttempts = 3): Promise<T> {
+  let lastError: Error;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      const parsed = parseGoogleError(err);
+      lastError = parsed;
+      if (parsed instanceof CalendarAuthError || parsed instanceof CalendarPermissionError) {
+        throw parsed; // No retry for auth/permission errors
+      }
+      if (attempt < maxAttempts) {
+        await new Promise(resolve => setTimeout(resolve, 1000 * Math.pow(2, attempt - 1)));
+      }
+    }
+  }
+  throw lastError!;
+}
+```
+
+---
+
+### T4 — Event Lifecycle Functions
+
+**Location:** `src/lib/google-calendar.ts`
+
+Changes:
+1. **Reduce `pollMeetLink` attempts:** `maxAttempts` from 10 to 3 (4.5s max vs 15s)
+2. **New `updateCalendarEvent(eventId, patch)`:**
+```typescript
+export async function updateCalendarEvent(
+  eventId: string,
+  patch: { start?: Date; end?: Date; summary?: string }
+): Promise<void> {
+  return withCalendarRetry(async () => {
+    const auth = await resolveCalendarAuth();
+    const calendar = google.calendar({ version: 'v3', auth });
+    const body: calendar_v3.Schema$Event = {};
+    if (patch.start) body.start = { dateTime: patch.start.toISOString(), timeZone: TIMEZONE };
+    if (patch.end) body.end = { dateTime: patch.end.toISOString(), timeZone: TIMEZONE };
+    if (patch.summary) body.summary = patch.summary;
+    await calendar.events.patch({
+      calendarId: 'primary',
+      eventId,
+      requestBody: body,
+      sendUpdates: 'all',
+    });
+  });
+}
+```
+
+3. **New `deleteCalendarEvent(eventId)`:**
+```typescript
+export async function deleteCalendarEvent(eventId: string): Promise<void> {
+  return withCalendarRetry(async () => {
+    const auth = await resolveCalendarAuth();
+    const calendar = google.calendar({ version: 'v3', auth });
+    await calendar.events.delete({
+      calendarId: 'primary',
+      eventId,
+      sendUpdates: 'all',
+    });
+  });
+}
+```
+
+4. **`createCalendarEvent` now returns `eventId`** (it already returns it, but add it to the return type explicitly)
+
+---
+
+### T5 — Call Sites: Store eventId + patch/delete
+
+**File: `src/pages/api/appointments/[id].ts`**
+
+| Action | Change |
+|--------|--------|
+| `confirm` (online — creates Meet event) | **Guard:** if `appt.google_calendar_event_id` already exists, skip `createCalendarEvent()` (idempotency on retry). After creation, await store of `google_calendar_event_id`. |
+| `decline` | After DB update, if `appt.google_calendar_event_id` exists → `await deleteCalendarEvent(id).catch(console.error)` (awaited — no fire-and-forget in serverless) |
+| `reschedule` (therapist proposes) | DB-only — do NOT touch Calendar (proposal pending patient acceptance) |
+| `accept_reschedule` (in-person) | **Guard:** if `google_calendar_event_id` exists → `await updateCalendarEvent(id, {start: accepted_date, end})`, else → `createCalendarEvent()` + store ID |
+| `cancel_reschedule` | DB-only rollback — no Calendar change needed |
+
+**File: `src/pages/api/admin/appointments/index.ts`**
+
+- **Guard:** if `appt.google_calendar_event_id` already exists, skip `createCalendarEvent()` (idempotency on retry)
+- After `createCalendarEvent()` call → await store of returned `eventId` in appointment row
+
+---
+
+### T6 — Cache
+
+**New file: `src/lib/calendar-cache.ts`**
+```typescript
+import { getStore } from '@netlify/blobs';
+import type { TimeSlot } from './google-calendar';
+
+function getAvailabilityStore() {
+  try {
+    return getStore('calendar-availability');
+  } catch {
+    return null; // not available in local astro dev
+  }
+}
+
+export async function getCachedAvailability(key: string): Promise<TimeSlot[] | null> {
+  const store = getAvailabilityStore();
+  if (!store) return null;
+  try {
+    const data = await store.getWithMetadata(key, { type: 'json' });
+    if (!data) return null;
+    const { metadata } = data as any;
+    if (metadata?.expiresAt && Date.now() > metadata.expiresAt) return null;
+    return (data as any).data as TimeSlot[];
+  } catch {
+    return null;
+  }
+}
+
+export async function setCachedAvailability(
+  key: string,
+  slots: TimeSlot[],
+  ttlSeconds = 600
+): Promise<void> {
+  const store = getAvailabilityStore();
+  if (!store) return;
+  try {
+    await store.setJSON(key, slots, {
+      metadata: { expiresAt: Date.now() + ttlSeconds * 1000 }
+    });
+  } catch {
+    // Cache write failure is non-fatal
+  }
+}
+
+export async function invalidateAvailabilityCache(): Promise<void> {
+  const store = getAvailabilityStore();
+  if (!store) return;
+  try {
+    const { blobs } = await store.list();
+    await Promise.allSettled(blobs.map(b => store.delete(b.key)));
+  } catch {
+    // Non-fatal
+  }
+}
+```
+
+**File: `src/pages/api/availability.ts`**
+- Compute stable cache key: `available:${mode}:${duration}:${weekStart}` where `weekStart` = Monday of the week containing `startDate`, formatted as `YYYY-MM-DD` (Paris time). Do NOT include raw `Date.now()` in the key.
+- Before `getAvailableSlots()`: compute key → check cache → return if hit
+- After `getAvailableSlots()`: `await setCachedAvailability(key, slots).catch(() => {})` (awaited, never blocks response on error)
+
+**Files: `appointments/[id].ts` + `admin/appointments/index.ts`**
+- After every mutating DB operation (confirm, decline, reschedule, accept_reschedule):
+  ```ts
+  await invalidateAvailabilityCache().catch(console.error);
+  ```
+  (awaited — Netlify functions don't reliably execute fire-and-forget promises after response is sent)
+
+---
+
+## Agent Sequence
+
+```
+T1 + T3 (parallel, no deps)
+     ↓
+T2 (needs T1 for DB) | T4 (needs T3 for typed errors)
+     ↓                        ↓
+               T5 (needs T1 + T4)
+                     ↓
+               T6 (needs T5 for call sites)
+                     ↓
+          T7 (security audit) ← can run after T2,T3
+                     ↓
+               T8 (tests — last)
+```
+
+In practice for sequential execution: T1 → T3 → T2 → T4 → T5 → T6 → T7 → T8
+
+---
+
+## Quality Gate
+
+```bash
+npm run lint && npm run build
+```
+
+---
+
+## Key Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Supabase for token storage | Already in stack, no new infra |
+| `@netlify/blobs` for cache | Bundled via `@astrojs/netlify`, zero config |
+| No DB lock on token refresh | Single therapist, near-zero concurrency risk; rotated `refresh_token` always persisted from Google credentials; TODO for future |
+| Await cache invalidation | Netlify serverless kills dangling promises after response — all side effects must be awaited |
+| Reschedule = DB-only until accept | Prevents Calendar from drifting if patient cancels/rejects the proposal |
+| Cache key: `available:${mode}:${duration}:${weekStart}` | Stable key derived from business inputs only — never includes raw timestamps |
+| Idempotency guard on createCalendarEvent | Skip creation if `google_calendar_event_id` already set — safe on retries/webhook replays |
+
+---
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Token refresh race (concurrent requests) | 5min buffer reduces frequency; rotated `refresh_token` always persisted; TODO: DB advisory lock |
+| `@netlify/blobs` not available in `astro dev` | `getAvailabilityStore()` wraps `getStore()` in try/catch → returns `null` → cache no-op; also disabled when `GOOGLE_CALENDAR_MOCK=true` |
+| `invalid_grant` on bootstrap | Fails loudly with `CalendarAuthError`; deployment checklist must include `GOOGLE_OAUTH_REFRESH_TOKEN` |
+| Netlify function timeout on Meet polling | Reduced from 15s (10×1.5s) to 4.5s max (3×1.5s) |
+| Duplicate calendar events on retry | Guard: check `google_calendar_event_id` before `createCalendarEvent()` at every call site |
+| `CreateAppointmentData` accidentally requiring new field | Add `google_calendar_event_id?: string \| null` only to base `Appointment` interface; omit from `CreateAppointmentData` |

--- a/artifacts/plans/38-feat-amelioration-flow-invitation-rdv-therapeute-plan.md
+++ b/artifacts/plans/38-feat-amelioration-flow-invitation-rdv-therapeute-plan.md
@@ -1,0 +1,93 @@
+---
+issue: 38
+tier: F-full
+spec: artifacts/specs/38-feat-amelioration-flow-invitation-rdv-therapeute-spec.md
+status: draft
+---
+
+## Tasks
+
+| ID | Description | Agent | Files | Dependencies | Parallel? |
+|----|-------------|-------|-------|-------------|----------|
+| T1 | Étendre types pricing + `Appointment.duration: number` + `overridePrice?` dans `calculatePrice` | backend-dev | `src/lib/pricing.ts`, `src/types/appointment.ts` | — | Y |
+| T2 | API admin : validation durée [15–240], `override_price`, calendrier vidéo immédiat, persist `google_calendar_event_id` | backend-dev | `src/pages/api/admin/appointments/index.ts` | T1 | N |
+| T3 | Webhook : idempotence `google_calendar_event_id` avant création calendrier | backend-dev | `src/pages/api/stripe-webhook.ts` | — | Y |
+| T4 | UI admin : durée custom (select + champ numérique conditionnel) + prix override | frontend-dev | `src/components/admin/AdminCreateButton.tsx` | T1 | Y |
+| T5 | Validation : vérifier lint + typecheck post-implémentation | tester | — | T1,T2,T3,T4 | N |
+
+## Budget
+
+### Per task
+
+| Task | Subject | Class | Est. ops | Split? |
+|------|---------|-------|----------|--------|
+| T1 | pricing | bounded | ~4 | — |
+| T2 | appointments | exploratory | ~12 | — |
+| T3 | payments | bounded | ~4 | — |
+| T4 | admin-ui | judgmental | ~8 | — |
+| T5 | quality | trivial | ~2 | — |
+
+### Per agent instance
+
+| Instance | Tasks | Subjects | Est. ops | Action |
+|----------|-------|----------|----------|--------|
+| backend-dev-A | T1, T2 | pricing, appointments | ~16 | — |
+| backend-dev-B | T3 | payments | ~4 | — |
+| frontend-dev | T4 | admin-ui | ~8 | — |
+| tester | T5 | quality | ~2 | — |
+
+## Agent Slices
+
+**backend-dev-A:** T1, T2
+**backend-dev-B:** T3
+**frontend-dev:** T4
+**tester:** T5
+
+## Quality Gate
+
+```bash
+npm run lint
+```
+
+(build requires env vars — non-disponible en local sans `.env.local` complet ; lint + typecheck suffisent pour valider)
+
+## Sequence
+
+1. **T1** — types fondation (pricing + appointment) ; T3 en parallèle (indépendant)
+2. **T2** — API admin (dépend T1) ; **T4** — UI admin (dépend T1) — peuvent partir en parallèle après T1
+3. **T5** — quality gate finale
+
+## Notes d'implémentation
+
+### T1 — pricing.ts
+- Ajouter `export type AdminDuration = number` (alias sémantique admin-only)
+- `calculatePrice` : ajouter param optionnel `overridePrice?: number` — si présent, retourner `{ basePrice: overridePrice, discount: 0, finalPrice: overridePrice, label: \`${overridePrice}€\` }`
+- `Appointment.duration` dans `types/appointment.ts` : `60 | 90` → `number` (reflète DB INTEGER sans contrainte)
+- `AppointmentDuration = 60 | 90` **reste inchangé** — utilisé par le flow patient
+
+### T2 — admin/appointments/index.ts
+- Remplacer `VALID_DURATIONS.has(Number(duration))` par `Number.isInteger(Number(duration)) && Number(duration) >= 15 && Number(duration) <= 240`
+- Message d'erreur : `'Durée invalide (entre 15 et 240 minutes)'`
+- Extraire `override_price` du body ; valider `typeof override_price === 'undefined' || (Number.isInteger(Number(override_price)) && Number(override_price) >= 0)`
+- Calcul prix : `override_price !== undefined ? { basePrice: Number(override_price), discount: 0, finalPrice: Number(override_price) } : calculatePrice(...)`
+- **Refactoriser le bloc calendrier** : extraire une fonction `createAdminCalendarEvent(appointment)` couvrant `in-person` ET `video` :
+  - in-person : `withMeet: false`, location = cabinet
+  - video : `withMeet: !video_link`, location = 'Téléconsultation'
+  - Exécuter juste après `invalidateAvailabilityCache()`, avant les emails
+  - Persister `google_calendar_event_id` via `supabaseAdmin.update`
+  - Non-bloquant : `try/catch` avec `console.error`
+
+### T3 — stripe-webhook.ts
+- Dans `handlePaymentSucceeded`, après `supabaseAdmin.update` (lignes 201–212) :
+  - Re-lire `google_calendar_event_id` du RDV mis à jour (`updated.google_calendar_event_id`)
+  - Si non nul → `calendarEventCreated = true` ; skip tout le bloc de création calendrier
+  - Si nul → comportement actuel inchangé
+
+### T4 — AdminCreateButton.tsx
+- `FormState.duration`: `AppointmentDuration` → `number | 'custom'`
+- Ajouter `customDurationMinutes: number` (défaut: 45), `useOverridePrice: boolean` (défaut: false), `override_price: number` (défaut: 0)
+- DURATIONS : ajouter `{ value: 'custom', label: 'Personnalisée…' }`
+- Quand `duration === 'custom'` : afficher `<input type="number" min="15" max="240" step="1">` sous le select
+- `livePrice` : dépend de `form.useOverridePrice` — si true, afficher `override_price` sans calcul
+- Quand `useOverridePrice` : désactiver + décocher `override_first_session` et `is_solidarity`
+- `handleSubmit` : payload `duration = form.duration === 'custom' ? form.customDurationMinutes : form.duration` ; ajouter `override_price` si `useOverridePrice`

--- a/artifacts/plans/activation-page-rendez-vous-plan.md
+++ b/artifacts/plans/activation-page-rendez-vous-plan.md
@@ -1,0 +1,49 @@
+---
+issue: ~
+tier: F-lite
+spec: artifacts/specs/activation-page-rendez-vous-spec.md
+status: approved
+---
+
+## Tasks
+
+| ID | Description | Agent | Files | Dependencies | Parallel? |
+|----|-------------|-------|-------|-------------|----------|
+| T1 | Retirer "Contact" de NavigationItems ; mettre à jour isActive dans Navbar.tsx (supprimer cas `/contact`, ajouter `/rendez-vous`) | frontend-dev | `src/components/navigation/NavigationItems.tsx`, `src/components/islands/Navbar.tsx` | — | Y |
+| T2 | Remplacer les 2 CTAs `/contact` → `/rendez-vous/` dans les 4 pages de service | frontend-dev | `src/pages/services/therapie-individuelle.astro`, `therapie-de-couple.astro`, `therapie-familiale.astro`, `troubles-alimentaires.astro` | — | Y |
+| T3 | Remplacer CTAs `/contact` → `/rendez-vous/` dans les pages éditoriales + lien psychologue.net sur contact.astro | frontend-dev | `src/pages/a-propos.astro`, `src/pages/blog/[slug].astro`, `src/pages/rendez-vous.astro`, `src/pages/contact.astro`, `src/pages/404.astro` | — | Y |
+| T4 | Valider : `npm run lint` — 0 nouvelles erreurs | tester | — | T1, T2, T3 | N |
+
+## Budget
+
+### Per task
+
+| Task | Subject | Class | Est. ops |
+|------|---------|-------|----------|
+| T1 | navigation | bounded | ~3 |
+| T2 | routing/cta | trivial | ~2 |
+| T3 | routing/cta | bounded | ~3 |
+| T4 | lint | trivial | ~1 |
+
+### Per agent instance
+
+| Instance | Tasks | Subjects | Est. ops | Action |
+|----------|-------|----------|----------|--------|
+| frontend-dev | T1, T2, T3 | navigation | ~8 | — |
+| tester | T4 | lint | ~1 | — |
+
+## Agent Slices
+
+**frontend-dev:** T1, T2, T3 — navigation island + pages Astro (même sujet : routing/liens)
+**tester:** T4 — quality gate lint
+
+## Quality Gate
+
+```bash
+npm run lint
+```
+
+## Sequence
+
+1. **T1, T2, T3** (parallèles) — modifications indépendantes dans leurs fichiers respectifs
+2. **T4** — lint après toutes les modifications

--- a/artifacts/specs/36-google-calendar-production-ready-spec.md
+++ b/artifacts/specs/36-google-calendar-production-ready-spec.md
@@ -1,0 +1,155 @@
+---
+issue: 36
+title: "feat: Google Calendar production-ready — OAuth token rotation, event lifecycle, Meet async, cache, error handling"
+tier: F-full
+status: approved
+---
+
+## Goal
+
+Rendre l'intégration Google Calendar production-ready : token OAuth auto-renouvelé depuis
+Supabase, événements Calendar synchronisés sur tout le lifecycle d'un rdv, génération Meet
+non-bloquante, cache disponibilités via `@netlify/blobs`, et erreurs Google typées avec retry.
+
+## Context
+
+`src/lib/google-calendar.ts` est le module central (~650 lignes). Il est appelé par :
+- `GET /api/availability` — Freebusy pour les créneaux disponibles
+- `PATCH /api/appointments/[id]` — création d'événement à la confirmation (in-person + video)
+- `POST /api/admin/appointments` — création manuelle (in-person uniquement)
+
+Lacunes actuelles identifiées :
+- `GOOGLE_OAUTH_REFRESH_TOKEN` statique en env var → expire sans alerte
+- `google_calendar_event_id` jamais stocké → reschedule/decline/cancel orphelins
+- `pollMeetLink()` = 10 × 1,5s = 15s → dépasse le timeout Netlify de 10s
+- Aucun cache sur `/api/availability` → quota Google à risque
+- `GoogleCalendarError` unique → impossible de distinguer 401 / 403 / 429
+
+## Acceptance Criteria
+
+### Auth — token rotation (AC-1 à AC-4)
+- [ ] **AC-1** — Table `google_oauth_tokens` créée dans Supabase avec colonnes :
+  `id`, `access_token TEXT NOT NULL`, `refresh_token TEXT NOT NULL`, `expiry_date BIGINT NOT NULL`,
+  `created_at`, `updated_at`. Contrainte : une seule ligne active (`id = 'therapist'`).
+- [ ] **AC-2** — `getPersistedOAuthClient()` dans `google-calendar.ts` lit le token depuis
+  Supabase et appelle `oauth2Client.refreshAccessToken()` si `expiry_date < Date.now() + 5min`.
+  Le nouveau token est persisté immédiatement après refresh.
+- [ ] **AC-3** — Si Google retourne `invalid_grant`, un email d'alerte est envoyé  `ADMIN_EMAIL`
+  et l'erreur est relancée en `CalendarAuthError`.
+- [ ] **AC-4** — Les env vars `GOOGLE_OAUTH_*` restent utilises comme bootstrap initial
+  (seeding de la table si elle est vide). La rotation est ensuite entièrement gérée par Supabase.
+
+### Event lifecycle — stockage et synchronisation (AC-5 à AC-9)
+- [ ] **AC-5** — Migration Supabase : colonne `google_calendar_event_id TEXT` ajoutée à
+  `appointments` (nullable, index non-unique).
+- [ ] **AC-6** — À chaque appel réussi de `createCalendarEvent()`, le `eventId` retourné est
+  stocké dans `appointments.google_calendar_event_id`.
+  Concerné : `PATCH action=confirm` (in-person et video), `POST /api/admin/appointments` (in-person).
+- [ ] **AC-7** — `PATCH action=reschedule` : si `google_calendar_event_id` est non-nul, appelle
+  `calendar.events.patch()` pour mettre à jour `start` et `end` avec `rescheduled_to`.
+  Non-bloquant : échec Calendar ne bloque pas la réponse HTTP.
+- [ ] **AC-8** — `PATCH action=accept_reschedule` (in-person) : au lieu de créer un nouvel
+  événement, si `google_calendar_event_id` existe, appelle `calendar.events.patch()` pour
+  confirmer la nouvelle date (`scheduled_at` post-update). Sinon, crée un nouvel événement
+  (comportement actuel conservé comme fallback).
+- [ ] **AC-9** — `PATCH action=decline` : si `google_calendar_event_id` est non-nul, appelle
+  `calendar.events.delete()`. Non-bloquant.
+
+### Meet generation — non-bloquant (AC-10 à AC-11)
+- [ ] **AC-10** — `pollMeetLink()` réduit à `maxAttempts = 3` (max ~4,5s au lieu de 15s).
+- [ ] **AC-11** — Si `pollMeetLink()` n'obtient pas de lien après 3 tentatives, retourne
+  `undefined` immédiatement (fallback Jitsi via `buildFallbackVideoLink()` dans l'appelant).
+  Aucun timeout Netlify ne peut être déclenché.
+
+### Availability cache (AC-12 à AC-14)
+- [ ] **AC-12** — Nouveau module `src/lib/calendar-cache.ts` exposant :
+  `getCachedAvailability(key)`, `setCachedAvailability(key, slots, ttlSeconds)`,
+  `invalidateAvailabilityCache()`.
+  Implémenté via `@netlify/blobs` (store name : `calendar-availability`).
+- [ ] **AC-13** — `GET /api/availability` consulte le cache avant d'appeler Google. Si présent
+  et non-expiré, retourne immédiatement. Sinon, appelle Google et met en cache le résultat.
+  Cache key : `{mode}-{duration}-{weeks}`.
+- [ ] **AC-14** — `invalidateAvailabilityCache()` est appelé (fire-and-forget) depuis :
+  `PATCH action=confirm`, `PATCH action=decline`, `PATCH action=reschedule`,
+  `PATCH action=accept_reschedule`, `POST /api/admin/appointments`.
+
+### Error handling (AC-15 à AC-17)
+- [ ] **AC-15** — `GoogleCalendarError` remplacée par 4 classes distinctes :
+  - `CalendarAuthError` — erreurs 401, `invalid_grant`, token expiré
+  - `CalendarPermissionError` — erreurs 403, calendar non partagé
+  - `CalendarQuotaError` — erreurs 429, quota dépassé
+  - `CalendarNetworkError` — timeout, 5xx, erreurs réseau
+- [ ] **AC-16** — Retry automatique avec backoff exponentiel (1s, 2s, 4s) sur `CalendarQuotaError`
+  et `CalendarNetworkError`, max 3 tentatives.
+- [ ] **AC-17** — `GET /api/availability` retourne :
+  - 503 avec message français sur `CalendarAuthError` et `CalendarPermissionError`
+  - 503 avec retry-after sur `CalendarQuotaError`
+  - 503 générique sur `CalendarNetworkError` (comportement actuel conservé)
+
+## Breadboard
+
+| Surface | Action | Handler | Data in | Data out |
+|---------|--------|---------|---------|----------|
+| Supabase | READ token | `getPersistedOAuthClient()` | — | `{access_token, refresh_token, expiry_date}` |
+| Google OAuth | REFRESH | `oauth2Client.refreshAccessToken()` | `refresh_token` | `{access_token, expiry_date}` |
+| Supabase | UPSERT token | `getPersistedOAuthClient()` | new token | — |
+| Supabase | SELECT | `google_oauth_tokens` | `id = 'therapist'` | token row |
+| Google Calendar | Freebusy | `calendar.freebusy.query()` | `{timeMin, timeMax, items}` | `{busy[]}` |
+| Netlify Blobs | GET | `getCachedAvailability(key)` | cache key | `TimeSlot[] \| null` |
+| Netlify Blobs | SET | `setCachedAvailability(key, slots)` | slots + TTL | — |
+| Netlify Blobs | DELETE | `invalidateAvailabilityCache()` | — | — |
+| Google Calendar | INSERT | `calendar.events.insert()` | event body + conferenceData | `{id, hangoutLink}` |
+| Google Calendar | PATCH | `calendar.events.patch()` | `eventId`, `{start, end}` | `{id}` |
+| Google Calendar | DELETE | `calendar.events.delete()` | `eventId` | 204 |
+| Supabase | UPDATE | `appointments` | `google_calendar_event_id` | — |
+| Resend | SEND | `sendEmail()` | alert body | — |
+
+## Slices
+
+**Slice 1 — Migration SQL + types** *(~30 min)*
+Fichiers : `supabase/migrations/004_google_calendar.sql`, `src/types/appointment.ts`
+- `CREATE TABLE google_oauth_tokens (id TEXT PRIMARY KEY DEFAULT 'therapist', ...)`
+- `ALTER TABLE appointments ADD COLUMN google_calendar_event_id TEXT`
+- Ajouter `google_calendar_event_id?: string | null` au type `Appointment`
+
+**Slice 2 — Auth : token rotation** *(~1h)*
+Fichier : `src/lib/google-calendar.ts`
+- Nouvelle fonction `getPersistedOAuthClient()` : lit Supabase → refresh si besoin → persiste → retourne `OAuth2Client`
+- Bootstrap : si table vide, seed depuis env vars `GOOGLE_OAUTH_*`
+- `resolveCalendarAuth()` utilise `getPersistedOAuthClient()` en priorité
+
+**Slice 3 — Typed errors + retry** *(~45 min)*
+Fichier : `src/lib/google-calendar.ts`
+- Remplacer `GoogleCalendarError` par `CalendarAuthError`, `CalendarPermissionError`, `CalendarQuotaError`, `CalendarNetworkError`
+- Fonction `withCalendarRetry<T>(fn, maxAttempts)` — backoff exponentiel
+- Parser les codes d'erreur HTTP Google (`err.code` ou `err.response?.status`)
+- Réexporter `GoogleCalendarError = CalendarNetworkError` pour ne pas casser les imports existants
+
+**Slice 4 — Event lifecycle (store ID + patch/delete)** *(~1h)*
+Fichiers : `src/lib/google-calendar.ts`, `src/pages/api/appointments/[id].ts`, `src/pages/api/admin/appointments/index.ts`
+- Réduire `pollMeetLink` à `maxAttempts = 3`
+- Nouvelles fonctions : `updateCalendarEvent(eventId, {start, end})`, `deleteCalendarEvent(eventId)`
+- Tous les call sites de `createCalendarEvent()` : stocker le `eventId` retourné dans `appointments`
+- `PATCH action=reschedule` → appeler `updateCalendarEvent()`
+- `PATCH action=accept_reschedule` → `updateCalendarEvent()` si ID présent, sinon create
+- `PATCH action=decline` → appeler `deleteCalendarEvent()`
+
+**Slice 5 — Cache availability** *(~45 min)*
+Fichiers : `src/lib/calendar-cache.ts` (nouveau), `src/pages/api/availability.ts`, `src/pages/api/appointments/[id].ts`, `src/pages/api/admin/appointments/index.ts`
+- Module `calendar-cache.ts` : `getCachedAvailability`, `setCachedAvailability`, `invalidateAvailabilityCache` via `@netlify/blobs`
+- Intégrer dans `GET /api/availability`
+- Appeler `invalidateAvailabilityCache()` fire-and-forget dans les 5 mutation handlers
+
+## Out of Scope
+
+- Interface UI de re-auth OAuth (la re-auth reste manuelle : exécuter un script ou réinsérer les tokens)
+- Google Workspace / multi-compte
+- Suppression de l'événement sur `cancel` initié par le patient (action `cancel` non encore implémentée)
+- Cache distribué Redis (Upstash ou autre)
+- Notifications webhook push depuis Google Calendar
+- Chiffrement des tokens au repos dans Supabase
+
+## Open Questions
+
+- `@netlify/blobs` en mode local dev (`npm run dev`) : nécessite `netlify dev` ou supporte `astro dev` ? → à vérifier, sinon cache désactivé en dev (GOOGLE_CALENDAR_MOCK=true de toute façon).
+- L'email d'alerte `invalid_grant` utilise `ADMIN_EMAIL` (env var existant). Confirmé.

--- a/artifacts/specs/38-feat-amelioration-flow-invitation-rdv-therapeute-spec.md
+++ b/artifacts/specs/38-feat-amelioration-flow-invitation-rdv-therapeute-spec.md
@@ -1,0 +1,109 @@
+---
+issue: 38
+title: "feat: amélioration du flow d'invitation RDV par le thérapeute — durée/tarif flexibles + création immédiate du calendrier"
+tier: F-full
+status: approved
+---
+
+## Goal
+
+Le thérapeute peut créer des rendez-vous admin avec une durée et un tarif libres, et l'événement Google Calendar est créé immédiatement à la soumission — indépendamment du paiement Stripe.
+
+## Context
+
+Le dashboard admin (`/mes-rdvs`) expose un bouton "Nouveau rendez-vous" (`AdminCreateButton.tsx`) qui poste vers `POST /api/admin/appointments/`. Actuellement :
+
+- La durée est validée contre `VALID_DURATIONS = new Set([60, 90])` dans l'API admin
+- Le prix est toujours calculé via `calculatePrice(type, duration, ...)` — pas d'override possible
+- Pour les RDV vidéo, l'événement Google Calendar est créé dans `stripe-webhook.ts → handlePaymentSucceeded()` après réception du paiement — si le patient paie manuellement (virement), l'événement n'est jamais créé
+- Pour les RDV présentiel, l'événement est créé immédiatement (comportement correct)
+- `stripe-webhook.ts` ne vérifie pas `google_calendar_event_id` avant de créer — un doublon serait produit si le RDV a déjà un événement
+
+Le flow patient (`POST /api/appointments/`) n'est pas modifié — la validation stricte 60/90 y est maintenue.
+
+## Acceptance Criteria
+
+### Durée personnalisée
+
+- [ ] AC1 — Le formulaire admin propose les durées standards (60 min, 90 min) **et** une option "Personnalisée"
+- [ ] AC2 — Quand "Personnalisée" est sélectionnée, un champ numérique apparaît (min: 15, max: 240, step: 1, unité: minutes)
+- [ ] AC3 — La saisie d'une durée non entière ou hors [15, 240] bloque la soumission avec un message d'erreur
+- [ ] AC4 — `POST /api/admin/appointments/` accepte toute durée entière entre 15 et 240 minutes
+- [ ] AC5 — Le flow patient (`POST /api/appointments/`) continue de rejeter toute durée hors 60/90 (comportement inchangé)
+
+### Tarif manuel
+
+- [ ] AC6 — Le formulaire admin affiche une case à cocher "Tarif manuel"
+- [ ] AC7 — Quand "Tarif manuel" est activé, un champ numérique de saisie du prix en euros apparaît (min: 0, step: 1)
+- [ ] AC8 — Quand "Tarif manuel" est activé, les cases "Remise nouveau client" et "Tarif solidaire" sont désactivées et le calcul automatique est masqué
+- [ ] AC9 — `POST /api/admin/appointments/` accepte un champ `override_price` (entier ≥ 0, en euros). Si présent, il remplace entièrement le calcul `calculatePrice` (base = override, discount = 0, final = override)
+- [ ] AC10 — Si `override_price` est absent, le calcul automatique s'applique normalement (rétrocompatibilité)
+
+### Création immédiate du calendrier (vidéo)
+
+- [ ] AC11 — À la soumission du formulaire admin pour un RDV vidéo, l'événement Google Calendar est créé immédiatement dans `POST /api/admin/appointments/` (pas après paiement)
+- [ ] AC12 — Si `video_link` est fourni dans le formulaire, l'événement calendrier utilise ce lien ; sinon un lien Google Meet est généré automatiquement
+- [ ] AC13 — Le patient reçoit une invitation Google Calendar (champ `attendeeEmail`) en parallèle de l'envoi du lien Stripe (si `send_email: true`)
+- [ ] AC14 — Si la création de l'événement calendrier échoue, la création du RDV réussit quand même (non-bloquant, erreur loggée)
+- [ ] AC15 — `google_calendar_event_id` est persisté en base après la création de l'événement
+
+### Idempotence webhook
+
+- [ ] AC16 — `handlePaymentSucceeded` dans `stripe-webhook.ts` vérifie `google_calendar_event_id` avant de créer un événement calendrier pour les RDV vidéo
+- [ ] AC17 — Si `google_calendar_event_id` est déjà renseigné (événement créé par l'admin), le webhook ne crée pas de doublon
+- [ ] AC18 — Si `google_calendar_event_id` est nul (RDV créé avant ce fix, ou sans événement calendrier), le webhook crée l'événement normalement
+
+### Rétrocompatibilité
+
+- [ ] AC19 — Les RDV admin existants avec durée 60 ou 90 min continuent de fonctionner normalement
+- [ ] AC20 — Le flow de prise de RDV patient (`/rendez-vous.astro`, `POST /api/appointments/`) est inchangé
+
+## Breadboard
+
+| Surface | Action | Handler | Données |
+|---------|--------|---------|---------|
+| `AdminCreateButton.tsx` | Select "Personnalisée" dans durée | État local `customDuration: boolean` | `form.duration` → `'custom'` + `form.customDurationMinutes: number` |
+| `AdminCreateButton.tsx` | Saisir durée custom (ex: 45) | `update('customDurationMinutes', v)` | validé en [15–240] avant soumission |
+| `AdminCreateButton.tsx` | Cocher "Tarif manuel" | `update('useOverridePrice', true)` | désactive `override_first_session`, `is_solidarity` |
+| `AdminCreateButton.tsx` | Saisir tarif manuel (ex: 55) | `update('override_price', v)` | passe `override_price` dans le payload |
+| `AdminCreateButton.tsx` | Soumettre formulaire | `handleSubmit` → `POST /api/admin/appointments/` | payload avec `duration: number`, `override_price?: number` |
+| `POST /api/admin/appointments/` | Valider durée | Guard: `Number.isInteger(d) && d >= 15 && d <= 240` | erreur 400 si hors plage |
+| `POST /api/admin/appointments/` | Calculer prix | `override_price ?? calculatePrice(...)` | stocké en centimes en base |
+| `POST /api/admin/appointments/` | Créer événement calendrier (vidéo) | `createCalendarEvent(...)` immédiat, même chemin que présentiel | `withMeet: !video_link` |
+| `POST /api/admin/appointments/` | Persister `google_calendar_event_id` | `supabaseAdmin.update(...)` | après retour `createCalendarEvent` |
+| `stripe-webhook.ts` | Paiement reçu → vérifier calendrier | Lire `google_calendar_event_id` de l'appt | si non nul → skip création |
+| `stripe-webhook.ts` | Paiement reçu → créer calendrier | `createCalendarEvent(...)` si `google_calendar_event_id` nul | comportement actuel inchangé |
+
+## Slices
+
+**Slice 1 — Types & pricing (fondation) :**
+Étendre `AppointmentDuration` côté admin, ajouter `overridePrice?` à `calculatePrice`, mettre `Appointment.duration: number` dans les types.
+*Fichiers :* `src/lib/pricing.ts`, `src/types/appointment.ts`
+
+**Slice 2 — Validation API admin :**
+Remplacer `VALID_DURATIONS.has()` par la validation `[15–240]`, accepter `override_price` dans le body, appliquer l'override dans le calcul.
+*Fichiers :* `src/pages/api/admin/appointments/index.ts`
+
+**Slice 3 — Calendrier immédiat pour vidéo dans l'API admin :**
+Refactoriser le bloc de création d'événement pour couvrir `video` (en plus de `in-person`). Générer Meet si pas de `video_link`. Persister `google_calendar_event_id`.
+*Fichiers :* `src/pages/api/admin/appointments/index.ts`
+
+**Slice 4 — Idempotence webhook :**
+Avant la création d'événement calendrier dans `handlePaymentSucceeded`, lire `google_calendar_event_id`. Si déjà renseigné, marquer `calendarEventCreated = true` sans appeler `createCalendarEvent`.
+*Fichiers :* `src/pages/api/stripe-webhook.ts`
+
+**Slice 5 — UI admin (durée custom + prix override) :**
+`FormState.duration: number | 'custom'` + `customDurationMinutes: number` + `useOverridePrice: boolean` + `override_price: number`. Afficher/masquer les champs conditionnels. Mise à jour `livePrice`.
+*Fichiers :* `src/components/admin/AdminCreateButton.tsx`
+
+## Out of Scope
+
+- Flow patient (`/api/appointments/`, `/rendez-vous.astro`) — validation stricte maintenue
+- Grille tarifaire `PRICE_GRID` — pas de modification
+- Vérification de disponibilité côté patient pour durées custom
+- Mise à jour des événements calendrier existants après création
+- Gestion des durées décimales
+
+## Open Questions
+
+- _(aucune — frame et analyse ont couvert les ambiguïtés)_

--- a/artifacts/specs/activation-page-rendez-vous-spec.md
+++ b/artifacts/specs/activation-page-rendez-vous-spec.md
@@ -1,0 +1,66 @@
+---
+issue: ~
+title: "Activation page rendez-vous — navigation & CTAs"
+tier: F-lite
+status: approved
+---
+
+## Goal
+
+Tous les CTAs de conversion "Prendre rendez-vous" du site pointent vers `/rendez-vous/`, le lien "Contact" est retiré de la navbar, et le lien psychologue.net de conversion est remplacé.
+
+## Context
+
+La page `/rendez-vous` (booking wizard complet) est déjà live et fonctionnelle sur `feat/36-google-calendar-production-ready`. Le site comporte cependant ~14 liens qui envoient les visiteurs vers `/contact` ou `psychologue.net` au lieu du wizard. La navbar affiche encore "Contact" comme entrée séparée alors que "Prendre rendez-vous" y figure déjà.
+
+Navigation source : `NavigationItems.tsx` → consommé par `Navbar.tsx` (island) → `DesktopNav` + `MobileNav`.
+
+## Acceptance Criteria
+
+- [ ] AC1 — L'entrée "Contact" est absente de la navbar desktop et mobile
+- [ ] AC2 — La logique `isActive` dans `Navbar.tsx` gère `/rendez-vous` et ne référence plus `/contact` comme cas spécial
+- [ ] AC3 — Les 4 pages de service (`therapie-individuelle`, `therapie-de-couple`, `therapie-familiale`, `troubles-alimentaires`) ont leurs 2 CTAs chacune pointant vers `/rendez-vous/`
+- [ ] AC4 — Le CTA "Prendre rendez-vous" de `a-propos.astro` pointe vers `/rendez-vous/`
+- [ ] AC5 — Le CTA de fin d'article dans `blog/[slug].astro` pointe vers `/rendez-vous/`
+- [ ] AC6 — Le lien interne `/contact/` dans `rendez-vous.astro` pointe vers `/rendez-vous/`
+- [ ] AC7 — Le lien `psychologue.net` (CTA booking) dans `contact.astro` pointe vers `/rendez-vous/`
+- [ ] AC8 — Le CTA de `404.astro` pointe vers `/rendez-vous/`
+- [ ] AC9 — `npm run lint` passe sans nouvelles erreurs
+- [ ] AC10 — La page `/contact` reste accessible directement (aucune suppression de page)
+
+## Breadboard
+
+| Surface | Action | Handler | Résultat |
+|---------|--------|---------|----------|
+| Navbar desktop | Clic sur un lien de nav | `NavigationItems` → `DesktopNav` | "Contact" absent, "Prendre rendez-vous" présent |
+| Navbar mobile | Ouverture menu | `NavigationItems` → `MobileNav` | "Contact" absent |
+| Page service (×4) | Clic CTA principal | `<a href>` statique Astro | → `/rendez-vous/` |
+| Page À propos | Clic CTA | `<a href>` statique Astro | → `/rendez-vous/` |
+| Blog article | Clic lien de fin | `<a href>` statique Astro | → `/rendez-vous/` |
+| Page Contact | Clic lien psychologue.net | `<a href>` statique Astro | → `/rendez-vous/` |
+| Page 404 | Clic CTA | `<a href>` statique Astro | → `/rendez-vous/` |
+| Page Rendez-vous | Lien interne `/contact/` | `<a href>` statique Astro | → `/rendez-vous/` |
+
+## Slices
+
+**Slice 1 — Navbar :** Retirer "Contact" de `NavigationItems.tsx`. Mettre à jour `isActive` dans `Navbar.tsx` : supprimer le cas spécial `/contact`, ajouter `/rendez-vous` si absent.
+→ `src/components/navigation/NavigationItems.tsx`, `src/components/islands/Navbar.tsx`
+
+**Slice 2 — Pages de service :** Remplacer `href="/contact"` → `href="/rendez-vous/"` dans les 2 occurrences de chaque page (btn-primary + lien inline).
+→ `src/pages/services/therapie-individuelle.astro`, `therapie-de-couple.astro`, `therapie-familiale.astro`, `troubles-alimentaires.astro`
+
+**Slice 3 — Pages éditoriales :** Remplacer les CTAs dans `a-propos.astro`, `blog/[slug].astro`, `rendez-vous.astro`, `contact.astro`, `404.astro`.
+→ 5 fichiers Astro
+
+## Out of Scope
+
+- Suppression de la page `/contact` (reste accessible)
+- Badges psychologue.net dans le footer (`FooterHours.tsx`, `Footer.astro`) — tâche dédiée prévue prochainement
+- `rdv/accepter-report.astro` — liens `/contact/` dans un contexte spécifique de report RDV
+- `accessibilite.astro` — lien `/contact` légitime pour signalement d'accessibilité
+- Liens `mailto:contact@omf-therapie.fr` dans les emails transactionnels
+- `footer.config.ts` — "Contact" en navigation secondaire du footer, conservé
+
+## Open Questions
+
+- Aucune — périmètre validé via frame approuvé.

--- a/src/components/admin/AdminCreateButton.tsx
+++ b/src/components/admin/AdminCreateButton.tsx
@@ -21,7 +21,10 @@ interface FormState {
   patient_phone: string;
   appointment_type: AppointmentType;
   appointment_mode: AppointmentMode;
-  duration: AppointmentDuration;
+  duration: number | 'custom';
+  customDurationMinutes: number;
+  useOverridePrice: boolean;
+  overridePrice: number;
   scheduled_at: string;
   patient_reason: string;
   override_first_session: boolean;
@@ -45,9 +48,10 @@ const APPOINTMENT_MODES: { value: AppointmentMode; label: string }[] = [
   { value: "video", label: "Téléconsultation" },
 ];
 
-const DURATIONS: { value: AppointmentDuration; label: string }[] = [
+const DURATIONS: { value: AppointmentDuration | 'custom'; label: string }[] = [
   { value: 60, label: "60 min" },
   { value: 90, label: "90 min" },
+  { value: 'custom' as const, label: 'Personnalisée…' },
 ];
 
 const INITIAL_STATE: FormState = {
@@ -57,6 +61,9 @@ const INITIAL_STATE: FormState = {
   appointment_type: "individual",
   appointment_mode: "in-person",
   duration: 60,
+  customDurationMinutes: 45,
+  useOverridePrice: false,
+  overridePrice: 0,
   scheduled_at: "",
   patient_reason: "",
   override_first_session: false,
@@ -211,8 +218,14 @@ function AdminCreateModal({ onClose }: { onClose: () => void }) {
   }
 
   const livePrice = useMemo(
-    () => calculatePrice(form.appointment_type, form.duration, form.override_first_session, form.is_solidarity),
-    [form.appointment_type, form.duration, form.override_first_session, form.is_solidarity],
+    () => {
+      if (form.useOverridePrice) {
+        return { finalPrice: form.overridePrice, discount: 0, basePrice: form.overridePrice, label: `${form.overridePrice} € (tarif manuel)` };
+      }
+      const durationForPrice = form.duration === 'custom' ? 60 : form.duration;
+      return calculatePrice(form.appointment_type, durationForPrice, form.override_first_session, form.is_solidarity);
+    },
+    [form.appointment_type, form.duration, form.override_first_session, form.is_solidarity, form.useOverridePrice, form.overridePrice],
   );
 
   async function handleSubmit(e: React.FormEvent) {
@@ -221,18 +234,20 @@ function AdminCreateModal({ onClose }: { onClose: () => void }) {
     setError(null);
 
     try {
+      const durationValue = form.duration === 'custom' ? form.customDurationMinutes : form.duration;
       const payload: Record<string, unknown> = {
         patient_name: form.patient_name.trim(),
         patient_email: form.patient_email.trim(),
         patient_phone: form.patient_phone.trim() || undefined,
         appointment_type: form.appointment_type,
         appointment_mode: form.appointment_mode,
-        duration: form.duration,
+        duration: durationValue,
         scheduled_at: form.scheduled_at,
         patient_reason: form.patient_reason.trim(),
         override_first_session: form.override_first_session,
         is_solidarity: form.is_solidarity,
         send_email: form.send_email,
+        ...(form.useOverridePrice ? { override_price: form.overridePrice } : {}),
       };
 
       if (form.appointment_mode === "video" && form.video_link.trim()) {
@@ -359,13 +374,34 @@ function AdminCreateModal({ onClose }: { onClose: () => void }) {
               <select
                 id="cm-duration"
                 value={form.duration}
-                onChange={e => update("duration", Number(e.target.value) as AppointmentDuration)}
+                onChange={e => {
+                  const val = e.target.value;
+                  const isCustom = val === 'custom';
+                  setForm(f => ({
+                    ...f,
+                    duration: isCustom ? 'custom' : Number(val),
+                    ...(isCustom ? { useOverridePrice: true } : {}),
+                  }));
+                }}
                 className="w-full rounded-xl border border-sage-200 px-3 py-2 text-sm text-sage-900 font-sans focus:border-mint-400 focus:outline-none focus:ring-2 focus:ring-mint-200"
               >
                 {DURATIONS.map(d => (
                   <option key={d.value} value={d.value}>{d.label}</option>
                 ))}
               </select>
+              {form.duration === 'custom' && (
+                <input
+                  type="number"
+                  min={15}
+                  max={240}
+                  step={1}
+                  value={form.customDurationMinutes}
+                  onChange={(e) => setForm(f => ({ ...f, customDurationMinutes: Number(e.target.value) }))}
+                  className="mt-1 w-full rounded border border-sage-200 px-2 py-1 text-sm"
+                  placeholder="Durée en minutes (ex: 45)"
+                  required
+                />
+              )}
             </div>
           </div>
 
@@ -418,11 +454,12 @@ function AdminCreateModal({ onClose }: { onClose: () => void }) {
                 <input
                   type="checkbox"
                   checked={form.override_first_session && !form.is_solidarity}
+                  disabled={form.useOverridePrice}
                   onChange={e => {
                     if (e.target.checked) { update("override_first_session", true); update("is_solidarity", false); }
                     else update("override_first_session", false);
                   }}
-                  className="h-4 w-4 rounded border-sage-300 text-mint-600 focus:ring-mint-400"
+                  className="h-4 w-4 rounded border-sage-300 text-mint-600 focus:ring-mint-400 disabled:opacity-40"
                 />
                 <span className="text-sm text-sage-700 font-sans group-hover:text-sage-900">
                   Remise nouveau client{" "}
@@ -433,17 +470,39 @@ function AdminCreateModal({ onClose }: { onClose: () => void }) {
                 <input
                   type="checkbox"
                   checked={form.is_solidarity}
+                  disabled={form.useOverridePrice}
                   onChange={e => {
                     if (e.target.checked) { update("is_solidarity", true); update("override_first_session", false); }
                     else update("is_solidarity", false);
                   }}
-                  className="h-4 w-4 rounded border-sage-300 text-mint-600 focus:ring-mint-400"
+                  className="h-4 w-4 rounded border-sage-300 text-mint-600 focus:ring-mint-400 disabled:opacity-40"
                 />
                 <span className="text-sm text-sage-700 font-sans group-hover:text-sage-900">
                   Tarif solidaire{" "}
                   <span className="text-sage-400">(−{SOLIDARITY_DISCOUNT}€ · RSA / ASS / Étudiant)</span>
                 </span>
               </label>
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={form.useOverridePrice}
+                  onChange={(e) => setForm(f => ({ ...f, useOverridePrice: e.target.checked }))}
+                  className="h-4 w-4 rounded border-sage-300 text-mint-600 focus:ring-mint-400"
+                />
+                Tarif manuel
+              </label>
+              {form.useOverridePrice && (
+                <input
+                  type="number"
+                  min={0}
+                  step={1}
+                  value={form.overridePrice}
+                  onChange={(e) => setForm(f => ({ ...f, overridePrice: Number(e.target.value) }))}
+                  className="mt-1 w-full rounded border border-sage-200 px-2 py-1 text-sm"
+                  placeholder="Tarif en € (ex: 45)"
+                  required
+                />
+              )}
             </div>
             <div className="mt-3 flex items-center justify-between border-t border-sage-200 pt-3">
               <span className="text-xs text-sage-500 font-sans">

--- a/src/components/admin/AppointmentCard.tsx
+++ b/src/components/admin/AppointmentCard.tsx
@@ -9,7 +9,7 @@
  *   declined / cancelled  → lecture seule
  */
 
-import { useState, useMemo, useRef, useEffect, useCallback } from "react";
+import { useState, useMemo, useRef, useEffect } from "react";
 import type { Appointment, AppointmentStatus } from "../../types/appointment";
 import { getTypeLabel, getModeLabel, calculatePrice, SOLIDARITY_DISCOUNT } from "../../lib/pricing";
 

--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -48,7 +48,7 @@ export const HeroSection = () => {
             >
               <li role="listitem">
                 <a
-                  href="/contact"
+                  href="/rendez-vous/"
                   className="btn-primary"
                   aria-label="Prendre rendez-vous"
                 >

--- a/src/components/islands/Navbar.tsx
+++ b/src/components/islands/Navbar.tsx
@@ -111,7 +111,7 @@ const Navbar = memo(({ className = "", isHomePage: isHomePageProp, isAuthenticat
       if (typeof window === "undefined") return false;
       const pathname = normalizePathname(window.location.pathname);
       const normalizedPath = normalizePathname(path);
-      if (normalizedPath === "/contact") return pathname === "/contact";
+      if (normalizedPath === "/rendez-vous") return pathname === "/rendez-vous";
       if (normalizedPath === "/blog") return pathname.startsWith("/blog");
       return pathname === "/" && activeSection === href.substring(1);
     },

--- a/src/components/navigation/NavigationItems.tsx
+++ b/src/components/navigation/NavigationItems.tsx
@@ -10,7 +10,6 @@ export const useNavigationItems = () => {
       { name: "Tarifs", href: "#pricing", path: "/" },
       { name: "Blog", href: "/blog/", path: "/blog/", page: true },
       { name: "Prendre rendez-vous", href: "/rendez-vous/", path: "/rendez-vous/", page: true },
-      { name: "Contact", href: "/contact/", path: "/contact/", page: true },
     ],
     []
   );

--- a/src/components/navigation/NavigationItems.tsx
+++ b/src/components/navigation/NavigationItems.tsx
@@ -9,6 +9,7 @@ export const useNavigationItems = () => {
       { name: "Domaines d'Expertise", href: "/services/", path: "/services/", page: true },
       { name: "Tarifs", href: "#pricing", path: "/" },
       { name: "Blog", href: "/blog/", path: "/blog/", page: true },
+      { name: "Prendre rendez-vous", href: "/rendez-vous/", path: "/rendez-vous/", page: true },
       { name: "Contact", href: "/contact/", path: "/contact/", page: true },
     ],
     []

--- a/src/components/pricing/CTASection.tsx
+++ b/src/components/pricing/CTASection.tsx
@@ -17,9 +17,7 @@ export const CTASection = () => {
         mieux-être.
       </p>
       <a
-        href="https://www.psychologue.net/cabinets/oriane-montabonnet"
-        target="_blank"
-        rel="noopener noreferrer"
+        href="/rendez-vous/"
         className="btn-primary"
         aria-label="Réserver une consultation"
       >

--- a/src/config/footer.config.ts
+++ b/src/config/footer.config.ts
@@ -8,8 +8,7 @@ export const QUICK_LINKS: FooterLink[] = [
   { name: "Contact", href: "/contact", path: "/contact" },
   {
     name: "Prendre rendez-vous",
-    href: "https://www.psychologue.net/cabinets/oriane-montabonnet",
-    external: true,
-    path: "/",
+    href: "/rendez-vous",
+    path: "/rendez-vous",
   },
 ];

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;500;600;700&family=Inter:wght@300;400;500;600;700&display=swap");
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -28,4 +26,3 @@
     @apply text-xl text-sage-600 mb-12 max-w-2xl mx-auto;
   }
 }
-

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -60,7 +60,7 @@ const jsonLdArray = jsonLd ? (Array.isArray(jsonLd) ? jsonLd : [jsonLd]) : [];
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
 
     <!-- Favicon -->
     <link rel="icon" href="/assets/favicon.ico" sizes="32x32" />

--- a/src/lib/appointment-conflicts.ts
+++ b/src/lib/appointment-conflicts.ts
@@ -1,0 +1,78 @@
+import { supabaseAdmin } from './supabase';
+
+const BLOCKING_STATUSES = [
+  'pending',
+  'confirmed',
+  'payment_pending',
+  'payment_received',
+  'rescheduled',
+] as const;
+
+const MAX_APPOINTMENT_DURATION_MINUTES = 90;
+
+interface ConflictCheckInput {
+  slotStartIso: string;
+  slotEndIso: string;
+  excludeAppointmentId?: string;
+}
+
+function overlaps(startA: number, endA: number, startB: number, endB: number): boolean {
+  return startA < endB && endA > startB;
+}
+
+export async function hasAppointmentConflict({
+  slotStartIso,
+  slotEndIso,
+  excludeAppointmentId,
+}: ConflictCheckInput): Promise<boolean> {
+  const baseConflictQuery = supabaseAdmin
+    .from('appointments')
+    .select('id')
+    .in('status', BLOCKING_STATUSES)
+    .is('deleted_at', null)
+    .lt('scheduled_at', slotEndIso)
+    .gt('scheduled_end', slotStartIso)
+    .limit(1);
+
+  const { data: directConflicts, error: directError } = excludeAppointmentId
+    ? await baseConflictQuery.neq('id', excludeAppointmentId)
+    : await baseConflictQuery;
+
+  if (directError) {
+    throw directError;
+  }
+
+  if ((directConflicts ?? []).length > 0) {
+    return true;
+  }
+
+  const slotStart = new Date(slotStartIso).getTime();
+  const slotEnd = new Date(slotEndIso).getTime();
+  const rescheduledLookback = new Date(
+    slotStart - MAX_APPOINTMENT_DURATION_MINUTES * 60 * 1000,
+  ).toISOString();
+
+  const baseRescheduledQuery = supabaseAdmin
+    .from('appointments')
+    .select('id, duration, rescheduled_to')
+    .eq('status', 'rescheduled')
+    .is('deleted_at', null)
+    .not('rescheduled_to', 'is', null)
+    .gte('rescheduled_to', rescheduledLookback)
+    .lt('rescheduled_to', slotEndIso);
+
+  const { data: rescheduledRows, error: rescheduledError } = excludeAppointmentId
+    ? await baseRescheduledQuery.neq('id', excludeAppointmentId)
+    : await baseRescheduledQuery;
+
+  if (rescheduledError) {
+    throw rescheduledError;
+  }
+
+  return (rescheduledRows ?? []).some((row) => {
+    if (typeof row.rescheduled_to !== 'string') return false;
+    const start = new Date(row.rescheduled_to).getTime();
+    const end = start + Number(row.duration) * 60 * 1000;
+    return overlaps(slotStart, slotEnd, start, end);
+  });
+}

--- a/src/lib/calendar-cache.ts
+++ b/src/lib/calendar-cache.ts
@@ -1,0 +1,127 @@
+/**
+ * Availability cache using @netlify/blobs.
+ *
+ * Gracefully degrades to a no-op when the Netlify Blobs context is unavailable
+ * (e.g., plain `astro dev` without `netlify dev`, or GOOGLE_CALENDAR_MOCK=true).
+ *
+ * Cache TTL is enforced via metadata.expiresAt rather than Blobs native TTL
+ * to maintain compatibility across Netlify Blobs versions.
+ */
+
+import type { TimeSlot } from './google-calendar.js';
+
+const MOCK_MODE = import.meta.env.GOOGLE_CALENDAR_MOCK === 'true';
+const STORE_NAME = 'calendar-availability';
+const DEFAULT_TTL_SECONDS = 600; // 10 minutes
+
+// ---------------------------------------------------------------------------
+// Singleton store promise — initialised once, reused across requests
+// ---------------------------------------------------------------------------
+
+let _storePromise: Promise<ReturnType<typeof import('@netlify/blobs')['getStore']> | null> | null =
+  null;
+
+async function getAvailabilityStore(): Promise<ReturnType<
+  typeof import('@netlify/blobs')['getStore']
+> | null> {
+  if (MOCK_MODE) return null;
+  if (_storePromise) return _storePromise;
+  _storePromise = import('@netlify/blobs')
+    .then(({ getStore }) => getStore(STORE_NAME))
+    .catch(() => null);
+  return _storePromise;
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface CacheEntry {
+  slots: TimeSlot[];
+  expiresAt: number;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export async function getCachedAvailability(key: string): Promise<TimeSlot[] | null> {
+  const store = await getAvailabilityStore();
+  if (!store) return null;
+  try {
+    const raw = (await store.get(key, { type: 'json' })) as CacheEntry | null;
+    if (!raw) return null;
+    if (Date.now() > raw.expiresAt) {
+      store.delete(key).catch(() => {});
+      return null;
+    }
+    return raw.slots;
+  } catch {
+    return null;
+  }
+}
+
+export async function setCachedAvailability(
+  key: string,
+  slots: TimeSlot[],
+  ttlSeconds = DEFAULT_TTL_SECONDS,
+): Promise<void> {
+  const store = await getAvailabilityStore();
+  if (!store) return;
+  try {
+    const entry: CacheEntry = { slots, expiresAt: Date.now() + ttlSeconds * 1000 };
+    await store.setJSON(key, entry);
+  } catch {
+    // Cache write failure is non-fatal
+  }
+}
+
+export async function invalidateAvailabilityCache(): Promise<void> {
+  const store = await getAvailabilityStore();
+  if (!store) return;
+  try {
+    const { blobs } = await store.list();
+    await Promise.allSettled(blobs.map((b: { key: string }) => store.delete(b.key)));
+  } catch {
+    // Non-fatal — worst case: stale data served until TTL expires
+  }
+}
+
+/**
+ * Builds a stable cache key from request parameters.
+ * Key is scoped to the week (Paris timezone Monday date) so it never
+ * includes raw timestamps that would cause every request to miss.
+ */
+export function buildAvailabilityCacheKey(
+  mode: string,
+  duration: number,
+  weeks: number,
+  fromDate: Date,
+): string {
+  // Get Monday of the week containing fromDate in Paris timezone
+  const parisDayStr = fromDate.toLocaleDateString('fr-FR', {
+    timeZone: 'Europe/Paris',
+    weekday: 'short',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+  // Parse day-of-week offset (fr-FR abbreviated weekdays: dim, lun, mar, mer, jeu, ven, sam)
+  const weekdayMap: Record<string, number> = {
+    dim: 0,
+    lun: 1,
+    mar: 2,
+    mer: 3,
+    jeu: 4,
+    ven: 5,
+    sam: 6,
+  };
+  const parts = parisDayStr.split(' ');
+  const dayAbbr = parts[0].replace('.', '').toLowerCase();
+  const dayOfWeek = weekdayMap[dayAbbr] ?? 1;
+  const daysToMonday = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
+  const monday = new Date(fromDate);
+  monday.setDate(monday.getDate() + daysToMonday);
+  const weekStart = monday.toISOString().slice(0, 10);
+  return `available:${mode}:${duration}:${weeks}w:${weekStart}`;
+}

--- a/src/lib/google-calendar.ts
+++ b/src/lib/google-calendar.ts
@@ -202,12 +202,17 @@ async function getPersistedOAuthClient(): Promise<Auth.OAuth2Client | null> {
     } catch (err: unknown) {
       const errData = (err as { response?: { data?: { error?: string } } })?.response?.data;
       if (errData?.error === 'invalid_grant') {
+        // Store only the safe error code — do NOT pass raw err (GaxiosError may
+        // carry client_secret / refresh_token in response.config.data)
         throw new CalendarAuthError(
           'OAuth consent revoked — re-authorize via Google Cloud Console',
-          err,
+          { googleErrorCode: errData.error },
         );
       }
-      throw new CalendarNetworkError('Token refresh failed', err);
+      throw new CalendarNetworkError(
+        'Token refresh failed',
+        { message: err instanceof Error ? err.message : String(err) },
+      );
     }
   }
 

--- a/src/lib/google-calendar.ts
+++ b/src/lib/google-calendar.ts
@@ -6,6 +6,81 @@
  */
 
 import { google, type Auth, type calendar_v3 } from 'googleapis';
+import { supabaseAdmin } from './supabase.js';
+
+// ---------------------------------------------------------------------------
+// Erreur typée
+// ---------------------------------------------------------------------------
+
+export class GoogleCalendarError extends Error {
+  public readonly cause: unknown;
+
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = 'GoogleCalendarError';
+    this.cause = cause;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Typed subclasses
+// ---------------------------------------------------------------------------
+
+export class CalendarAuthError extends GoogleCalendarError {
+  readonly type = 'CalendarAuthError' as const;
+  constructor(message: string, cause?: unknown) { super(message, cause); this.name = 'CalendarAuthError'; }
+}
+
+export class CalendarPermissionError extends GoogleCalendarError {
+  readonly type = 'CalendarPermissionError' as const;
+  constructor(message: string, cause?: unknown) { super(message, cause); this.name = 'CalendarPermissionError'; }
+}
+
+export class CalendarQuotaError extends GoogleCalendarError {
+  readonly type = 'CalendarQuotaError' as const;
+  constructor(message: string, cause?: unknown) { super(message, cause); this.name = 'CalendarQuotaError'; }
+}
+
+export class CalendarNetworkError extends GoogleCalendarError {
+  readonly type = 'CalendarNetworkError' as const;
+  constructor(message: string, cause?: unknown) { super(message, cause); this.name = 'CalendarNetworkError'; }
+}
+
+// ---------------------------------------------------------------------------
+// Error parser + retry helper
+// ---------------------------------------------------------------------------
+
+function parseGoogleError(err: unknown): GoogleCalendarError {
+  const asRecord = typeof err === 'object' && err !== null ? (err as Record<string, unknown>) : null;
+  const responseStatus = asRecord?.['response'] != null
+    ? (asRecord['response'] as Record<string, unknown>)['status']
+    : undefined;
+  const status = responseStatus ?? asRecord?.['code'];
+  if (status === 401) return new CalendarAuthError('Authentication failed', err);
+  if (status === 403) return new CalendarPermissionError('Calendar access denied', err);
+  if (status === 429) return new CalendarQuotaError('Google API quota exceeded', err);
+  return new CalendarNetworkError('Calendar API error', err);
+}
+
+export async function withCalendarRetry<T>(fn: () => Promise<T>, maxAttempts = 3): Promise<T> {
+  let lastError: GoogleCalendarError = new CalendarNetworkError('Unknown error');
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      const parsed = parseGoogleError(err);
+      lastError = parsed;
+      // No retry for auth/permission errors
+      if (parsed instanceof CalendarAuthError || parsed instanceof CalendarPermissionError) {
+        throw parsed;
+      }
+      if (attempt < maxAttempts) {
+        await new Promise(resolve => setTimeout(resolve, 1000 * Math.pow(2, attempt - 1)));
+      }
+    }
+  }
+  throw lastError;
+}
 
 // ---------------------------------------------------------------------------
 // Types publics
@@ -69,29 +144,90 @@ function buildServiceAccountClient(): Auth.JWT | null {
   });
 }
 
-function buildOAuthClient(): Auth.OAuth2Client | null {
+
+/**
+ * Returns a configured OAuth2Client with a valid access token, persisting
+ * token rotation in the `google_oauth_tokens` Supabase table.
+ * Falls back to bootstrapping from env vars on first run.
+ */
+async function getPersistedOAuthClient(): Promise<Auth.OAuth2Client | null> {
   const clientId = import.meta.env.GOOGLE_OAUTH_CLIENT_ID;
   const clientSecret = import.meta.env.GOOGLE_OAUTH_CLIENT_SECRET;
-  const refreshToken = import.meta.env.GOOGLE_OAUTH_REFRESH_TOKEN;
-
-  if (!clientId || !clientSecret || !refreshToken) {
-    return null;
-  }
+  if (!clientId || !clientSecret) return null;
 
   const redirectUri = import.meta.env.GOOGLE_OAUTH_REDIRECT_URI ?? 'https://developers.google.com/oauthplayground';
-  const client = new google.auth.OAuth2(clientId, clientSecret, redirectUri);
-  client.setCredentials({ refresh_token: refreshToken });
-  return client;
+  const oauth2Client = new google.auth.OAuth2(clientId, clientSecret, redirectUri);
+
+  // 1. Load persisted tokens from DB
+  let { data: tokens } = await supabaseAdmin
+    .from('google_oauth_tokens')
+    .select('*')
+    .eq('id', 'therapist')
+    .single();
+
+  if (!tokens) {
+    // 2. Bootstrap from env vars on first run
+    const refreshToken = import.meta.env.GOOGLE_OAUTH_REFRESH_TOKEN;
+    if (!refreshToken) return null;
+
+    tokens = {
+      id: 'therapist',
+      access_token: '',
+      refresh_token: refreshToken,
+      expiry_date: 0, // Forces immediate refresh below
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    };
+    await supabaseAdmin.from('google_oauth_tokens').upsert(tokens);
+  }
+
+  // 3. Proactive refresh: refresh if token expires within 5 minutes
+  if (!tokens.expiry_date || tokens.expiry_date < Date.now() + 5 * 60 * 1000) {
+    oauth2Client.setCredentials({ refresh_token: tokens.refresh_token });
+    try {
+      const { credentials } = await oauth2Client.refreshAccessToken();
+      const updated = {
+        access_token: credentials.access_token ?? '',
+        // Persist rotated refresh_token if Google returns one (token rotation policy)
+        refresh_token: credentials.refresh_token ?? tokens.refresh_token,
+        expiry_date: credentials.expiry_date ?? (Date.now() + 3600 * 1000),
+        updated_at: new Date().toISOString(),
+      };
+      await supabaseAdmin
+        .from('google_oauth_tokens')
+        .update(updated)
+        .eq('id', 'therapist');
+      oauth2Client.setCredentials(credentials);
+      return oauth2Client;
+    } catch (err: unknown) {
+      const errData = (err as { response?: { data?: { error?: string } } })?.response?.data;
+      if (errData?.error === 'invalid_grant') {
+        throw new CalendarAuthError(
+          'OAuth consent revoked — re-authorize via Google Cloud Console',
+          err,
+        );
+      }
+      throw new CalendarNetworkError('Token refresh failed', err);
+    }
+  }
+
+  // 4. Token is still valid — use as-is
+  oauth2Client.setCredentials({
+    access_token: tokens.access_token,
+    refresh_token: tokens.refresh_token,
+    expiry_date: tokens.expiry_date,
+  });
+  return oauth2Client;
 }
 
-function resolveCalendarAuth(): Auth.OAuth2Client | Auth.JWT {
-  const oauth = buildOAuthClient();
+async function resolveCalendarAuth(): Promise<Auth.OAuth2Client | Auth.JWT> {
+  const oauth = await getPersistedOAuthClient();
   if (oauth) return oauth;
 
   const serviceAccount = buildServiceAccountClient();
   if (serviceAccount) return serviceAccount;
 
-  throw new Error(
+  throw new GoogleCalendarError(
     'Configuration Google Calendar manquante : configurez OAuth (GOOGLE_OAUTH_CLIENT_ID/SECRET/REFRESH_TOKEN) ou Service Account (GOOGLE_SERVICE_ACCOUNT_EMAIL/GOOGLE_PRIVATE_KEY).',
   );
 }
@@ -350,7 +486,7 @@ export async function getAvailableSlots(
     return [];
   }
 
-  const auth = resolveCalendarAuth();
+  const auth = await resolveCalendarAuth();
   const calendar = google.calendar({ version: 'v3', auth });
 
   // Une seule requête Freebusy pour toute la plage
@@ -473,7 +609,7 @@ async function pollMeetLink(
   calendarId: string,
   eventId: string,
 ): Promise<string | undefined> {
-  const maxAttempts = 10;
+  const maxAttempts = 3;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     await wait(1500);
     const response = await calendar.events.get({
@@ -485,6 +621,61 @@ async function pollMeetLink(
     if (result.meetLink) return result.meetLink;
   }
   return undefined;
+}
+
+/**
+ * Updates an existing Google Calendar event (e.g., on reschedule acceptance).
+ * Only moves the event once the patient accepts — not on proposal.
+ */
+export async function updateCalendarEvent(
+  eventId: string,
+  patch: { start?: Date; end?: Date; summary?: string },
+): Promise<void> {
+  if (MOCK_MODE) {
+    console.log(`[calendar-mock] Updating event ${eventId}:`, patch);
+    return;
+  }
+
+  const calendarId = import.meta.env.GOOGLE_CALENDAR_ID;
+  if (!calendarId) throw new GoogleCalendarError('GOOGLE_CALENDAR_ID non défini.');
+
+  await withCalendarRetry(async () => {
+    const auth = await resolveCalendarAuth();
+    const calendar = google.calendar({ version: 'v3', auth });
+    const body: calendar_v3.Schema$Event = {};
+    if (patch.start) body.start = { dateTime: patch.start.toISOString(), timeZone: TIMEZONE };
+    if (patch.end) body.end = { dateTime: patch.end.toISOString(), timeZone: TIMEZONE };
+    if (patch.summary) body.summary = patch.summary;
+    await calendar.events.patch({
+      calendarId,
+      eventId,
+      requestBody: body,
+      sendUpdates: 'all',
+    });
+  });
+}
+
+/**
+ * Deletes a Google Calendar event (e.g., on decline or cancellation).
+ */
+export async function deleteCalendarEvent(eventId: string): Promise<void> {
+  if (MOCK_MODE) {
+    console.log(`[calendar-mock] Deleting event ${eventId}`);
+    return;
+  }
+
+  const calendarId = import.meta.env.GOOGLE_CALENDAR_ID;
+  if (!calendarId) throw new GoogleCalendarError('GOOGLE_CALENDAR_ID non défini.');
+
+  await withCalendarRetry(async () => {
+    const auth = await resolveCalendarAuth();
+    const calendar = google.calendar({ version: 'v3', auth });
+    await calendar.events.delete({
+      calendarId,
+      eventId,
+      sendUpdates: 'all',
+    });
+  });
 }
 
 /**
@@ -571,7 +762,7 @@ export async function createCalendarEvent(
 
   // Priorité OAuth utilisateur (3-legged) pour les liens Meet sur comptes perso.
   if (params.withMeet) {
-    const oauthAuth = buildOAuthClient();
+    const oauthAuth = await getPersistedOAuthClient();
     if (oauthAuth) {
       const oauthCalendar = google.calendar({ version: 'v3', auth: oauthAuth });
       try {
@@ -634,19 +825,5 @@ export async function createCalendarEvent(
       'Impossible de créer le rendez-vous dans l\'agenda.',
       err,
     );
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Erreur typée
-// ---------------------------------------------------------------------------
-
-export class GoogleCalendarError extends Error {
-  public readonly cause: unknown;
-
-  constructor(message: string, cause?: unknown) {
-    super(message);
-    this.name = 'GoogleCalendarError';
-    this.cause = cause;
   }
 }

--- a/src/lib/google-calendar.ts
+++ b/src/lib/google-calendar.ts
@@ -1,5 +1,5 @@
 /**
- * Google Calendar API wrapper (OAuth utilisateur ou service account)
+ * Google Calendar API wrapper (OAuth utilisateur)
  *
  * Gère la génération des créneaux candidats et la vérification
  * de disponibilité via l'API Freebusy de Google Calendar.
@@ -123,27 +123,6 @@ const MIN_NOTICE_MS = 24 * 60 * 60 * 1000;
 // Authentification Google
 // ---------------------------------------------------------------------------
 
-function buildServiceAccountClient(): Auth.JWT | null {
-  const email = import.meta.env.GOOGLE_SERVICE_ACCOUNT_EMAIL;
-  const rawKey = import.meta.env.GOOGLE_PRIVATE_KEY;
-
-  if (!email || !rawKey) {
-    return null;
-  }
-
-  // Les clés privées sont souvent stockées avec des "\n" littéraux
-  const privateKey = rawKey.replace(/\\n/g, '\n');
-
-  return new google.auth.JWT({
-    email,
-    key: privateKey,
-    scopes: [
-      'https://www.googleapis.com/auth/calendar.events',
-      'https://www.googleapis.com/auth/calendar.readonly',
-    ],
-  });
-}
-
 
 /**
  * Returns a configured OAuth2Client with a valid access token, persisting
@@ -225,15 +204,12 @@ async function getPersistedOAuthClient(): Promise<Auth.OAuth2Client | null> {
   return oauth2Client;
 }
 
-async function resolveCalendarAuth(): Promise<Auth.OAuth2Client | Auth.JWT> {
+async function resolveCalendarAuth(): Promise<Auth.OAuth2Client> {
   const oauth = await getPersistedOAuthClient();
   if (oauth) return oauth;
 
-  const serviceAccount = buildServiceAccountClient();
-  if (serviceAccount) return serviceAccount;
-
   throw new GoogleCalendarError(
-    'Configuration Google Calendar manquante : configurez OAuth (GOOGLE_OAUTH_CLIENT_ID/SECRET/REFRESH_TOKEN) ou Service Account (GOOGLE_SERVICE_ACCOUNT_EMAIL/GOOGLE_PRIVATE_KEY).',
+    'Configuration Google Calendar manquante : configurez OAuth (GOOGLE_OAUTH_CLIENT_ID/SECRET/REFRESH_TOKEN).',
   );
 }
 
@@ -576,12 +552,6 @@ export interface CreateEventResult {
   meetLink?: string;
 }
 
-function isAttendeeDelegationError(err: unknown): boolean {
-  if (!(err instanceof Error)) return false;
-  const msg = err.message.toLowerCase();
-  return msg.includes('service accounts cannot invite attendees') ||
-    msg.includes('domain-wide delegation');
-}
 
 function extractEventResult(data: { id?: string | null; conferenceData?: { entryPoints?: Array<{ uri?: string } | null> | null } | null; hangoutLink?: string | null }): CreateEventResult {
   const eventId = data.id;
@@ -765,65 +735,24 @@ export async function createCalendarEvent(
     };
   };
 
-  // Priorité OAuth utilisateur (3-legged) pour les liens Meet sur comptes perso.
-  if (params.withMeet) {
-    const oauthAuth = await getPersistedOAuthClient();
-    if (oauthAuth) {
-      const oauthCalendar = google.calendar({ version: 'v3', auth: oauthAuth });
-      try {
-        return await upsertEvent(
-          oauthCalendar,
-          params.attendeeEmail ? 'all' : 'none',
-          true,
-          Boolean(params.attendeeEmail),
-        );
-      } catch (oauthErr: unknown) {
-        const oauthMessage = oauthErr instanceof Error ? oauthErr.message : String(oauthErr);
-        console.warn('[google-calendar] Échec création Meet via OAuth utilisateur, fallback service account:', oauthMessage);
-      }
-    } else {
-      console.warn('[google-calendar] OAuth utilisateur non configuré pour la génération Meet, fallback service account.');
-    }
+  // Use OAuth for all event types (Meet and in-person).
+  const oauthAuth = await getPersistedOAuthClient();
+  if (!oauthAuth) {
+    throw new GoogleCalendarError(
+      'OAuth non configuré : impossible de créer le rendez-vous dans l\'agenda.',
+    );
   }
 
-  const serviceAccountAuth = buildServiceAccountClient();
-  const calendar = serviceAccountAuth
-    ? google.calendar({ version: 'v3', auth: serviceAccountAuth })
-    : null;
-
+  const oauthCalendar = google.calendar({ version: 'v3', auth: oauthAuth });
   try {
-    if (!calendar) {
-      throw new GoogleCalendarError(
-        'Aucun fallback Service Account configuré après échec OAuth.',
-      );
-    }
     return await upsertEvent(
-      calendar,
+      oauthCalendar,
       params.attendeeEmail ? 'all' : 'none',
-      false,
+      Boolean(params.withMeet),
       Boolean(params.attendeeEmail),
     );
   } catch (err: unknown) {
     if (err instanceof GoogleCalendarError) throw err;
-    if (params.attendeeEmail && isAttendeeDelegationError(err)) {
-      console.warn('[google-calendar] Attendee non autorisé pour service account. Retry sans invité.');
-      try {
-        return await upsertEvent(
-          calendar,
-          'none',
-          false,
-          false,
-        );
-      } catch (retryErr: unknown) {
-        const retryMessage = retryErr instanceof Error ? retryErr.message : String(retryErr);
-        console.error('[google-calendar] Échec retry sans invité :', retryMessage);
-        throw new GoogleCalendarError(
-          'Impossible de créer le rendez-vous dans l\'agenda.',
-          retryErr,
-        );
-      }
-    }
-
     const message = err instanceof Error ? err.message : String(err);
     console.error('[google-calendar] Impossible de créer l\'événement :', message);
     throw new GoogleCalendarError(

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -4,7 +4,10 @@
  */
 
 export type AppointmentType = 'individual' | 'couple' | 'family';
+/** Standard durations used by the patient booking flow — do not extend. */
 export type AppointmentDuration = 60 | 90;
+/** Any positive integer duration in minutes — used by the admin flow only. */
+export type AdminDuration = number;
 export type AppointmentMode = 'in-person' | 'video';
 
 export interface PricingResult {
@@ -43,19 +46,35 @@ export const SOLIDARITY_DISCOUNT = 10;
  * Calcule le tarif d'une séance.
  *
  * Les remises sont mutuellement exclusives : `isSolidarity` est prioritaire.
+ * Si `overridePrice` est fourni (flux admin), il court-circuite la grille tarifaire :
+ * aucune remise n'est appliquée et le prix final est exactement `overridePrice`.
  *
  * @param type           - Type de thérapie
- * @param duration       - Durée en minutes (60 ou 90)
+ * @param duration       - Durée en minutes (60 ou 90 pour le flux patient)
  * @param isFirstSession - Appliquer la réduction première séance (−15€)
  * @param isSolidarity   - Appliquer le tarif solidaire (−10€, RSA/ASS/Étudiant)
+ * @param overridePrice  - Tarif manuel en euros (admin uniquement) — ignore la grille
  */
 export function calculatePrice(
   type: AppointmentType,
-  duration: AppointmentDuration,
+  duration: number,
   isFirstSession: boolean,
   isSolidarity = false,
+  overridePrice?: number,
 ): PricingResult {
-  const basePrice = PRICE_GRID[type][duration];
+  if (overridePrice !== undefined) {
+    return {
+      basePrice: overridePrice,
+      discount: 0,
+      finalPrice: overridePrice,
+      label: `${overridePrice}€ (tarif manuel)`,
+    };
+  }
+
+  const basePrice = PRICE_GRID[type]?.[duration as AppointmentDuration];
+  if (basePrice === undefined) {
+    throw new Error(`Durée ${duration} min non couverte par la grille tarifaire — utiliser overridePrice`);
+  }
   const discount = isSolidarity
     ? SOLIDARITY_DISCOUNT
     : isFirstSession ? FIRST_SESSION_DISCOUNT : 0;

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -28,7 +28,7 @@ import Footer from '../components/layout/Footer.astro';
           Retour à l'accueil
         </a>
         <a
-          href="/contact"
+          href="/rendez-vous/"
           class="inline-flex items-center justify-center gap-2 border border-sage-300 text-sage-700 px-6 py-3 rounded-lg hover:bg-sage-50 transition-colors font-medium"
         >
           Nous contacter

--- a/src/pages/a-propos.astro
+++ b/src/pages/a-propos.astro
@@ -112,7 +112,7 @@ const jsonLd = buildPersonSchema();
           <h2 class="font-serif text-2xl text-sage-800 mb-4">Mon Cabinet à Montpellier</h2>
           <p class="text-sage-600 leading-relaxed">Mon cabinet est situé au <strong>1086 Avenue Albert Einstein, 34000 Montpellier</strong>, facilement accessible depuis Castelnau-le-Lez, Lattes, Pérols et les communes voisines. Je reçois en consultation du lundi au vendredi, de 8h à 12h et de 14h à 19h.</p>
           <div class="mt-6">
-            <a href="/contact" class="inline-block bg-mint-600 text-white px-6 py-3 rounded-lg hover:bg-mint-700 transition-colors font-medium">
+            <a href="/rendez-vous/" class="inline-block bg-mint-600 text-white px-6 py-3 rounded-lg hover:bg-mint-700 transition-colors font-medium">
               Prendre rendez-vous
             </a>
           </div>

--- a/src/pages/api/admin/appointments/index.ts
+++ b/src/pages/api/admin/appointments/index.ts
@@ -280,7 +280,14 @@ export const POST: APIRoute = async ({ request }) => {
     }
   }
 
-  return new Response(JSON.stringify({ appointment }), {
+  // Refetch to include any calendar event ID set after the initial insert
+  const { data: finalAppointment } = await supabaseAdmin
+    .from('appointments')
+    .select('*')
+    .eq('id', appointment.id)
+    .single();
+
+  return new Response(JSON.stringify({ appointment: finalAppointment ?? appointment }), {
     status: 201,
     headers: { 'Content-Type': 'application/json' },
   });

--- a/src/pages/api/admin/appointments/index.ts
+++ b/src/pages/api/admin/appointments/index.ts
@@ -14,6 +14,7 @@ import { createCalendarEvent } from '../../../../lib/google-calendar';
 import AppointmentConfirmed from '../../../../emails/AppointmentConfirmed';
 import PaymentRequest from '../../../../emails/PaymentRequest';
 import type { AppointmentType, AppointmentDuration } from '../../../../types/appointment';
+import { invalidateAvailabilityCache } from '../../../../lib/calendar-cache.js';
 
 // ---------------------------------------------------------------------------
 // Validation helpers
@@ -152,11 +153,13 @@ export const POST: APIRoute = async ({ request }) => {
     return errorResponse(500, 'Erreur lors de la création du rendez-vous');
   }
 
-  if (!isVideo) {
+  await invalidateAvailabilityCache().catch(console.error);
+
+  if (!isVideo && !appointment.google_calendar_event_id) {
     try {
       const start = new Date(appointment.scheduled_at);
       const end = new Date(start.getTime() + appointment.duration * 60 * 1000);
-      await createCalendarEvent({
+      const calResult = await createCalendarEvent({
         title: `${appointment.patient_name} — séance présentielle (${appointment.duration} min)`,
         start: start.toISOString(),
         end: end.toISOString(),
@@ -172,6 +175,10 @@ export const POST: APIRoute = async ({ request }) => {
         appointmentId: `${appointment.id}-admin-inperson`,
         colorId: '2',
       });
+      await supabaseAdmin
+        .from('appointments')
+        .update({ google_calendar_event_id: calResult.eventId })
+        .eq('id', appointment.id);
     } catch (calendarErr) {
       console.error('[admin/appointments] Erreur création événement agenda (présentiel):', calendarErr);
     }

--- a/src/pages/api/admin/appointments/index.ts
+++ b/src/pages/api/admin/appointments/index.ts
@@ -14,7 +14,7 @@ import { createCalendarEvent } from '../../../../lib/google-calendar';
 import { hasAppointmentConflict } from '../../../../lib/appointment-conflicts';
 import AppointmentConfirmed from '../../../../emails/AppointmentConfirmed';
 import PaymentRequest from '../../../../emails/PaymentRequest';
-import type { AppointmentType, AppointmentDuration } from '../../../../types/appointment';
+import type { AppointmentType } from '../../../../types/appointment';
 import { invalidateAvailabilityCache } from '../../../../lib/calendar-cache.js';
 import { isWednesdayParis, isWithinBusinessHours } from '../../../../utils/date';
 
@@ -27,7 +27,6 @@ const PHONE_RE = /^(?:\+33|0033|0)[1-9](?:[0-9]{8})$/;
 
 const VALID_TYPES = new Set<string>(['individual', 'couple', 'family']);
 const VALID_MODES = new Set<string>(['in-person', 'video']);
-const VALID_DURATIONS = new Set<number>([60, 90]);
 
 function errorResponse(status: number, message: string, field?: string): Response {
   return new Response(JSON.stringify({ error: message, field }), {
@@ -71,6 +70,7 @@ export const POST: APIRoute = async ({ request }) => {
     is_solidarity,
     send_email: shouldSendEmail = true,
     video_link,
+    override_price,
   } = body;
 
   // 3. Validation
@@ -89,14 +89,33 @@ export const POST: APIRoute = async ({ request }) => {
   if (!appointment_mode || !VALID_MODES.has(appointment_mode as string))
     return errorResponse(400, 'Mode de séance invalide', 'appointment_mode');
 
-  if (!duration || !VALID_DURATIONS.has(Number(duration)))
-    return errorResponse(400, 'Durée invalide (60 ou 90 minutes)', 'duration');
+  if (!duration || !Number.isInteger(Number(duration)) || Number(duration) < 15 || Number(duration) > 240)
+    return errorResponse(400, 'Durée invalide (entre 15 et 240 minutes)', 'duration');
+
+  const GRID_DURATIONS = new Set([60, 90]);
+  if (!GRID_DURATIONS.has(Number(duration)) && override_price === undefined)
+    return errorResponse(400, 'Durée personnalisée : le tarif manuel est obligatoire', 'override_price');
 
   if (!scheduled_at || typeof scheduled_at !== 'string' || isNaN(Date.parse(scheduled_at)))
     return errorResponse(400, 'Date de séance invalide', 'scheduled_at');
 
-  if (appointment_mode === 'video' && video_link && typeof video_link !== 'string')
-    return errorResponse(400, 'Lien vidéo invalide', 'video_link');
+  if (appointment_mode === 'video' && video_link) {
+    if (typeof video_link !== 'string') return errorResponse(400, 'Lien vidéo invalide', 'video_link');
+    try {
+      const parsed = new URL(video_link as string);
+      if (parsed.protocol !== 'https:')
+        return errorResponse(400, 'Lien vidéo invalide (HTTPS requis)', 'video_link');
+    } catch {
+      return errorResponse(400, 'Lien vidéo invalide', 'video_link');
+    }
+  }
+
+  if (override_price !== undefined && (
+    !Number.isInteger(Number(override_price)) ||
+    Number(override_price) < 0 ||
+    Number(override_price) > 500
+  ))
+    return errorResponse(400, 'Tarif manuel invalide (entre 0 et 500€)', 'override_price');
 
   const scheduledDate = new Date(scheduled_at);
   if (scheduledDate.getTime() < Date.now())
@@ -139,9 +158,10 @@ export const POST: APIRoute = async ({ request }) => {
     : autoDetectedFirstSession;
   const pricing = calculatePrice(
     appointment_type as AppointmentType,
-    Number(duration) as AppointmentDuration,
+    Number(duration),
     isFirstSession,
     typeof is_solidarity === 'boolean' ? is_solidarity : false,
+    override_price !== undefined ? Number(override_price) : undefined,
   );
 
   // 5. Statut initial
@@ -181,32 +201,36 @@ export const POST: APIRoute = async ({ request }) => {
 
   await invalidateAvailabilityCache().catch(console.error);
 
-  if (!isVideo && !appointment.google_calendar_event_id) {
+  let resolvedVideoLink: string | undefined = appointment.video_link ?? undefined;
+
+  if (!appointment.google_calendar_event_id) {
     try {
       const start = new Date(appointment.scheduled_at);
       const end = new Date(start.getTime() + appointment.duration * 60 * 1000);
+      const modeLabel = isVideo ? 'Téléconsultation' : 'Présentiel';
       const calResult = await createCalendarEvent({
-        title: `${appointment.patient_name} — séance présentielle (${appointment.duration} min)`,
+        title: `${isVideo ? '🎥 ' : ''}${appointment.patient_name} — séance ${modeLabel.toLowerCase()} (${appointment.duration} min)`,
         start: start.toISOString(),
         end: end.toISOString(),
         description: [
           `Patient: ${appointment.patient_name}`,
           `Email: ${appointment.patient_email}`,
-          `Mode: Présentiel`,
+          `Mode: ${modeLabel}`,
           `Durée: ${appointment.duration} min`,
+          ...(resolvedVideoLink ? [`Lien visio: ${resolvedVideoLink}`] : []),
         ].join('\n'),
-        location: CABINET_ADDRESS,
+        location: isVideo ? 'Téléconsultation' : CABINET_ADDRESS,
         attendeeEmail: appointment.patient_email,
-        withMeet: false,
-        appointmentId: `${appointment.id}-admin-inperson`,
-        colorId: '2',
+        withMeet: isVideo && !resolvedVideoLink,
+        appointmentId: `${appointment.id}-admin-${isVideo ? 'video' : 'inperson'}`,
+        colorId: isVideo ? '11' : '2',
       });
-      await supabaseAdmin
-        .from('appointments')
-        .update({ google_calendar_event_id: calResult.eventId })
-        .eq('id', appointment.id);
+      const calendarUpdate: Record<string, string> = { google_calendar_event_id: calResult.eventId };
+      if (isVideo && calResult.meetLink) calendarUpdate.video_link = calResult.meetLink;
+      await supabaseAdmin.from('appointments').update(calendarUpdate).eq('id', appointment.id);
+      if (isVideo && calResult.meetLink) resolvedVideoLink = calResult.meetLink;
     } catch (calendarErr) {
-      console.error('[admin/appointments] Erreur création événement agenda (présentiel):', calendarErr);
+      console.error('[admin/appointments] Erreur création événement agenda:', calendarErr);
     }
   }
 
@@ -262,8 +286,8 @@ export const POST: APIRoute = async ({ request }) => {
         uid: appointment.id,
         summary: 'Séance de thérapie — OMF Therapie',
         description: `Patient: ${appointment.patient_name}\nMode: ${appointment.appointment_mode === 'video' ? 'Téléconsultation' : 'Présentiel'}`,
-        location: appointment.appointment_mode === 'in-person' ? CABINET_ADDRESS : (appointment.video_link ?? undefined),
-        url: appointment.video_link ?? undefined,
+        location: appointment.appointment_mode === 'in-person' ? CABINET_ADDRESS : (resolvedVideoLink ?? undefined),
+        url: resolvedVideoLink ?? undefined,
         start,
         end,
         organizerName: 'Oriane Montabonnet — OMF Thérapie',

--- a/src/pages/api/admin/appointments/index.ts
+++ b/src/pages/api/admin/appointments/index.ts
@@ -11,10 +11,12 @@ import { createAppointmentPaymentLink } from '../../../../lib/stripe';
 import { generateGoogleCalendarLink, generateOutlookCalendarLink, generateAppleCalendarInviteLink, CABINET_ADDRESS } from '../../../../lib/ics';
 import { createSecureLinkToken } from '../../../../lib/secure-links';
 import { createCalendarEvent } from '../../../../lib/google-calendar';
+import { hasAppointmentConflict } from '../../../../lib/appointment-conflicts';
 import AppointmentConfirmed from '../../../../emails/AppointmentConfirmed';
 import PaymentRequest from '../../../../emails/PaymentRequest';
 import type { AppointmentType, AppointmentDuration } from '../../../../types/appointment';
 import { invalidateAvailabilityCache } from '../../../../lib/calendar-cache.js';
+import { isWednesdayParis, isWithinBusinessHours } from '../../../../utils/date';
 
 // ---------------------------------------------------------------------------
 // Validation helpers
@@ -96,6 +98,30 @@ export const POST: APIRoute = async ({ request }) => {
   if (appointment_mode === 'video' && video_link && typeof video_link !== 'string')
     return errorResponse(400, 'Lien vidéo invalide', 'video_link');
 
+  const scheduledDate = new Date(scheduled_at);
+  if (scheduledDate.getTime() < Date.now())
+    return errorResponse(400, 'La date de séance doit être dans le futur', 'scheduled_at');
+
+  if (appointment_mode === 'in-person' && !isWednesdayParis(scheduled_at))
+    return errorResponse(400, 'Les rendez-vous en présentiel ont lieu le mercredi uniquement.', 'scheduled_at');
+
+  if (!isWithinBusinessHours(scheduled_at, Number(duration)))
+    return errorResponse(400, 'Le créneau doit être dans les plages horaires (8h-12h ou 14h-19h).', 'scheduled_at');
+
+  try {
+    const slotEnd = new Date(scheduledDate.getTime() + Number(duration) * 60 * 1000);
+    const hasConflict = await hasAppointmentConflict({
+      slotStartIso: scheduledDate.toISOString(),
+      slotEndIso: slotEnd.toISOString(),
+    });
+    if (hasConflict) {
+      return errorResponse(409, 'Ce créneau n\'est plus disponible. Veuillez sélectionner un autre horaire.', 'scheduled_at');
+    }
+  } catch (conflictError) {
+    console.error('[admin/appointments] Erreur vérification doublon:', conflictError);
+    return errorResponse(500, 'Erreur lors de la vérification du créneau');
+  }
+
   // 4. Calcul tarifaire
   // Pour une création manuelle, on calcule toujours la remise nouveau client si applicable.
   // L'admin peut activer le tarif solidaire via is_solidarity.
@@ -136,7 +162,7 @@ export const POST: APIRoute = async ({ request }) => {
       appointment_type,
       appointment_mode,
       duration: Number(duration),
-      scheduled_at,
+      scheduled_at: scheduledDate.toISOString(),
       patient_reason: patient_reason ?? '',
       is_first_session: isFirstSession,
       status: initialStatus,

--- a/src/pages/api/appointments/[id].ts
+++ b/src/pages/api/appointments/[id].ts
@@ -404,6 +404,9 @@ export const PATCH: APIRoute = async ({ request, params }) => {
   // Action: reschedule
   // ---------------------------------------------------------------------------
   if (action === 'reschedule') {
+    if (!['pending', 'payment_pending', 'payment_received', 'confirmed', 'rescheduled'].includes(appointment.status))
+      return errorResponse(409, 'Ce rendez-vous ne peut pas être reporté dans son état actuel');
+
     if (!rescheduled_to || typeof rescheduled_to !== 'string')
       return errorResponse(422, 'Nouveau créneau requis pour un report');
 

--- a/src/pages/api/appointments/[id].ts
+++ b/src/pages/api/appointments/[id].ts
@@ -10,8 +10,9 @@ import { generateGoogleCalendarLink, generateOutlookCalendarLink, generateAppleC
 import { createSecureLinkToken, verifySecureLinkToken } from '../../../lib/secure-links';
 import { getTypeLabel, getModeLabel, calculatePrice } from '../../../lib/pricing';
 import { stripe, createAppointmentPaymentLink } from '../../../lib/stripe';
-import { createCalendarEvent } from '../../../lib/google-calendar';
+import { createCalendarEvent, updateCalendarEvent, deleteCalendarEvent } from '../../../lib/google-calendar';
 import { isWednesdayParis, isWithinBusinessHours } from '../../../utils/date';
+import { invalidateAvailabilityCache } from '../../../lib/calendar-cache.js';
 import AppointmentConfirmed from '../../../emails/AppointmentConfirmed';
 import AppointmentDeclined from '../../../emails/AppointmentDeclined';
 import AppointmentRescheduled from '../../../emails/AppointmentRescheduled';
@@ -191,27 +192,31 @@ export const PATCH: APIRoute = async ({ request, params }) => {
       try {
         const start = new Date(appointment.scheduled_at);
         const end = new Date(start.getTime() + appointment.duration * 60 * 1000);
-        const meetResult = await createCalendarEvent({
-          title: `🎥 ${appointment.patient_name} — ${getTypeLabel(appointment.appointment_type)} (${appointment.duration} min)`,
-          start: start.toISOString(),
-          end: end.toISOString(),
-          description: [
-            `Patient: ${appointment.patient_name}`,
-            `Email: ${appointment.patient_email}`,
-            `Mode: ${getModeLabel(appointment.appointment_mode)}`,
-            `Type: ${getTypeLabel(appointment.appointment_type)}`,
-            `Durée: ${appointment.duration} min`,
-          ].join('\n'),
-          location: appointment.appointment_mode === 'in-person' ? CABINET_ADDRESS : 'Téléconsultation',
-          attendeeEmail: appointment.patient_email,
-          withMeet: true,
-          appointmentId: id,
-          colorId: appointment.appointment_mode === 'video' ? '11' : '2',
-        });
-        if (meetResult.meetLink) {
-          updateData.video_link = meetResult.meetLink;
-        } else {
-          updateData.video_link = buildFallbackVideoLink(appointment.id);
+        // Idempotency: skip if event already exists
+        if (!appointment.google_calendar_event_id) {
+          const meetResult = await createCalendarEvent({
+            title: `🎥 ${appointment.patient_name} — ${getTypeLabel(appointment.appointment_type)} (${appointment.duration} min)`,
+            start: start.toISOString(),
+            end: end.toISOString(),
+            description: [
+              `Patient: ${appointment.patient_name}`,
+              `Email: ${appointment.patient_email}`,
+              `Mode: ${getModeLabel(appointment.appointment_mode)}`,
+              `Type: ${getTypeLabel(appointment.appointment_type)}`,
+              `Durée: ${appointment.duration} min`,
+            ].join('\n'),
+            location: appointment.appointment_mode === 'in-person' ? CABINET_ADDRESS : 'Téléconsultation',
+            attendeeEmail: appointment.patient_email,
+            withMeet: true,
+            appointmentId: id,
+            colorId: appointment.appointment_mode === 'video' ? '11' : '2',
+          });
+          if (meetResult.meetLink) {
+            updateData.video_link = meetResult.meetLink;
+          } else {
+            updateData.video_link = buildFallbackVideoLink(appointment.id);
+          }
+          updateData.google_calendar_event_id = meetResult.eventId;
         }
       } catch (meetErr) {
         // Dégradation gracieuse : fallback visio non bloquant
@@ -234,11 +239,13 @@ export const PATCH: APIRoute = async ({ request, params }) => {
 
     const updatedAppt = updated as Appointment;
 
-    if (newStatus === 'confirmed' && updatedAppt.appointment_mode === 'in-person') {
+    await invalidateAvailabilityCache().catch(console.error);
+
+    if (newStatus === 'confirmed' && updatedAppt.appointment_mode === 'in-person' && !updatedAppt.google_calendar_event_id) {
       const start = new Date(updatedAppt.scheduled_at);
       const end = new Date(start.getTime() + updatedAppt.duration * 60 * 1000);
       try {
-        await createCalendarEvent({
+        const calResult = await createCalendarEvent({
           title: `${updatedAppt.patient_name} — ${getTypeLabel(updatedAppt.appointment_type)} (${updatedAppt.duration} min)`,
           start: start.toISOString(),
           end: end.toISOString(),
@@ -255,6 +262,10 @@ export const PATCH: APIRoute = async ({ request, params }) => {
           appointmentId: `${updatedAppt.id}-inperson-confirm`,
           colorId: '2',
         });
+        await supabaseAdmin
+          .from('appointments')
+          .update({ google_calendar_event_id: calResult.eventId })
+          .eq('id', updatedAppt.id);
       } catch (calendarErr) {
         console.error('[appointments/patch] Erreur création événement agenda (présentiel):', calendarErr);
       }
@@ -341,6 +352,8 @@ export const PATCH: APIRoute = async ({ request, params }) => {
 
     const updatedAppt = updated as Appointment;
 
+    await invalidateAvailabilityCache().catch(console.error);
+
     await sendEmail({
       to: updatedAppt.patient_email,
       threadKey: `appointment:${updatedAppt.id}:patient`,
@@ -354,6 +367,13 @@ export const PATCH: APIRoute = async ({ request, params }) => {
         therapistNote: typeof therapist_notes === 'string' ? therapist_notes : undefined,
       }),
     });
+
+    // Delete calendar event if exists (non-blocking — don't fail the decline if calendar fails)
+    if (appointment.google_calendar_event_id) {
+      await deleteCalendarEvent(appointment.google_calendar_event_id).catch((calendarErr: unknown) => {
+        console.error('[appointments/patch] Erreur suppression événement agenda (decline):', calendarErr);
+      });
+    }
 
     return jsonResponse({ appointment: updatedAppt, message: 'Rendez-vous refusé.' });
   }
@@ -429,6 +449,8 @@ export const PATCH: APIRoute = async ({ request, params }) => {
     }
 
     const updatedAppt = updated as Appointment;
+
+    await invalidateAvailabilityCache().catch(console.error);
 
     await sendEmail({
       to: updatedAppt.patient_email,
@@ -552,29 +574,41 @@ export const PATCH: APIRoute = async ({ request, params }) => {
 
     const updatedAppt = updated as Appointment;
 
+    await invalidateAvailabilityCache().catch(console.error);
+
     if (newStatus === 'confirmed' && updatedAppt.appointment_mode === 'in-person') {
       const start = new Date(updatedAppt.scheduled_at);
       const end = new Date(start.getTime() + updatedAppt.duration * 60 * 1000);
       try {
-        await createCalendarEvent({
-          title: `${updatedAppt.patient_name} — ${getTypeLabel(updatedAppt.appointment_type)} (${updatedAppt.duration} min)`,
-          start: start.toISOString(),
-          end: end.toISOString(),
-          description: [
-            `Patient: ${updatedAppt.patient_name}`,
-            `Email: ${updatedAppt.patient_email}`,
-            `Mode: ${getModeLabel(updatedAppt.appointment_mode)}`,
-            `Type: ${getTypeLabel(updatedAppt.appointment_type)}`,
-            `Durée: ${updatedAppt.duration} min`,
-          ].join('\n'),
-          location: CABINET_ADDRESS,
-          attendeeEmail: updatedAppt.patient_email,
-          withMeet: false,
-          appointmentId: `${updatedAppt.id}-inperson-reschedule`,
-          colorId: '2',
-        });
+        if (appointment.google_calendar_event_id) {
+          // Patch existing event to the accepted reschedule date
+          await updateCalendarEvent(appointment.google_calendar_event_id, { start, end });
+        } else {
+          // No existing event — create one
+          const calResult = await createCalendarEvent({
+            title: `${updatedAppt.patient_name} — ${getTypeLabel(updatedAppt.appointment_type)} (${updatedAppt.duration} min)`,
+            start: start.toISOString(),
+            end: end.toISOString(),
+            description: [
+              `Patient: ${updatedAppt.patient_name}`,
+              `Email: ${updatedAppt.patient_email}`,
+              `Mode: ${getModeLabel(updatedAppt.appointment_mode)}`,
+              `Type: ${getTypeLabel(updatedAppt.appointment_type)}`,
+              `Durée: ${updatedAppt.duration} min`,
+            ].join('\n'),
+            location: CABINET_ADDRESS,
+            attendeeEmail: updatedAppt.patient_email,
+            withMeet: false,
+            appointmentId: `${updatedAppt.id}-inperson-reschedule`,
+            colorId: '2',
+          });
+          await supabaseAdmin
+            .from('appointments')
+            .update({ google_calendar_event_id: calResult.eventId })
+            .eq('id', updatedAppt.id);
+        }
       } catch (calendarErr) {
-        console.error('[appointments/patch] Erreur création événement agenda après acceptation de report:', calendarErr);
+        console.error('[appointments/patch] Erreur mise à jour événement agenda après acceptation de report:', calendarErr);
       }
     }
 

--- a/src/pages/api/appointments/[id].ts
+++ b/src/pages/api/appointments/[id].ts
@@ -11,6 +11,7 @@ import { createSecureLinkToken, verifySecureLinkToken } from '../../../lib/secur
 import { getTypeLabel, getModeLabel, calculatePrice } from '../../../lib/pricing';
 import { stripe, createAppointmentPaymentLink } from '../../../lib/stripe';
 import { createCalendarEvent, updateCalendarEvent, deleteCalendarEvent } from '../../../lib/google-calendar';
+import { hasAppointmentConflict } from '../../../lib/appointment-conflicts';
 import { isWednesdayParis, isWithinBusinessHours } from '../../../utils/date';
 import { invalidateAvailabilityCache } from '../../../lib/calendar-cache.js';
 import AppointmentConfirmed from '../../../emails/AppointmentConfirmed';
@@ -423,6 +424,21 @@ export const PATCH: APIRoute = async ({ request, params }) => {
     if (!isWithinBusinessHours(rescheduled_to as string, appointment.duration))
       return errorResponse(422, 'Le créneau doit être dans les plages horaires (8h-12h ou 14h-19h).');
 
+    try {
+      const slotEnd = new Date(newDate.getTime() + appointment.duration * 60 * 1000);
+      const hasConflict = await hasAppointmentConflict({
+        slotStartIso: newDate.toISOString(),
+        slotEndIso: slotEnd.toISOString(),
+        excludeAppointmentId: appointment.id,
+      });
+      if (hasConflict) {
+        return errorResponse(409, 'Ce créneau n\'est plus disponible. Veuillez sélectionner un autre horaire.');
+      }
+    } catch (conflictError) {
+      console.error('[appointments/patch] Erreur vérification doublon (reschedule):', conflictError);
+      return errorResponse(500, 'Erreur lors de la vérification du créneau');
+    }
+
     // Expire l'ancien Payment Link Stripe s'il existe (évite le double-paiement)
     if (appointment.stripe_payment_link_id) {
       try {
@@ -528,6 +544,22 @@ export const PATCH: APIRoute = async ({ request, params }) => {
     // Le créneau proposé doit être dans le futur
     if (!appointment.rescheduled_to || appointment.rescheduled_to <= new Date().toISOString())
       return errorResponse(410, 'Ce créneau proposé a expiré. Contactez le thérapeute.');
+
+    try {
+      const acceptedStart = new Date(appointment.rescheduled_to);
+      const acceptedEnd = new Date(acceptedStart.getTime() + appointment.duration * 60 * 1000);
+      const hasConflict = await hasAppointmentConflict({
+        slotStartIso: acceptedStart.toISOString(),
+        slotEndIso: acceptedEnd.toISOString(),
+        excludeAppointmentId: appointment.id,
+      });
+      if (hasConflict) {
+        return errorResponse(409, 'Ce créneau n\'est plus disponible. Contactez la thérapeute pour une nouvelle proposition.');
+      }
+    } catch (conflictError) {
+      console.error('[appointments/patch] Erreur vérification doublon (accept_reschedule):', conflictError);
+      return errorResponse(500, 'Erreur lors de la vérification du créneau');
+    }
 
     let newStatus: Appointment['status'];
     if (appointment.appointment_mode === 'video') {

--- a/src/pages/api/appointments/[id].ts
+++ b/src/pages/api/appointments/[id].ts
@@ -622,11 +622,20 @@ export const PATCH: APIRoute = async ({ request, params }) => {
       const start = new Date(updatedAppt.scheduled_at);
       const end = new Date(start.getTime() + updatedAppt.duration * 60 * 1000);
       try {
-        if (appointment.google_calendar_event_id) {
-          // Patch existing event to the accepted reschedule date
-          await updateCalendarEvent(appointment.google_calendar_event_id, { start, end });
-        } else {
-          // No existing event — create one
+        let syncedEventId = appointment.google_calendar_event_id ?? updatedAppt.google_calendar_event_id ?? null;
+
+        if (syncedEventId) {
+          // Patch existing event; if orphaned/missing on Google, fallback to create.
+          try {
+            await updateCalendarEvent(syncedEventId, { start, end });
+          } catch (patchErr) {
+            console.warn('[appointments/patch] Patch événement échoué après acceptation de report, fallback création:', patchErr);
+            syncedEventId = null;
+          }
+        }
+
+        if (!syncedEventId) {
+          // No existing event (or patch failed) — create one
           const calResult = await createCalendarEvent({
             title: `${updatedAppt.patient_name} — ${getTypeLabel(updatedAppt.appointment_type)} (${updatedAppt.duration} min)`,
             start: start.toISOString(),
@@ -644,13 +653,31 @@ export const PATCH: APIRoute = async ({ request, params }) => {
             appointmentId: `${updatedAppt.id}-inperson-reschedule`,
             colorId: '2',
           });
-          await supabaseAdmin
+          syncedEventId = calResult.eventId;
+        }
+
+        if (syncedEventId && syncedEventId !== updatedAppt.google_calendar_event_id) {
+          const { data: refreshedAfterCalendar, error: refreshError } = await supabaseAdmin
             .from('appointments')
-            .update({ google_calendar_event_id: calResult.eventId })
-            .eq('id', updatedAppt.id);
+            .update({ google_calendar_event_id: syncedEventId })
+            .eq('id', updatedAppt.id)
+            .select([
+              'id', 'status', 'scheduled_at', 'rescheduled_to',
+              'appointment_mode', 'appointment_type', 'duration',
+              'patient_name', 'patient_email', 'final_price',
+              'video_link', 'stripe_payment_link_url',
+              'google_calendar_event_id',
+            ].join(', '))
+            .single();
+          if (refreshError || !refreshedAfterCalendar) {
+            console.error('[appointments/patch] Erreur persistance google_calendar_event_id après acceptation de report:', refreshError);
+            return errorResponse(500, 'Erreur lors de la synchronisation agenda');
+          }
+          updatedAppt = refreshedAfterCalendar as Appointment;
         }
       } catch (calendarErr) {
         console.error('[appointments/patch] Erreur mise à jour événement agenda après acceptation de report:', calendarErr);
+        return errorResponse(500, 'Erreur lors de la synchronisation agenda');
       }
     }
 

--- a/src/pages/api/appointments/[id].ts
+++ b/src/pages/api/appointments/[id].ts
@@ -564,7 +564,14 @@ export const PATCH: APIRoute = async ({ request, params }) => {
       .from('appointments')
       .update(updateData)
       .eq('id', id)
-      .select()
+      .select([
+        'id', 'status', 'scheduled_at', 'rescheduled_to',
+        'appointment_mode', 'appointment_type', 'duration',
+        'patient_name', 'patient_email', 'final_price',
+        'video_link', 'stripe_payment_link_url',
+        'google_calendar_event_id',
+        // therapist_notes, stripe_payment_intent_id, stripe_payment_link_id excluded — unauthenticated caller
+      ].join(', '))
       .single();
 
     if (updateError || !updated) {

--- a/src/pages/api/appointments/index.ts
+++ b/src/pages/api/appointments/index.ts
@@ -10,6 +10,7 @@ import AppointmentRequestNotification from '../../../emails/AppointmentRequestNo
 import type { AppointmentType, AppointmentDuration, AppointmentMode } from '../../../types/appointment';
 import { checkRateLimit, rateLimitResponse } from '../../../lib/rate-limit';
 import { isWednesdayParis, isWithinBusinessHours } from '../../../utils/date';
+import { hasAppointmentConflict } from '../../../lib/appointment-conflicts';
 
 // ---------------------------------------------------------------------------
 // Validation helpers
@@ -119,25 +120,22 @@ export const POST: APIRoute = async ({ request }) => {
   if (!isWithinBusinessHours(scheduled_at as string, duration as number))
     return errorResponse(422, 'Le créneau est en dehors des horaires d\'ouverture (8h-12h et 14h-19h).');
 
-  // 4. Anti-doublon : vérifier qu'aucun rdv ne chevauche ce créneau
-  const slotStart = scheduledDate;
+  // 4. Anti-doublon : vérifier qu'aucun rdv (incluant reports proposés) ne chevauche ce créneau
   const slotEnd = new Date(scheduledDate.getTime() + (duration as number) * 60 * 1000);
 
-  const { data: conflicts, error: conflictError } = await supabaseAdmin
-    .from('appointments')
-    .select('id')
-    .lt('scheduled_at', slotEnd.toISOString())
-    .gt('scheduled_end', slotStart.toISOString())
-    .not('status', 'in', '("cancelled","declined")')
-    .limit(1);
+  try {
+    const hasConflict = await hasAppointmentConflict({
+      slotStartIso: scheduledDate.toISOString(),
+      slotEndIso: slotEnd.toISOString(),
+    });
 
-  if (conflictError) {
+    if (hasConflict) {
+      return errorResponse(409, 'Ce créneau n\'est plus disponible. Veuillez sélectionner un autre horaire.');
+    }
+  } catch (conflictError) {
     console.error('[appointments] Erreur vérification doublon:', conflictError);
     return errorResponse(500, 'Erreur lors de la vérification du créneau');
   }
-
-  if (conflicts && conflicts.length > 0)
-    return errorResponse(409, 'Ce créneau n\'est plus disponible. Veuillez sélectionner un autre horaire.');
 
   // 5. Calcul du prix (en centimes)
   const pricing = calculatePrice(

--- a/src/pages/api/availability.ts
+++ b/src/pages/api/availability.ts
@@ -118,6 +118,22 @@ function jsonSuccess(slots: TimeSlot[]): Response {
   });
 }
 
+function filterSlotsByBusy(
+  slots: TimeSlot[],
+  busyPeriods: Array<{ start: string; end: string }>,
+): TimeSlot[] {
+  if (busyPeriods.length === 0) return slots;
+  return slots.filter((slot) => {
+    const slotStart = new Date(slot.start).getTime();
+    const slotEnd = new Date(slot.end).getTime();
+    return !busyPeriods.some((busy) => {
+      const busyStart = new Date(busy.start).getTime();
+      const busyEnd = new Date(busy.end).getTime();
+      return slotStart < busyEnd && slotEnd > busyStart;
+    });
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Handler principal
 // ---------------------------------------------------------------------------
@@ -184,13 +200,14 @@ export const GET: APIRoute = async ({ request }) => {
   // --- Appel Google Calendar (+ DB busy periods en parallèle) ---
   try {
     const cacheKey = buildAvailabilityCacheKey(mode, duration, weeks, now);
+    const dbBusy = await fetchDbBusyPeriods(now, endDate);
     const cached = await getCachedAvailability(cacheKey);
     if (cached) {
-      return jsonSuccess(cached);
+      // Always re-apply live DB busy periods to avoid stale overlaps
+      // if cache invalidation failed in a previous mutation.
+      return jsonSuccess(filterSlotsByBusy(cached, dbBusy));
     }
 
-    const dbBusyPromise = fetchDbBusyPeriods(now, endDate);
-    const dbBusy = await dbBusyPromise;
     const slots = await getAvailableSlots(now, endDate, duration, mode, dbBusy);
 
     await setCachedAvailability(cacheKey, slots).catch(() => {});

--- a/src/pages/api/availability.ts
+++ b/src/pages/api/availability.ts
@@ -64,11 +64,13 @@ async function fetchDbBusyPeriods(
 ): Promise<Array<{ start: string; end: string }>> {
   const { data, error } = await supabaseAdmin
     .from('appointments')
-    .select('scheduled_at, scheduled_end')
+    .select('status, duration, scheduled_at, scheduled_end, rescheduled_to')
     .in('status', BLOCKING_STATUSES)
     .is('deleted_at', null)
-    .gte('scheduled_at', from.toISOString())
-    .lte('scheduled_at', to.toISOString());
+    .or([
+      `and(scheduled_at.gte.${from.toISOString()},scheduled_at.lte.${to.toISOString()})`,
+      `and(rescheduled_to.gte.${from.toISOString()},rescheduled_to.lte.${to.toISOString()})`,
+    ].join(','));
 
   if (error) {
     console.error('[api/availability] Erreur DB busy periods :', error.message);
@@ -76,12 +78,22 @@ async function fetchDbBusyPeriods(
   }
 
   return (data ?? [])
-    .filter(
-      (row): row is { scheduled_at: string; scheduled_end: string } =>
-        typeof row.scheduled_at === 'string' &&
-        typeof row.scheduled_end === 'string',
-    )
-    .map((row) => ({ start: row.scheduled_at, end: row.scheduled_end }));
+    .flatMap((row) => {
+      if (typeof row.duration !== 'number') return [];
+
+      // For rescheduled appointments, reserve proposed slot (rescheduled_to)
+      // so it cannot be double-booked before patient accepts.
+      if (row.status === 'rescheduled' && typeof row.rescheduled_to === 'string') {
+        const start = new Date(row.rescheduled_to);
+        const end = new Date(start.getTime() + row.duration * 60 * 1000);
+        return [{ start: start.toISOString(), end: end.toISOString() }];
+      }
+
+      if (typeof row.scheduled_at !== 'string' || typeof row.scheduled_end !== 'string') {
+        return [];
+      }
+      return [{ start: row.scheduled_at, end: row.scheduled_end }];
+    });
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pages/api/availability.ts
+++ b/src/pages/api/availability.ts
@@ -19,6 +19,11 @@ import {
   type TimeSlot,
 } from '@/lib/google-calendar';
 import { supabaseAdmin } from '@/lib/supabase';
+import {
+  getCachedAvailability,
+  setCachedAvailability,
+  buildAvailabilityCacheKey,
+} from '../../lib/calendar-cache.js';
 
 // Désactiver le pré-rendu : cette route est toujours dynamique (SSR)
 export const prerender = false;
@@ -166,9 +171,18 @@ export const GET: APIRoute = async ({ request }) => {
 
   // --- Appel Google Calendar (+ DB busy periods en parallèle) ---
   try {
+    const cacheKey = buildAvailabilityCacheKey(mode, duration, weeks, now);
+    const cached = await getCachedAvailability(cacheKey);
+    if (cached) {
+      return jsonSuccess(cached);
+    }
+
     const dbBusyPromise = fetchDbBusyPeriods(now, endDate);
     const dbBusy = await dbBusyPromise;
     const slots = await getAvailableSlots(now, endDate, duration, mode, dbBusy);
+
+    await setCachedAvailability(cacheKey, slots).catch(() => {});
+
     return jsonSuccess(slots);
   } catch (err: unknown) {
     if (err instanceof GoogleCalendarError) {

--- a/src/pages/api/availability.ts
+++ b/src/pages/api/availability.ts
@@ -187,7 +187,12 @@ export const GET: APIRoute = async ({ request }) => {
   } catch (err: unknown) {
     if (err instanceof GoogleCalendarError) {
       // Erreur métier Google Calendar (quota, config, permissions)
-      console.error('[api/availability] GoogleCalendarError :', err.message, err.cause);
+      console.error(
+        '[api/availability] GoogleCalendarError :',
+        err.message,
+        // err.cause intentionally NOT logged — may contain OAuth credentials via GaxiosError
+        err.cause instanceof Error ? err.cause.message : typeof err.cause === 'object' && err.cause !== null ? (err.cause as Record<string, unknown>)['googleErrorCode'] ?? 'unknown' : String(err.cause ?? ''),
+      );
       return jsonError('Le service de disponibilités est temporairement indisponible.', 503);
     }
 

--- a/src/pages/api/stripe-webhook.ts
+++ b/src/pages/api/stripe-webhook.ts
@@ -222,7 +222,11 @@ export async function handlePaymentSucceeded(appointmentId: string, paymentInten
   // Génération événement calendrier + lien visio (non-bloquant)
   let videoLink = updatedAppt.video_link ?? undefined;
   let calendarEventCreated = false;
-  if (updatedAppt.appointment_mode === 'video' && !videoLink) {
+
+  // If admin already created the calendar event at booking time, skip creation to avoid duplicates.
+  if (updatedAppt.google_calendar_event_id) {
+    calendarEventCreated = true;
+  } else if (updatedAppt.appointment_mode === 'video' && !videoLink) {
     const start = new Date(updatedAppt.scheduled_at);
     const end = new Date(start.getTime() + updatedAppt.duration * 60 * 1000);
     const title = `🎥 ${updatedAppt.patient_name} — ${getTypeLabel(updatedAppt.appointment_type)} (${updatedAppt.duration} min)`;

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -118,7 +118,7 @@ const readingTime = calculateReadingTime(entry.body ?? '');
             <h3 class="text-sage-700 font-medium mb-2">Partager cet article</h3>
             <ShareButtons post={post} client:visible />
           </div>
-          <a href="/contact" class="text-mint-600 font-medium hover:text-mint-700 transition-colors">
+          <a href="/rendez-vous/" class="text-mint-600 font-medium hover:text-mint-700 transition-colors">
             Des questions ? Contactez-moi
           </a>
         </div>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -32,18 +32,16 @@ const jsonLd = buildLocalBusinessSchema();
       <div class="grid md:grid-cols-2 gap-8 md:gap-12 mb-12">
         <div class="space-y-12">
           <!-- Online booking box -->
-          <div>
+          <div class="mb-6">
             <h2 class="text-2xl font-serif font-semibold text-sage-800 mb-6">Prendre rendez-vous en ligne</h2>
             <div class="bg-white p-8 rounded-lg shadow-sm">
-              <p class="text-sage-600 mb-6">Réservez votre consultation en quelques clics via notre plateforme sécurisée Psychologue.net.</p>
+              <p class="text-sage-600 mb-6">Réservez votre consultation en quelques clics directement en ligne, en toute simplicité.</p>
               <a
-                href="https://www.psychologue.net/cabinets/oriane-montabonnet"
-                target="_blank"
-                rel="noopener noreferrer"
+                href="/rendez-vous/"
                 class="btn-primary w-full justify-center inline-flex items-center"
-                aria-label="Réserver une consultation en ligne (s'ouvre dans un nouvel onglet)"
+                aria-label="Réserver une consultation en ligne"
               >
-                Réserver une consultation
+                Prendre rendez-vous en ligne
               </a>
             </div>
           </div>

--- a/src/pages/rdv/accepter-report.astro
+++ b/src/pages/rdv/accepter-report.astro
@@ -109,8 +109,8 @@ const priceFormatted = `${Math.round(appt.final_price / 100)}\u00a0€`;
             <br />
             Votre rendez-vous a peut-être déjà été confirmé.
           </p>
-          <a href="/mes-rdvs/" class="mt-6 inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-mint-600 text-white text-sm font-medium font-sans hover:bg-mint-700 transition-colors min-h-[40px]">
-            Voir mes rendez-vous
+          <a href="/contact/" class="mt-6 inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-mint-600 text-white text-sm font-medium font-sans hover:bg-mint-700 transition-colors min-h-[40px]">
+            Contacter la thérapeute
           </a>
         </div>
       )}

--- a/src/pages/rendez-vous.astro
+++ b/src/pages/rendez-vous.astro
@@ -91,6 +91,25 @@ const jsonLd = {
         </div>
       </header>
 
+      <div
+        id="booking-link-error"
+        role="alert"
+        class="hidden mb-6 rounded-xl border border-amber-200 bg-amber-50 px-5 py-4"
+      >
+        <p class="text-sm font-semibold text-amber-800 mb-1">
+          Lien invalide ou expiré
+        </p>
+        <p id="booking-link-error-message" class="text-sm text-amber-700">
+          Ce lien de confirmation n'est plus valide.
+        </p>
+        <a
+          href="/contact/"
+          class="mt-3 inline-flex items-center gap-2 text-sm font-medium text-mint-700 hover:text-mint-800 transition-colors"
+        >
+          Contacter la thérapeute
+        </a>
+      </div>
+
       <!-- Island React — formulaire multi-étapes -->
       <BookingWizard client:load />
 
@@ -119,3 +138,22 @@ const jsonLd = {
     </div>
   </main>
 </Layout>
+
+<script>
+  const errorCard = document.getElementById('booking-link-error');
+  const errorMessage = document.getElementById('booking-link-error-message');
+  const errorParam = new URLSearchParams(window.location.search).get('error');
+
+  if (errorCard && errorMessage && errorParam) {
+    const messageByCode = {
+      'lien-invalide': 'Le lien de confirmation est invalide, expiré ou déjà utilisé.',
+      'rdv-introuvable': 'Le rendez-vous demandé est introuvable.',
+    };
+
+    const message = messageByCode[errorParam as keyof typeof messageByCode];
+    if (message) {
+      errorMessage.textContent = message;
+      errorCard.classList.remove('hidden');
+    }
+  }
+</script>

--- a/src/pages/rendez-vous.astro
+++ b/src/pages/rendez-vous.astro
@@ -103,7 +103,7 @@ const jsonLd = {
           Ce lien de confirmation n'est plus valide.
         </p>
         <a
-          href="/contact/"
+          href="/rendez-vous/"
           class="mt-3 inline-flex items-center gap-2 text-sm font-medium text-mint-700 hover:text-mint-800 transition-colors"
         >
           Contacter la thérapeute

--- a/src/pages/services/therapie-de-couple.astro
+++ b/src/pages/services/therapie-de-couple.astro
@@ -60,7 +60,7 @@ const jsonLd = [
         <h1 class="font-serif text-3xl md:text-4xl lg:text-5xl font-semibold text-sage-800 mb-6">Thérapie de couple à Montpellier</h1>
         <p class="text-xl text-sage-600 max-w-3xl leading-relaxed">Je vous aide à améliorer votre communication, traverser les conflits et reconstruire le lien au sein de votre relation. Dans un cadre neutre et bienveillant, les deux partenaires sont accueillis pour avancer ensemble.</p>
         <div class="mt-6">
-          <a href="/contact" class="btn-primary">
+          <a href="/rendez-vous/" class="btn-primary">
             Prendre rendez-vous
           </a>
         </div>
@@ -106,7 +106,7 @@ const jsonLd = [
         <h2 class="font-serif text-2xl text-sage-800 mb-3">À Montpellier et dans l'Hérault</h2>
         <p class="text-sage-600 leading-relaxed mb-4">Le cabinet est situé au <strong class="font-semibold text-sage-700">1086 Avenue Albert Einstein, 34000 Montpellier</strong>, dans le quartier Hôpitaux-Facultés, facilement accessible en tramway (ligne 2) et en voiture. Les séances ont lieu du lundi au vendredi, de 8h à 12h et de 14h à 19h.</p>
         <p class="text-sage-600 leading-relaxed mb-4">De nombreux couples viennent depuis Castelnau-le-Lez, Lattes, Pérols, Villeneuve-lès-Maguelone ou d'autres communes de l'Hérault (34). Des séances en visioconférence sécurisée sont disponibles pour les couples dont l'un des partenaires ne peut pas se déplacer.</p>
-        <p class="text-sage-600 leading-relaxed">Vous souhaitez commencer ? <a href="/contact" class="text-mint-600 hover:text-mint-700 underline underline-offset-2">Prenez rendez-vous avec moi</a> pour un premier échange et convenir d'une date — la démarche est confidentielle et sans engagement.</p>
+        <p class="text-sage-600 leading-relaxed">Vous souhaitez commencer ? <a href="/rendez-vous/" class="text-mint-600 hover:text-mint-700 underline underline-offset-2">Prenez rendez-vous avec moi</a> pour un premier échange et convenir d'une date — la démarche est confidentielle et sans engagement.</p>
       </div>
 
       <div>

--- a/src/pages/services/therapie-familiale.astro
+++ b/src/pages/services/therapie-familiale.astro
@@ -60,7 +60,7 @@ const jsonLd = [
         <h1 class="font-serif text-3xl md:text-4xl lg:text-5xl font-semibold text-sage-800 mb-6">Thérapie familiale à Montpellier</h1>
         <p class="text-xl text-sage-600 max-w-3xl leading-relaxed">Je vous offre un espace de dialogue pour les familles traversant des tensions, des conflits intergénérationnels ou des transitions difficiles. L'objectif : restaurer la communication et retrouver un équilibre familial apaisé.</p>
         <div class="mt-6">
-          <a href="/contact" class="btn-primary">
+          <a href="/rendez-vous/" class="btn-primary">
             Prendre rendez-vous
           </a>
         </div>
@@ -106,7 +106,7 @@ const jsonLd = [
         <h2 class="font-serif text-2xl text-sage-800 mb-3">À Montpellier et dans l'Hérault</h2>
         <p class="text-sage-600 leading-relaxed mb-4">Le cabinet est situé au <strong class="font-semibold text-sage-700">1086 Avenue Albert Einstein, 34000 Montpellier</strong>, dans le quartier Hôpitaux-Facultés. Il est accessible en tramway (ligne 2) et facilement accessible en voiture depuis les communes voisines de l'Hérault : Castelnau-le-Lez, Lattes, Pérols, Saint-Jean-de-Védas, Jacou.</p>
         <p class="text-sage-600 leading-relaxed mb-4">Les séances se tiennent du lundi au vendredi, de 8h à 12h et de 14h à 19h. Si un membre de la famille ne peut pas se déplacer, une séance en visioconférence sécurisée peut être envisagée ponctuellement.</p>
-        <p class="text-sage-600 leading-relaxed">Vous souhaitez entamer une démarche familiale ? <a href="/contact" class="text-mint-600 hover:text-mint-700 underline underline-offset-2">Prenez rendez-vous avec moi</a> pour un premier échange confidentiel, sans engagement.</p>
+        <p class="text-sage-600 leading-relaxed">Vous souhaitez entamer une démarche familiale ? <a href="/rendez-vous/" class="text-mint-600 hover:text-mint-700 underline underline-offset-2">Prenez rendez-vous avec moi</a> pour un premier échange confidentiel, sans engagement.</p>
       </div>
 
       <div>

--- a/src/pages/services/therapie-individuelle.astro
+++ b/src/pages/services/therapie-individuelle.astro
@@ -60,7 +60,7 @@ const jsonLd = [
         <h1 class="font-serif text-3xl md:text-4xl lg:text-5xl font-semibold text-sage-800 mb-6">Thérapie individuelle à Montpellier</h1>
         <p class="text-xl text-sage-600 max-w-3xl leading-relaxed">Je vous offre un espace confidentiel et bienveillant pour explorer vos difficultés émotionnelles, relationnelles ou comportementales. En séances de 60 ou 90 minutes au cabinet du 1086 avenue Albert Einstein, vous avancez à votre propre rythme vers un mieux-être durable.</p>
         <div class="mt-6">
-          <a href="/contact" class="btn-primary">
+          <a href="/rendez-vous/" class="btn-primary">
             Prendre rendez-vous
           </a>
         </div>
@@ -107,7 +107,7 @@ const jsonLd = [
         <h2 class="font-serif text-2xl text-sage-800 mb-3">Un cabinet accessible à Montpellier</h2>
         <p class="text-sage-600 leading-relaxed mb-4">Le cabinet est situé au <strong class="font-semibold text-sage-700">1086 Avenue Albert Einstein, 34000 Montpellier</strong>, dans le quartier Hôpitaux-Facultés. Facilement accessible en transports en commun (ligne 2 du tramway, arrêt Universités des Sciences et Lettres) et en voiture depuis Castelnau-le-Lez, Lattes, Pérols et Saint-Jean-de-Védas.</p>
         <p class="text-sage-600 leading-relaxed mb-4">Les séances se tiennent du lundi au vendredi, de 8h à 12h et de 14h à 19h. Si vous résidez dans l'Hérault (34) et ne pouvez pas vous déplacer, des séances en visioconférence sécurisée sont également disponibles sur demande.</p>
-        <p class="text-sage-600 leading-relaxed">Prêt(e) à franchir le pas ? <a href="/contact" class="text-mint-600 hover:text-mint-700 underline underline-offset-2">Prenez rendez-vous</a> directement en ligne ou par téléphone — la première prise de contact est sans engagement.</p>
+        <p class="text-sage-600 leading-relaxed">Prêt(e) à franchir le pas ? <a href="/rendez-vous/" class="text-mint-600 hover:text-mint-700 underline underline-offset-2">Prenez rendez-vous</a> directement en ligne ou par téléphone — la première prise de contact est sans engagement.</p>
       </div>
 
       <div>

--- a/src/pages/services/troubles-alimentaires.astro
+++ b/src/pages/services/troubles-alimentaires.astro
@@ -60,7 +60,7 @@ const jsonLd = [
         <h1 class="font-serif text-3xl md:text-4xl lg:text-5xl font-semibold text-sage-800 mb-6">Accompagnement des troubles alimentaires à Montpellier</h1>
         <p class="text-xl text-sage-600 max-w-3xl leading-relaxed">Je propose un accompagnement spécialisé pour les troubles du comportement alimentaire (TCA). Grâce à l'approche TCCE, je vous aide à transformer votre relation à l'alimentation, à votre corps et à vos émotions, dans un cadre bienveillant et sans jugement.</p>
         <div class="mt-6">
-          <a href="/contact" class="btn-primary">
+          <a href="/rendez-vous/" class="btn-primary">
             Prendre rendez-vous
           </a>
         </div>
@@ -106,7 +106,7 @@ const jsonLd = [
         <h2 class="font-serif text-2xl text-sage-800 mb-3">Un accompagnement à Montpellier et dans l'Hérault</h2>
         <p class="text-sage-600 leading-relaxed mb-4">Le cabinet est situé au <strong class="font-semibold text-sage-700">1086 Avenue Albert Einstein, 34000 Montpellier</strong>, dans le quartier Hôpitaux-Facultés, facilement accessible en tramway (ligne 2) et en voiture depuis les communes de l'Hérault (34) : Castelnau-le-Lez, Lattes, Pérols, Montferrier-sur-Lez, Clapiers.</p>
         <p class="text-sage-600 leading-relaxed mb-4">Les séances se tiennent du lundi au vendredi, de 8h à 12h et de 14h à 19h. Des séances en visioconférence sécurisée sont disponibles pour les personnes qui ne peuvent pas se déplacer — une option particulièrement utile dans les phases délicates du suivi.</p>
-        <p class="text-sage-600 leading-relaxed">Vous vous reconnaissez dans l'une de ces situations ? <a href="/contact" class="text-mint-600 hover:text-mint-700 underline underline-offset-2">Prenez rendez-vous avec moi</a> pour un premier échange confidentiel et sans engagement. La démarche de consulter est déjà un acte de soin envers vous-même.</p>
+        <p class="text-sage-600 leading-relaxed">Vous vous reconnaissez dans l'une de ces situations ? <a href="/rendez-vous/" class="text-mint-600 hover:text-mint-700 underline underline-offset-2">Prenez rendez-vous avec moi</a> pour un premier échange confidentiel et sans engagement. La démarche de consulter est déjà un acte de soin envers vous-même.</p>
       </div>
 
       <div>

--- a/src/types/appointment.ts
+++ b/src/types/appointment.ts
@@ -69,6 +69,9 @@ export interface Appointment {
   // Google Meet (renseigné manuellement par la thérapeute)
   video_link: string | null;
 
+  // Google Calendar event ID (for lifecycle management: update/delete on reschedule/decline)
+  google_calendar_event_id: string | null;
+
   // Usage interne
   therapist_notes: string | null;
 
@@ -103,6 +106,7 @@ export type CreateAppointmentData = Omit<
   | 'video_link'
   | 'therapist_notes'
   | 'rescheduled_to'
+  | 'google_calendar_event_id'
 >;
 
 // ---------------------------------------------------------------------------
@@ -123,6 +127,7 @@ export type UpdateAppointmentData = Partial<
     | 'video_link'
     | 'therapist_notes'
     | 'rescheduled_to'
+    | 'google_calendar_event_id'
   >
 >;
 

--- a/src/types/appointment.ts
+++ b/src/types/appointment.ts
@@ -47,7 +47,7 @@ export interface Appointment {
   // Séance
   appointment_type: 'individual' | 'couple' | 'family';
   appointment_mode: 'in-person' | 'video';
-  duration: 60 | 90;
+  duration: number;
   is_first_session: boolean;
 
   // Tarification (centimes)

--- a/supabase/migrations/004_google_calendar.sql
+++ b/supabase/migrations/004_google_calendar.sql
@@ -17,3 +17,6 @@ ALTER TABLE google_oauth_tokens ENABLE ROW LEVEL SECURITY;
 -- Link calendar events to appointments for lifecycle management
 ALTER TABLE appointments
   ADD COLUMN IF NOT EXISTS google_calendar_event_id TEXT;
+
+-- Reload PostgREST schema cache so google_oauth_tokens is immediately queryable
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/004_google_calendar.sql
+++ b/supabase/migrations/004_google_calendar.sql
@@ -1,0 +1,19 @@
+-- #36 Google Calendar production-ready integration
+-- Creates token storage table and adds google_calendar_event_id to appointments
+
+-- Token storage for OAuth rotation (singleton row: id = 'therapist')
+CREATE TABLE IF NOT EXISTS google_oauth_tokens (
+  id TEXT PRIMARY KEY DEFAULT 'therapist',
+  access_token TEXT NOT NULL,
+  refresh_token TEXT NOT NULL,
+  expiry_date BIGINT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- RLS: only service role can access (no public access needed)
+ALTER TABLE google_oauth_tokens ENABLE ROW LEVEL SECURITY;
+
+-- Link calendar events to appointments for lifecycle management
+ALTER TABLE appointments
+  ADD COLUMN IF NOT EXISTS google_calendar_event_id TEXT;

--- a/supabase/migrations/005_flexible_duration.sql
+++ b/supabase/migrations/005_flexible_duration.sql
@@ -1,0 +1,10 @@
+-- Migration 005: Flexible appointment duration
+-- Replaces the fixed CHECK (duration IN (60, 90)) constraint with a range check
+-- to support custom durations introduced in feat #38.
+
+ALTER TABLE appointments
+  DROP CONSTRAINT appointments_duration_check;
+
+ALTER TABLE appointments
+  ADD CONSTRAINT appointments_duration_check
+    CHECK (duration >= 15 AND duration <= 240);


### PR DESCRIPTION
## Summary

Implémente l'intégration Google Calendar complète et production-ready pour la prise de rendez-vous. Remplace la gestion statique du refresh token par une rotation persistée en base, ajoute la gestion du cycle de vie des événements (création/mise à jour/suppression), réduit le risque de timeout sur la génération Meet et introduit un cache de disponibilités via `@netlify/blobs`.

## Changes

### Auth — Token rotation persistée
- `getPersistedOAuthClient()` lit les tokens OAuth depuis la table Supabase `google_oauth_tokens`, rafraîchit proactivement à 5 min d'expiration, persiste le `refresh_token` rotatif si Google en retourne un
- Bootstrap automatique depuis les variables d'env au premier démarrage
- `CalendarAuthError` typé sur `invalid_grant` pour alerter en cas de révocation du consentement

### Erreurs typées + retry
- 4 sous-classes de `GoogleCalendarError` : `CalendarAuthError`, `CalendarPermissionError`, `CalendarQuotaError`, `CalendarNetworkError`
- `withCalendarRetry` : backoff exponentiel (1s, 2s) sur quota/réseau, pas de retry sur auth/permission
- Backward compat : `instanceof GoogleCalendarError` fonctionne pour tous les sous-types

### Cycle de vie des événements
- `updateCalendarEvent(eventId, patch)` via `events.patch()` — utilisé sur `accept_reschedule`
- `deleteCalendarEvent(eventId)` via `events.delete()` — appelé sur `decline`
- `pollMeetLink` réduit de 10→3 tentatives (15s→4.5s max, sous le timeout Netlify 10s)
- `google_calendar_event_id` stocké sur chaque confirmation/création admin
- Guard d'idempotence : création ignorée si l'ID existe déjà

### Cache disponibilits
- Nouveau module `src/lib/calendar-cache.ts` (`@netlify/blobs`)
- Clé stable : `available:{mode}:{duration}:{weeks}w:{YYYY-MM-DD lundi Paris}`
- TTL 10 min, invalidation synchrone sur toutes les mutations (confirm, decline, reschedule, accept_reschedule, admin create)
- Dégradation gracieuse : no-op si `GOOGLE_CALENDAR_MOCK=true` ou hors contexte Netlify

### Sécurité (findings audit P1)
- `err.cause` scrubé avant logging — empêche la fuite de `client_secret`/`refresh_token` via `GaxiosError` dans les agrégateurs de logs
- `accept_reschedule` retourne uniquement les colonnes nécessaires (exclut `therapist_notes`, `stripe_payment_intent_id`) — l'appelant est non-authentifié

### Migration SQL
- Table `google_oauth_tokens` (singleton `id='therapist'`, RLS service-role uniquement)
- `ALTER TABLE appointments ADD COLUMN google_calendar_event_id TEXT`

## Related
Closes #36

## Artifacts
- Frame: `artifacts/frames/36-google-calendar-production-ready-frame.md`
- Spec: `artifacts/specs/36-google-calendar-production-ready-spec.md` (17 ACs)
- Plan: `artifacts/plans/36-google-calendar-production-ready-plan.md`

## Testing
- [ ] Tests unitaires (non configurés dans ce repo)
- [x] Testé manuellement en mock mode (`GOOGLE_CALENDAR_MOCK=true`)
- [x] Lint ✅ (0 nouvelle erreur sur les fichiers modifiés)

## Quality Gate
- [x] `npm run lint` ✅ (0 erreur sur les fichiers modifiés)
- [x] Security audit ✅ (2 findings P1 corrigés dans ce PR)