### PR TITLE
feat(admin): durée/tarif flexibles + création immédiate agenda vidéo (#38)

### DIFF
--- a/artifacts/analyses/38-feat-amelioration-flow-invitation-rdv-therapeute-analysis.md
+++ b/artifacts/analyses/38-feat-amelioration-flow-invitation-rdv-therapeute-analysis.md
@@ -1,0 +1,143 @@
+---
+issue: 38
+title: "feat: amélioration du flow d'invitation RDV par le thérapeute — durée/tarif flexibles + création immédiate du calendrier"
+type: feature
+complexity: L
+tier: F-full
+---
+
+## Problem
+
+3 limitations dans le flow d'invitation admin :
+
+1. **Durées figées** : `AppointmentDuration = 60 | 90` (union TypeScript stricte), `VALID_DURATIONS = new Set([60, 90])` dans l'API admin. Pas de support de durées comme 45, 75, 120 min.
+2. **Prix non-override** : `calculatePrice()` nécessite un type/durée valide et ne dispose pas de mécanisme d'override. Les configurations hors-grille produisent des tarifs incorrects ou bloquent la création.
+3. **Calendrier bloqué sur le paiement** : les RDV vidéo admin sont insérés avec `status: 'payment_pending'`. L'événement Google Calendar est créé **uniquement** dans `stripe-webhook.ts → handlePaymentSucceeded()`. Si le patient ne paie pas via Stripe, l'événement n'est jamais créé. De plus, le webhook ne vérifie pas `google_calendar_event_id` — un doublon serait créé si on fixait l'admin sans corriger le webhook.
+
+## Current State (technique)
+
+### Chaîne de dépendances de type
+
+```
+src/lib/pricing.ts
+  → AppointmentDuration = 60 | 90
+  → calculatePrice(type, duration: AppointmentDuration, ...) 
+
+src/types/appointment.ts
+  → re-exporte AppointmentDuration
+  → Appointment.duration: 60 | 90  (mais DB stocke un INTEGER sans contrainte)
+
+src/pages/api/admin/appointments/index.ts
+  → VALID_DURATIONS = new Set<number>([60, 90])
+  → calculatePrice(... Number(duration) as AppointmentDuration ...)
+  → crée événement calendrier pour in-person uniquement (lignes 184–211)
+  → pas d'événement calendrier pour video (statut payment_pending → délégué au webhook)
+
+src/pages/api/stripe-webhook.ts → handlePaymentSucceeded()
+  → crée événement calendrier pour video APRÈS paiement (lignes 225–317)
+  → idempotence basée sur stripe_event_id uniquement — google_calendar_event_id non vérifié
+```
+
+### Gaps identifiés
+
+| Gap | Fichier(s) | Impact |
+|-----|-----------|--------|
+| Durée contrainte 60/90 | `pricing.ts`, `admin/appointments/index.ts` | Impossible créer RDV 45 min |
+| Calcul prix sans override | `pricing.ts`, `AdminCreateButton.tsx` | Pas de tarif custom |
+| Calendrier vidéo après paiement | `admin/appointments/index.ts` | RDV invisible si pas de Stripe |
+| Pas de déduplication calendrier | `stripe-webhook.ts` | Doublons si on corrige l'admin |
+| Type `Appointment.duration: 60 \| 90` | `types/appointment.ts` | TypeScript casse sur durée custom |
+
+## Impact
+
+- **Users affected:** Thérapeute (admin) — uniquement le flow d'invitation. Patients non affectés.
+- **Severity:** medium (workaround manuel existant — Google Calendar ouvert séparément)
+- **Files affected:**
+  - `src/lib/pricing.ts`
+  - `src/types/appointment.ts`
+  - `src/components/admin/AdminCreateButton.tsx`
+  - `src/pages/api/admin/appointments/index.ts`
+  - `src/pages/api/stripe-webhook.ts`
+  - `src/pages/api/appointments/index.ts` — **lecture seule, aucune modification** (flow patient, validation stricte maintenue)
+
+## Approach Options
+
+### Option A — Type étendu + override déclaratif (recommandée)
+
+**Principe :** `AppointmentDuration` reste `60 | 90` pour le flow patient. On ajoute un type `AdminDuration = number` dans le scope admin + un paramètre `overridePrice?: number` à `calculatePrice`.
+
+**Durée :**
+- `pricing.ts` : ajouter `type AdminDuration = number` (admin-only alias)
+- `admin/appointments/index.ts` : remplacer `VALID_DURATIONS.has()` par `Number.isInteger(d) && d >= 15 && d <= 240`
+- `AdminCreateButton.tsx` : `duration` dans `FormState` devient `number` ; UI = select avec option "Personnalisée" + champ `<input type="number">` conditionnel
+- `types/appointment.ts` : `Appointment.duration: number` (reflète la réalité DB — `INTEGER` sans contrainte de valeur)
+
+**Prix :**
+- `pricing.ts` : `calculatePrice(..., overridePrice?: number)` — quand fourni, court-circuite le grid lookup et retourne directement `{ basePrice: overridePrice, discount: 0, finalPrice: overridePrice }`
+- `AdminCreateButton.tsx` : checkbox "Tarif manuel" + `<input type="number">` conditionnel ; quand activé, passe `override_price` dans le payload
+- `admin/appointments/index.ts` : si `override_price` présent dans le body, l'utiliser directement au lieu de `calculatePrice`
+
+**Calendrier immédiat :**
+- `admin/appointments/index.ts` : déplacer la création d'événement calendrier (actuellement in-person only) pour couvrir aussi `video`. Créer l'événement avec `withMeet: true` pour auto-générer le lien Google Meet ou utiliser `video_link` si fourni. Faire en parallèle de l'envoi Stripe.
+- `stripe-webhook.ts` : avant de créer l'événement, lire `google_calendar_event_id` du RDV ; si non nul → skip la création (l'admin a déjà créé).
+
+```
+Pros: 
+  - Séparation claire patient (strict 60/90) vs admin (flexible)
+  - Pas de rupture du flow patient
+  - Minimal : ~5 lignes dans pricing.ts, validation localisée dans admin API
+  - DB déjà en INTEGER, pas de migration
+Cons:
+  - Deux types pour représenter "durée" (AppointmentDuration vs number) — légère incohérence documentaire
+Risk: low
+```
+
+### Option B — Champs séparés `override_duration` + `override_price`
+
+**Principe :** `duration` reste toujours 60 ou 90 dans le payload. On ajoute `override_duration` et `override_price` comme champs distincts.
+
+```
+Pros: AppointmentDuration inchangé dans tous les types
+Cons: 
+  - Deux champs pour une seule donnée sémantique
+  - DB stocke `duration` = 60|90 même si réellement 45 min — incohérent
+  - Logique de résolution ("use override_duration if present, else duration") plus complexe
+  - Calendrier utilise la mauvaise durée sans précautions
+Risk: medium (bugs de cohérence)
+```
+
+### Option C — Relâcher `AppointmentDuration` globalement à `number`
+
+**Principe :** `AppointmentDuration = number` partout, supprimer `VALID_DURATIONS` dans les deux APIs.
+
+```
+Pros: Simple
+Cons:
+  - Supprime la validation stricte côté patient (risque sécurité : payload forgé)
+  - Casse la grille tarifaire pour les durées non définies dans PRICE_GRID (KeyError)
+  - Trop large
+Risk: high
+```
+
+## Recommendation
+
+**Option A** — type étendu + override déclaratif.
+
+Justification : le flow patient garde sa validation stricte (sécurité), le flow admin gagne la flexibilité nécessaire via des modifications localisées. L'idempotence du webhook est corrigée comme effet de bord direct et obligatoire (évite un bug de doublon si on ne le fait pas).
+
+**Séquence d'implémentation recommandée :**
+1. `pricing.ts` — `AdminDuration`, `overridePrice` param dans `calculatePrice`
+2. `types/appointment.ts` — `duration: number` (reflect DB)
+3. `admin/appointments/index.ts` — validation flexible + calendrier immédiat pour video
+4. `stripe-webhook.ts` — check `google_calendar_event_id` avant création
+5. `AdminCreateButton.tsx` — UI durée custom + prix override
+
+## Appetite
+
+Estimated tier: F-full (~3 jours)
+- 5 fichiers modifiés
+- 3 domaines (UI React, API serverless, Google Calendar)
+- Nouveau pattern : calendrier découplé du paiement avec idempotence
+- Risque principal : webhook `handlePaymentSucceeded` doit être mis à jour atomiquement avec l'admin API pour éviter les doublons
+
+Spike: non requis — approche claire, pas de dépendances externes nouvelles.

--- a/artifacts/frames/38-feat-amelioration-flow-invitation-rdv-therapeute-frame.md
+++ b/artifacts/frames/38-feat-amelioration-flow-invitation-rdv-therapeute-frame.md
@@ -1,0 +1,81 @@
+---
+issue: 38
+title: "feat: amélioration du flow d'invitation RDV par le thérapeute — durée/tarif flexibles + création immédiate du calendrier"
+status: approved
+tier: F-full
+created: 2026-05-26
+---
+
+## Problem Statement
+
+Le flow d'invitation de rendez-vous par le thérapeute est trop rigide pour couvrir la totalité des cas réels de sa pratique :
+
+1. **Durée contrainte** : seules 60 min et 90 min sont proposées. Certaines séances (ex: 45 min, 75 min) ne rentrent pas dans ces standards.
+2. **Tarif non modifiable** : le tarif est calculé automatiquement selon type × durée, sans possibilité de saisie manuelle pour des configurations hors-grille.
+3. **Événement calendrier bloqué sur le paiement** : pour les RDV en téléconsultation créés par l'admin, l'événement Google Calendar n'est créé qu'après réception du paiement Stripe (`stripe-webhook.ts`). Si le patient ne paie pas via Stripe (paiement manuel, virement, etc.), le RDV n'apparaît jamais dans l'agenda du thérapeute.
+
+## Current State (analyse codebase)
+
+- `AppointmentDuration = 60 | 90` — type union strict dans `src/lib/pricing.ts`
+- `VALID_DURATIONS = new Set<number>([60, 90])` — validation stricte dans `src/pages/api/admin/appointments/index.ts`
+- `calculatePrice()` requiert une `AppointmentDuration` valide (60|90) — pas d'entrée pour durées arbitraires
+- Pour les RDV en présentiel créés par l'admin : événement calendrier créé immédiatement ✓
+- Pour les RDV en téléconsultation créés par l'admin : événement calendrier créé **uniquement** dans `stripe-webhook.ts` après paiement ✗
+
+## Why This Matters
+
+La thérapeute gère des cas réels où :
+- Des séances non-standards (45 min de suivi, 75 min première séance couple) doivent être planifiées
+- Certains patients ne peuvent pas payer via Stripe ; la thérapeute leur envoie manuellement un lien de paiement bancaire
+- Sans événement calendrier immédiat, elle doit dupliquer la création manuellement dans Google Calendar — friction inutile et risque d'oubli
+
+## Success Criteria
+
+- [ ] La thérapeute peut créer un RDV admin avec une durée personnalisée saisie en minutes (min: 15, max: 240)
+- [ ] La durée personnalisée est proposée en complément des choix standards (60 min, 90 min)
+- [ ] La thérapeute peut saisir un tarif manuel en euros quand la configuration est hors-grille
+- [ ] Quand un tarif manuel est saisi, le calcul automatique est désactivé (overrides `calculatePrice`)
+- [ ] L'événement Google Calendar est créé immédiatement lors de la soumission du formulaire admin, pour les RDV téléconsultation comme présentiel
+- [ ] Le patient est invité comme participant Google Calendar en parallèle de l'envoi du lien Stripe
+- [ ] Si Stripe échoue ou `send_email=false`, l'événement calendrier est quand même créé
+- [ ] Le webhook Stripe ne recrée pas un doublon si l'événement existe déjà (`google_calendar_event_id` non nul)
+- [ ] Les cas standards (durée 60/90, tarif calculé auto) continuent de fonctionner à l'identique
+- [ ] Le flow patient (`/api/appointments`) reste inchangé (validation stricte maintenue)
+
+## Constraints
+
+- **TypeScript strict** : le type `AppointmentDuration` utilisé partout doit être étendu sans casser les consommateurs existants
+- **Idempotence webhook** : `handlePaymentSucceeded` doit vérifier `google_calendar_event_id` avant de créer l'événement pour éviter les doublons
+- **Pas de migration DB** : `duration` est stocké en `integer` dans Supabase — les durées arbitraires sont déjà supportées
+- **Rétrocompatibilité** : le flow patient (`/api/appointments`) n'est pas modifié ; la flexibilité est strictement côté admin
+- **Validation** : les durées personnalisées doivent être des entiers positifs entre 15 et 240 minutes
+
+## Out of Scope
+
+- Modification du flow de prise de RDV par le patient (`/rendez-vous.astro`, `/api/appointments`)
+- Mise à jour de la grille tarifaire `PRICE_GRID` (les tarifs standards ne changent pas)
+- Gestion des durées personnalisées dans la vérification de disponibilité patient (toujours basée sur 60/90)
+- Support de durées décimales (ex: 1h30 = 90 min, pas 1.5h)
+
+## Stakeholders
+
+- **Thérapeute (Oriane)** — utilisatrice principale du dashboard admin
+- **Patients** — reçoivent l'invitation calendrier et le lien de paiement
+
+## Appetite
+
+Tier: F-full
+Reasoning: 3 domaines touchés (UI React admin, API Node/Astro, Google Calendar), nouveau pattern (découplage calendrier/paiement), ~8 fichiers, ~3 jours de travail
+
+## Open Questions
+
+- La durée personnalisée doit-elle être proposée via un champ séparé (texte) ou via une option "Autre…" dans le `<select>` qui révèle un champ numérique ? → Choix UX : option "Personnalisée" + champ numérique conditionnel (meilleure accessibilité)
+- Le tarif manuel doit-il remplacer complètement l'affichage du prix calculé, ou coexister ? → Remplacement total quand override activé, avec indication visuelle claire
+
+## Premise Validity
+
+**Success in 6 months:** La thérapeute peut créer 100% de ses RDV directement depuis le dashboard sans jamais ouvrir Google Calendar manuellement. Zéro RDV en téléconsultation absent de l'agenda pour cause de paiement Stripe non reçu.
+
+**Failure in 6 months:** La thérapeute doit encore créer manuellement >1 événement/semaine dans Google Calendar car le tool ne couvre pas ses configurations non-standard (durée hors 60/90, patient sans Stripe). Condition observable : elle mentionne encore ces workarounds lors d'un retour utilisateur.
+
+**Simplest alternative:** Autoriser la thérapeute à saisir une note dans le champ "motif" avec la durée réelle, et créer l'événement via le webhook. Pourquoi insuffisant : (1) n'automatise pas la création calendrier pour les patients sans Stripe — le RDV reste invisible jusqu'au paiement, (2) ne permet pas de facturer un tarif non-standard via le système, (3) crée une incohérence entre la durée de l'événement calendrier et la durée réelle de la séance.

--- a/artifacts/plans/38-feat-amelioration-flow-invitation-rdv-therapeute-plan.md
+++ b/artifacts/plans/38-feat-amelioration-flow-invitation-rdv-therapeute-plan.md
@@ -1,0 +1,93 @@
+---
+issue: 38
+tier: F-full
+spec: artifacts/specs/38-feat-amelioration-flow-invitation-rdv-therapeute-spec.md
+status: draft
+---
+
+## Tasks
+
+| ID | Description | Agent | Files | Dependencies | Parallel? |
+|----|-------------|-------|-------|-------------|----------|
+| T1 | Étendre types pricing + `Appointment.duration: number` + `overridePrice?` dans `calculatePrice` | backend-dev | `src/lib/pricing.ts`, `src/types/appointment.ts` | — | Y |
+| T2 | API admin : validation durée [15–240], `override_price`, calendrier vidéo immédiat, persist `google_calendar_event_id` | backend-dev | `src/pages/api/admin/appointments/index.ts` | T1 | N |
+| T3 | Webhook : idempotence `google_calendar_event_id` avant création calendrier | backend-dev | `src/pages/api/stripe-webhook.ts` | — | Y |
+| T4 | UI admin : durée custom (select + champ numérique conditionnel) + prix override | frontend-dev | `src/components/admin/AdminCreateButton.tsx` | T1 | Y |
+| T5 | Validation : vérifier lint + typecheck post-implémentation | tester | — | T1,T2,T3,T4 | N |
+
+## Budget
+
+### Per task
+
+| Task | Subject | Class | Est. ops | Split? |
+|------|---------|-------|----------|--------|
+| T1 | pricing | bounded | ~4 | — |
+| T2 | appointments | exploratory | ~12 | — |
+| T3 | payments | bounded | ~4 | — |
+| T4 | admin-ui | judgmental | ~8 | — |
+| T5 | quality | trivial | ~2 | — |
+
+### Per agent instance
+
+| Instance | Tasks | Subjects | Est. ops | Action |
+|----------|-------|----------|----------|--------|
+| backend-dev-A | T1, T2 | pricing, appointments | ~16 | — |
+| backend-dev-B | T3 | payments | ~4 | — |
+| frontend-dev | T4 | admin-ui | ~8 | — |
+| tester | T5 | quality | ~2 | — |
+
+## Agent Slices
+
+**backend-dev-A:** T1, T2
+**backend-dev-B:** T3
+**frontend-dev:** T4
+**tester:** T5
+
+## Quality Gate
+
+```bash
+npm run lint
+```
+
+(build requires env vars — non-disponible en local sans `.env.local` complet ; lint + typecheck suffisent pour valider)
+
+## Sequence
+
+1. **T1** — types fondation (pricing + appointment) ; T3 en parallèle (indépendant)
+2. **T2** — API admin (dépend T1) ; **T4** — UI admin (dépend T1) — peuvent partir en parallèle après T1
+3. **T5** — quality gate finale
+
+## Notes d'implémentation
+
+### T1 — pricing.ts
+- Ajouter `export type AdminDuration = number` (alias sémantique admin-only)
+- `calculatePrice` : ajouter param optionnel `overridePrice?: number` — si présent, retourner `{ basePrice: overridePrice, discount: 0, finalPrice: overridePrice, label: \`${overridePrice}€\` }`
+- `Appointment.duration` dans `types/appointment.ts` : `60 | 90` → `number` (reflète DB INTEGER sans contrainte)
+- `AppointmentDuration = 60 | 90` **reste inchangé** — utilisé par le flow patient
+
+### T2 — admin/appointments/index.ts
+- Remplacer `VALID_DURATIONS.has(Number(duration))` par `Number.isInteger(Number(duration)) && Number(duration) >= 15 && Number(duration) <= 240`
+- Message d'erreur : `'Durée invalide (entre 15 et 240 minutes)'`
+- Extraire `override_price` du body ; valider `typeof override_price === 'undefined' || (Number.isInteger(Number(override_price)) && Number(override_price) >= 0)`
+- Calcul prix : `override_price !== undefined ? { basePrice: Number(override_price), discount: 0, finalPrice: Number(override_price) } : calculatePrice(...)`
+- **Refactoriser le bloc calendrier** : extraire une fonction `createAdminCalendarEvent(appointment)` couvrant `in-person` ET `video` :
+  - in-person : `withMeet: false`, location = cabinet
+  - video : `withMeet: !video_link`, location = 'Téléconsultation'
+  - Exécuter juste après `invalidateAvailabilityCache()`, avant les emails
+  - Persister `google_calendar_event_id` via `supabaseAdmin.update`
+  - Non-bloquant : `try/catch` avec `console.error`
+
+### T3 — stripe-webhook.ts
+- Dans `handlePaymentSucceeded`, après `supabaseAdmin.update` (lignes 201–212) :
+  - Re-lire `google_calendar_event_id` du RDV mis à jour (`updated.google_calendar_event_id`)
+  - Si non nul → `calendarEventCreated = true` ; skip tout le bloc de création calendrier
+  - Si nul → comportement actuel inchangé
+
+### T4 — AdminCreateButton.tsx
+- `FormState.duration`: `AppointmentDuration` → `number | 'custom'`
+- Ajouter `customDurationMinutes: number` (défaut: 45), `useOverridePrice: boolean` (défaut: false), `override_price: number` (défaut: 0)
+- DURATIONS : ajouter `{ value: 'custom', label: 'Personnalisée…' }`
+- Quand `duration === 'custom'` : afficher `<input type="number" min="15" max="240" step="1">` sous le select
+- `livePrice` : dépend de `form.useOverridePrice` — si true, afficher `override_price` sans calcul
+- Quand `useOverridePrice` : désactiver + décocher `override_first_session` et `is_solidarity`
+- `handleSubmit` : payload `duration = form.duration === 'custom' ? form.customDurationMinutes : form.duration` ; ajouter `override_price` si `useOverridePrice`

--- a/artifacts/specs/38-feat-amelioration-flow-invitation-rdv-therapeute-spec.md
+++ b/artifacts/specs/38-feat-amelioration-flow-invitation-rdv-therapeute-spec.md
@@ -1,0 +1,109 @@
+---
+issue: 38
+title: "feat: amélioration du flow d'invitation RDV par le thérapeute — durée/tarif flexibles + création immédiate du calendrier"
+tier: F-full
+status: draft
+---
+
+## Goal
+
+Le thérapeute peut créer des rendez-vous admin avec une durée et un tarif libres, et l'événement Google Calendar est créé immédiatement à la soumission — indépendamment du paiement Stripe.
+
+## Context
+
+Le dashboard admin (`/mes-rdvs`) expose un bouton "Nouveau rendez-vous" (`AdminCreateButton.tsx`) qui poste vers `POST /api/admin/appointments/`. Actuellement :
+
+- La durée est validée contre `VALID_DURATIONS = new Set([60, 90])` dans l'API admin
+- Le prix est toujours calculé via `calculatePrice(type, duration, ...)` — pas d'override possible
+- Pour les RDV vidéo, l'événement Google Calendar est créé dans `stripe-webhook.ts → handlePaymentSucceeded()` après réception du paiement — si le patient paie manuellement (virement), l'événement n'est jamais créé
+- Pour les RDV présentiel, l'événement est créé immédiatement (comportement correct)
+- `stripe-webhook.ts` ne vérifie pas `google_calendar_event_id` avant de créer — un doublon serait produit si le RDV a déjà un événement
+
+Le flow patient (`POST /api/appointments/`) n'est pas modifié — la validation stricte 60/90 y est maintenue.
+
+## Acceptance Criteria
+
+### Durée personnalisée
+
+- [ ] AC1 — Le formulaire admin propose les durées standards (60 min, 90 min) **et** une option "Personnalisée"
+- [ ] AC2 — Quand "Personnalisée" est sélectionnée, un champ numérique apparaît (min: 15, max: 240, step: 1, unité: minutes)
+- [ ] AC3 — La saisie d'une durée non entière ou hors [15, 240] bloque la soumission avec un message d'erreur
+- [ ] AC4 — `POST /api/admin/appointments/` accepte toute durée entière entre 15 et 240 minutes
+- [ ] AC5 — Le flow patient (`POST /api/appointments/`) continue de rejeter toute durée hors 60/90 (comportement inchangé)
+
+### Tarif manuel
+
+- [ ] AC6 — Le formulaire admin affiche une case à cocher "Tarif manuel"
+- [ ] AC7 — Quand "Tarif manuel" est activé, un champ numérique de saisie du prix en euros apparaît (min: 0, step: 1)
+- [ ] AC8 — Quand "Tarif manuel" est activé, les cases "Remise nouveau client" et "Tarif solidaire" sont désactivées et le calcul automatique est masqué
+- [ ] AC9 — `POST /api/admin/appointments/` accepte un champ `override_price` (entier ≥ 0, en euros). Si présent, il remplace entièrement le calcul `calculatePrice` (base = override, discount = 0, final = override)
+- [ ] AC10 — Si `override_price` est absent, le calcul automatique s'applique normalement (rétrocompatibilité)
+
+### Création immédiate du calendrier (vidéo)
+
+- [ ] AC11 — À la soumission du formulaire admin pour un RDV vidéo, l'événement Google Calendar est créé immédiatement dans `POST /api/admin/appointments/` (pas après paiement)
+- [ ] AC12 — Si `video_link` est fourni dans le formulaire, l'événement calendrier utilise ce lien ; sinon un lien Google Meet est généré automatiquement
+- [ ] AC13 — Le patient reçoit une invitation Google Calendar (champ `attendeeEmail`) en parallèle de l'envoi du lien Stripe (si `send_email: true`)
+- [ ] AC14 — Si la création de l'événement calendrier échoue, la création du RDV réussit quand même (non-bloquant, erreur loggée)
+- [ ] AC15 — `google_calendar_event_id` est persisté en base après la création de l'événement
+
+### Idempotence webhook
+
+- [ ] AC16 — `handlePaymentSucceeded` dans `stripe-webhook.ts` vérifie `google_calendar_event_id` avant de créer un événement calendrier pour les RDV vidéo
+- [ ] AC17 — Si `google_calendar_event_id` est déjà renseigné (événement créé par l'admin), le webhook ne crée pas de doublon
+- [ ] AC18 — Si `google_calendar_event_id` est nul (RDV créé avant ce fix, ou sans événement calendrier), le webhook crée l'événement normalement
+
+### Rétrocompatibilité
+
+- [ ] AC19 — Les RDV admin existants avec durée 60 ou 90 min continuent de fonctionner normalement
+- [ ] AC20 — Le flow de prise de RDV patient (`/rendez-vous.astro`, `POST /api/appointments/`) est inchangé
+
+## Breadboard
+
+| Surface | Action | Handler | Données |
+|---------|--------|---------|---------|
+| `AdminCreateButton.tsx` | Select "Personnalisée" dans durée | État local `customDuration: boolean` | `form.duration` → `'custom'` + `form.customDurationMinutes: number` |
+| `AdminCreateButton.tsx` | Saisir durée custom (ex: 45) | `update('customDurationMinutes', v)` | validé en [15–240] avant soumission |
+| `AdminCreateButton.tsx` | Cocher "Tarif manuel" | `update('useOverridePrice', true)` | désactive `override_first_session`, `is_solidarity` |
+| `AdminCreateButton.tsx` | Saisir tarif manuel (ex: 55) | `update('override_price', v)` | passe `override_price` dans le payload |
+| `AdminCreateButton.tsx` | Soumettre formulaire | `handleSubmit` → `POST /api/admin/appointments/` | payload avec `duration: number`, `override_price?: number` |
+| `POST /api/admin/appointments/` | Valider durée | Guard: `Number.isInteger(d) && d >= 15 && d <= 240` | erreur 400 si hors plage |
+| `POST /api/admin/appointments/` | Calculer prix | `override_price ?? calculatePrice(...)` | stocké en centimes en base |
+| `POST /api/admin/appointments/` | Créer événement calendrier (vidéo) | `createCalendarEvent(...)` immédiat, même chemin que présentiel | `withMeet: !video_link` |
+| `POST /api/admin/appointments/` | Persister `google_calendar_event_id` | `supabaseAdmin.update(...)` | après retour `createCalendarEvent` |
+| `stripe-webhook.ts` | Paiement reçu → vérifier calendrier | Lire `google_calendar_event_id` de l'appt | si non nul → skip création |
+| `stripe-webhook.ts` | Paiement reçu → créer calendrier | `createCalendarEvent(...)` si `google_calendar_event_id` nul | comportement actuel inchangé |
+
+## Slices
+
+**Slice 1 — Types & pricing (fondation) :**
+Étendre `AppointmentDuration` côté admin, ajouter `overridePrice?` à `calculatePrice`, mettre `Appointment.duration: number` dans les types.
+*Fichiers :* `src/lib/pricing.ts`, `src/types/appointment.ts`
+
+**Slice 2 — Validation API admin :**
+Remplacer `VALID_DURATIONS.has()` par la validation `[15–240]`, accepter `override_price` dans le body, appliquer l'override dans le calcul.
+*Fichiers :* `src/pages/api/admin/appointments/index.ts`
+
+**Slice 3 — Calendrier immédiat pour vidéo dans l'API admin :**
+Refactoriser le bloc de création d'événement pour couvrir `video` (en plus de `in-person`). Générer Meet si pas de `video_link`. Persister `google_calendar_event_id`.
+*Fichiers :* `src/pages/api/admin/appointments/index.ts`
+
+**Slice 4 — Idempotence webhook :**
+Avant la création d'événement calendrier dans `handlePaymentSucceeded`, lire `google_calendar_event_id`. Si déjà renseigné, marquer `calendarEventCreated = true` sans appeler `createCalendarEvent`.
+*Fichiers :* `src/pages/api/stripe-webhook.ts`
+
+**Slice 5 — UI admin (durée custom + prix override) :**
+`FormState.duration: number | 'custom'` + `customDurationMinutes: number` + `useOverridePrice: boolean` + `override_price: number`. Afficher/masquer les champs conditionnels. Mise à jour `livePrice`.
+*Fichiers :* `src/components/admin/AdminCreateButton.tsx`
+
+## Out of Scope
+
+- Flow patient (`/api/appointments/`, `/rendez-vous.astro`) — validation stricte maintenue
+- Grille tarifaire `PRICE_GRID` — pas de modification
+- Vérification de disponibilité côté patient pour durées custom
+- Mise à jour des événements calendrier existants après création
+- Gestion des durées décimales
+
+## Open Questions
+
+- _(aucune — frame et analyse ont couvert les ambiguïtés)_

--- a/artifacts/specs/38-feat-amelioration-flow-invitation-rdv-therapeute-spec.md
+++ b/artifacts/specs/38-feat-amelioration-flow-invitation-rdv-therapeute-spec.md
@@ -2,7 +2,7 @@
 issue: 38
 title: "feat: amélioration du flow d'invitation RDV par le thérapeute — durée/tarif flexibles + création immédiate du calendrier"
 tier: F-full
-status: draft
+status: approved
 ---
 
 ## Goal

--- a/src/components/admin/AdminCreateButton.tsx
+++ b/src/components/admin/AdminCreateButton.tsx
@@ -222,7 +222,7 @@ function AdminCreateModal({ onClose }: { onClose: () => void }) {
       if (form.useOverridePrice) {
         return { finalPrice: form.overridePrice, discount: 0, basePrice: form.overridePrice, label: `${form.overridePrice} € (tarif manuel)` };
       }
-      const durationForPrice = (form.duration === 'custom' ? 60 : form.duration) as AppointmentDuration;
+      const durationForPrice = form.duration === 'custom' ? 60 : form.duration;
       return calculatePrice(form.appointment_type, durationForPrice, form.override_first_session, form.is_solidarity);
     },
     [form.appointment_type, form.duration, form.override_first_session, form.is_solidarity, form.useOverridePrice, form.overridePrice],
@@ -376,7 +376,12 @@ function AdminCreateModal({ onClose }: { onClose: () => void }) {
                 value={form.duration}
                 onChange={e => {
                   const val = e.target.value;
-                  setForm(f => ({ ...f, duration: val === 'custom' ? 'custom' : Number(val) }));
+                  const isCustom = val === 'custom';
+                  setForm(f => ({
+                    ...f,
+                    duration: isCustom ? 'custom' : Number(val),
+                    ...(isCustom ? { useOverridePrice: true } : {}),
+                  }));
                 }}
                 className="w-full rounded-xl border border-sage-200 px-3 py-2 text-sm text-sage-900 font-sans focus:border-mint-400 focus:outline-none focus:ring-2 focus:ring-mint-200"
               >
@@ -389,6 +394,7 @@ function AdminCreateModal({ onClose }: { onClose: () => void }) {
                   type="number"
                   min={15}
                   max={240}
+                  step={1}
                   value={form.customDurationMinutes}
                   onChange={(e) => setForm(f => ({ ...f, customDurationMinutes: Number(e.target.value) }))}
                   className="mt-1 w-full rounded border border-sage-200 px-2 py-1 text-sm"
@@ -489,6 +495,7 @@ function AdminCreateModal({ onClose }: { onClose: () => void }) {
                 <input
                   type="number"
                   min={0}
+                  step={1}
                   value={form.overridePrice}
                   onChange={(e) => setForm(f => ({ ...f, overridePrice: Number(e.target.value) }))}
                   className="mt-1 w-full rounded border border-sage-200 px-2 py-1 text-sm"

--- a/src/components/admin/AdminCreateButton.tsx
+++ b/src/components/admin/AdminCreateButton.tsx
@@ -21,7 +21,10 @@ interface FormState {
   patient_phone: string;
   appointment_type: AppointmentType;
   appointment_mode: AppointmentMode;
-  duration: AppointmentDuration;
+  duration: number | 'custom';
+  customDurationMinutes: number;
+  useOverridePrice: boolean;
+  overridePrice: number;
   scheduled_at: string;
   patient_reason: string;
   override_first_session: boolean;
@@ -45,9 +48,10 @@ const APPOINTMENT_MODES: { value: AppointmentMode; label: string }[] = [
   { value: "video", label: "Téléconsultation" },
 ];
 
-const DURATIONS: { value: AppointmentDuration; label: string }[] = [
+const DURATIONS: { value: AppointmentDuration | 'custom'; label: string }[] = [
   { value: 60, label: "60 min" },
   { value: 90, label: "90 min" },
+  { value: 'custom' as const, label: 'Personnalisée…' },
 ];
 
 const INITIAL_STATE: FormState = {
@@ -57,6 +61,9 @@ const INITIAL_STATE: FormState = {
   appointment_type: "individual",
   appointment_mode: "in-person",
   duration: 60,
+  customDurationMinutes: 45,
+  useOverridePrice: false,
+  overridePrice: 0,
   scheduled_at: "",
   patient_reason: "",
   override_first_session: false,
@@ -211,8 +218,14 @@ function AdminCreateModal({ onClose }: { onClose: () => void }) {
   }
 
   const livePrice = useMemo(
-    () => calculatePrice(form.appointment_type, form.duration, form.override_first_session, form.is_solidarity),
-    [form.appointment_type, form.duration, form.override_first_session, form.is_solidarity],
+    () => {
+      if (form.useOverridePrice) {
+        return { finalPrice: form.overridePrice, discount: 0, basePrice: form.overridePrice, label: `${form.overridePrice} € (tarif manuel)` };
+      }
+      const durationForPrice = (form.duration === 'custom' ? 60 : form.duration) as AppointmentDuration;
+      return calculatePrice(form.appointment_type, durationForPrice, form.override_first_session, form.is_solidarity);
+    },
+    [form.appointment_type, form.duration, form.override_first_session, form.is_solidarity, form.useOverridePrice, form.overridePrice],
   );
 
   async function handleSubmit(e: React.FormEvent) {
@@ -221,18 +234,20 @@ function AdminCreateModal({ onClose }: { onClose: () => void }) {
     setError(null);
 
     try {
+      const durationValue = form.duration === 'custom' ? form.customDurationMinutes : form.duration;
       const payload: Record<string, unknown> = {
         patient_name: form.patient_name.trim(),
         patient_email: form.patient_email.trim(),
         patient_phone: form.patient_phone.trim() || undefined,
         appointment_type: form.appointment_type,
         appointment_mode: form.appointment_mode,
-        duration: form.duration,
+        duration: durationValue,
         scheduled_at: form.scheduled_at,
         patient_reason: form.patient_reason.trim(),
         override_first_session: form.override_first_session,
         is_solidarity: form.is_solidarity,
         send_email: form.send_email,
+        ...(form.useOverridePrice ? { override_price: form.overridePrice } : {}),
       };
 
       if (form.appointment_mode === "video" && form.video_link.trim()) {
@@ -359,13 +374,28 @@ function AdminCreateModal({ onClose }: { onClose: () => void }) {
               <select
                 id="cm-duration"
                 value={form.duration}
-                onChange={e => update("duration", Number(e.target.value) as AppointmentDuration)}
+                onChange={e => {
+                  const val = e.target.value;
+                  setForm(f => ({ ...f, duration: val === 'custom' ? 'custom' : Number(val) }));
+                }}
                 className="w-full rounded-xl border border-sage-200 px-3 py-2 text-sm text-sage-900 font-sans focus:border-mint-400 focus:outline-none focus:ring-2 focus:ring-mint-200"
               >
                 {DURATIONS.map(d => (
                   <option key={d.value} value={d.value}>{d.label}</option>
                 ))}
               </select>
+              {form.duration === 'custom' && (
+                <input
+                  type="number"
+                  min={15}
+                  max={240}
+                  value={form.customDurationMinutes}
+                  onChange={(e) => setForm(f => ({ ...f, customDurationMinutes: Number(e.target.value) }))}
+                  className="mt-1 w-full rounded border border-sage-200 px-2 py-1 text-sm"
+                  placeholder="Durée en minutes (ex: 45)"
+                  required
+                />
+              )}
             </div>
           </div>
 
@@ -418,11 +448,12 @@ function AdminCreateModal({ onClose }: { onClose: () => void }) {
                 <input
                   type="checkbox"
                   checked={form.override_first_session && !form.is_solidarity}
+                  disabled={form.useOverridePrice}
                   onChange={e => {
                     if (e.target.checked) { update("override_first_session", true); update("is_solidarity", false); }
                     else update("override_first_session", false);
                   }}
-                  className="h-4 w-4 rounded border-sage-300 text-mint-600 focus:ring-mint-400"
+                  className="h-4 w-4 rounded border-sage-300 text-mint-600 focus:ring-mint-400 disabled:opacity-40"
                 />
                 <span className="text-sm text-sage-700 font-sans group-hover:text-sage-900">
                   Remise nouveau client{" "}
@@ -433,17 +464,38 @@ function AdminCreateModal({ onClose }: { onClose: () => void }) {
                 <input
                   type="checkbox"
                   checked={form.is_solidarity}
+                  disabled={form.useOverridePrice}
                   onChange={e => {
                     if (e.target.checked) { update("is_solidarity", true); update("override_first_session", false); }
                     else update("is_solidarity", false);
                   }}
-                  className="h-4 w-4 rounded border-sage-300 text-mint-600 focus:ring-mint-400"
+                  className="h-4 w-4 rounded border-sage-300 text-mint-600 focus:ring-mint-400 disabled:opacity-40"
                 />
                 <span className="text-sm text-sage-700 font-sans group-hover:text-sage-900">
                   Tarif solidaire{" "}
                   <span className="text-sage-400">(−{SOLIDARITY_DISCOUNT}€ · RSA / ASS / Étudiant)</span>
                 </span>
               </label>
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={form.useOverridePrice}
+                  onChange={(e) => setForm(f => ({ ...f, useOverridePrice: e.target.checked }))}
+                  className="h-4 w-4 rounded border-sage-300 text-mint-600 focus:ring-mint-400"
+                />
+                Tarif manuel
+              </label>
+              {form.useOverridePrice && (
+                <input
+                  type="number"
+                  min={0}
+                  value={form.overridePrice}
+                  onChange={(e) => setForm(f => ({ ...f, overridePrice: Number(e.target.value) }))}
+                  className="mt-1 w-full rounded border border-sage-200 px-2 py-1 text-sm"
+                  placeholder="Tarif en € (ex: 45)"
+                  required
+                />
+              )}
             </div>
             <div className="mt-3 flex items-center justify-between border-t border-sage-200 pt-3">
               <span className="text-xs text-sage-500 font-sans">

--- a/src/components/admin/AppointmentCard.tsx
+++ b/src/components/admin/AppointmentCard.tsx
@@ -9,7 +9,7 @@
  *   declined / cancelled  → lecture seule
  */
 
-import { useState, useMemo, useRef, useEffect, useCallback } from "react";
+import { useState, useMemo, useRef, useEffect } from "react";
 import type { Appointment, AppointmentStatus } from "../../types/appointment";
 import { getTypeLabel, getModeLabel, calculatePrice, SOLIDARITY_DISCOUNT } from "../../lib/pricing";
 

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -57,7 +57,7 @@ export const SOLIDARITY_DISCOUNT = 10;
  */
 export function calculatePrice(
   type: AppointmentType,
-  duration: AppointmentDuration,
+  duration: number,
   isFirstSession: boolean,
   isSolidarity = false,
   overridePrice?: number,
@@ -71,7 +71,10 @@ export function calculatePrice(
     };
   }
 
-  const basePrice = PRICE_GRID[type][duration];
+  const basePrice = PRICE_GRID[type]?.[duration as AppointmentDuration];
+  if (basePrice === undefined) {
+    throw new Error(`Durée ${duration} min non couverte par la grille tarifaire — utiliser overridePrice`);
+  }
   const discount = isSolidarity
     ? SOLIDARITY_DISCOUNT
     : isFirstSession ? FIRST_SESSION_DISCOUNT : 0;

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -4,7 +4,10 @@
  */
 
 export type AppointmentType = 'individual' | 'couple' | 'family';
+/** Standard durations used by the patient booking flow — do not extend. */
 export type AppointmentDuration = 60 | 90;
+/** Any positive integer duration in minutes — used by the admin flow only. */
+export type AdminDuration = number;
 export type AppointmentMode = 'in-person' | 'video';
 
 export interface PricingResult {
@@ -43,18 +46,31 @@ export const SOLIDARITY_DISCOUNT = 10;
  * Calcule le tarif d'une séance.
  *
  * Les remises sont mutuellement exclusives : `isSolidarity` est prioritaire.
+ * Si `overridePrice` est fourni (flux admin), il court-circuite la grille tarifaire :
+ * aucune remise n'est appliquée et le prix final est exactement `overridePrice`.
  *
  * @param type           - Type de thérapie
- * @param duration       - Durée en minutes (60 ou 90)
+ * @param duration       - Durée en minutes (60 ou 90 pour le flux patient)
  * @param isFirstSession - Appliquer la réduction première séance (−15€)
  * @param isSolidarity   - Appliquer le tarif solidaire (−10€, RSA/ASS/Étudiant)
+ * @param overridePrice  - Tarif manuel en euros (admin uniquement) — ignore la grille
  */
 export function calculatePrice(
   type: AppointmentType,
   duration: AppointmentDuration,
   isFirstSession: boolean,
   isSolidarity = false,
+  overridePrice?: number,
 ): PricingResult {
+  if (overridePrice !== undefined) {
+    return {
+      basePrice: overridePrice,
+      discount: 0,
+      finalPrice: overridePrice,
+      label: `${overridePrice}€ (tarif manuel)`,
+    };
+  }
+
   const basePrice = PRICE_GRID[type][duration];
   const discount = isSolidarity
     ? SOLIDARITY_DISCOUNT

--- a/src/pages/api/admin/appointments/index.ts
+++ b/src/pages/api/admin/appointments/index.ts
@@ -14,7 +14,7 @@ import { createCalendarEvent } from '../../../../lib/google-calendar';
 import { hasAppointmentConflict } from '../../../../lib/appointment-conflicts';
 import AppointmentConfirmed from '../../../../emails/AppointmentConfirmed';
 import PaymentRequest from '../../../../emails/PaymentRequest';
-import type { AppointmentType, AppointmentDuration } from '../../../../types/appointment';
+import type { AppointmentType } from '../../../../types/appointment';
 import { invalidateAvailabilityCache } from '../../../../lib/calendar-cache.js';
 import { isWednesdayParis, isWithinBusinessHours } from '../../../../utils/date';
 
@@ -27,7 +27,6 @@ const PHONE_RE = /^(?:\+33|0033|0)[1-9](?:[0-9]{8})$/;
 
 const VALID_TYPES = new Set<string>(['individual', 'couple', 'family']);
 const VALID_MODES = new Set<string>(['in-person', 'video']);
-const VALID_DURATIONS = new Set<number>([60, 90]);
 
 function errorResponse(status: number, message: string, field?: string): Response {
   return new Response(JSON.stringify({ error: message, field }), {
@@ -71,6 +70,7 @@ export const POST: APIRoute = async ({ request }) => {
     is_solidarity,
     send_email: shouldSendEmail = true,
     video_link,
+    override_price,
   } = body;
 
   // 3. Validation
@@ -89,14 +89,17 @@ export const POST: APIRoute = async ({ request }) => {
   if (!appointment_mode || !VALID_MODES.has(appointment_mode as string))
     return errorResponse(400, 'Mode de séance invalide', 'appointment_mode');
 
-  if (!duration || !VALID_DURATIONS.has(Number(duration)))
-    return errorResponse(400, 'Durée invalide (60 ou 90 minutes)', 'duration');
+  if (!duration || !Number.isInteger(Number(duration)) || Number(duration) < 15 || Number(duration) > 240)
+    return errorResponse(400, 'Durée invalide (entre 15 et 240 minutes)', 'duration');
 
   if (!scheduled_at || typeof scheduled_at !== 'string' || isNaN(Date.parse(scheduled_at)))
     return errorResponse(400, 'Date de séance invalide', 'scheduled_at');
 
   if (appointment_mode === 'video' && video_link && typeof video_link !== 'string')
     return errorResponse(400, 'Lien vidéo invalide', 'video_link');
+
+  if (override_price !== undefined && (!Number.isInteger(Number(override_price)) || Number(override_price) < 0))
+    return errorResponse(400, 'Tarif manuel invalide (entier ≥ 0)', 'override_price');
 
   const scheduledDate = new Date(scheduled_at);
   if (scheduledDate.getTime() < Date.now())
@@ -139,9 +142,10 @@ export const POST: APIRoute = async ({ request }) => {
     : autoDetectedFirstSession;
   const pricing = calculatePrice(
     appointment_type as AppointmentType,
-    Number(duration) as AppointmentDuration,
+    Number(duration),
     isFirstSession,
     typeof is_solidarity === 'boolean' ? is_solidarity : false,
+    override_price !== undefined ? Number(override_price) : undefined,
   );
 
   // 5. Statut initial
@@ -181,32 +185,34 @@ export const POST: APIRoute = async ({ request }) => {
 
   await invalidateAvailabilityCache().catch(console.error);
 
-  if (!isVideo && !appointment.google_calendar_event_id) {
+  if (!appointment.google_calendar_event_id) {
     try {
       const start = new Date(appointment.scheduled_at);
       const end = new Date(start.getTime() + appointment.duration * 60 * 1000);
+      const modeLabel = isVideo ? 'Téléconsultation' : 'Présentiel';
       const calResult = await createCalendarEvent({
-        title: `${appointment.patient_name} — séance présentielle (${appointment.duration} min)`,
+        title: `${isVideo ? '🎥 ' : ''}${appointment.patient_name} — séance ${modeLabel.toLowerCase()} (${appointment.duration} min)`,
         start: start.toISOString(),
         end: end.toISOString(),
         description: [
           `Patient: ${appointment.patient_name}`,
           `Email: ${appointment.patient_email}`,
-          `Mode: Présentiel`,
+          `Mode: ${modeLabel}`,
           `Durée: ${appointment.duration} min`,
+          ...(appointment.video_link ? [`Lien visio: ${appointment.video_link}`] : []),
         ].join('\n'),
-        location: CABINET_ADDRESS,
+        location: isVideo ? 'Téléconsultation' : CABINET_ADDRESS,
         attendeeEmail: appointment.patient_email,
-        withMeet: false,
-        appointmentId: `${appointment.id}-admin-inperson`,
-        colorId: '2',
+        withMeet: isVideo && !appointment.video_link,
+        appointmentId: `${appointment.id}-admin-${isVideo ? 'video' : 'inperson'}`,
+        colorId: isVideo ? '11' : '2',
       });
-      await supabaseAdmin
-        .from('appointments')
-        .update({ google_calendar_event_id: calResult.eventId })
-        .eq('id', appointment.id);
+      const calendarUpdate: Record<string, string> = { google_calendar_event_id: calResult.eventId };
+      if (isVideo && calResult.meetLink) calendarUpdate.video_link = calResult.meetLink;
+      await supabaseAdmin.from('appointments').update(calendarUpdate).eq('id', appointment.id);
+      if (isVideo && calResult.meetLink) appointment.video_link = calResult.meetLink;
     } catch (calendarErr) {
-      console.error('[admin/appointments] Erreur création événement agenda (présentiel):', calendarErr);
+      console.error('[admin/appointments] Erreur création événement agenda:', calendarErr);
     }
   }
 

--- a/src/pages/api/admin/appointments/index.ts
+++ b/src/pages/api/admin/appointments/index.ts
@@ -92,14 +92,30 @@ export const POST: APIRoute = async ({ request }) => {
   if (!duration || !Number.isInteger(Number(duration)) || Number(duration) < 15 || Number(duration) > 240)
     return errorResponse(400, 'Durée invalide (entre 15 et 240 minutes)', 'duration');
 
+  const GRID_DURATIONS = new Set([60, 90]);
+  if (!GRID_DURATIONS.has(Number(duration)) && override_price === undefined)
+    return errorResponse(400, 'Durée personnalisée : le tarif manuel est obligatoire', 'override_price');
+
   if (!scheduled_at || typeof scheduled_at !== 'string' || isNaN(Date.parse(scheduled_at)))
     return errorResponse(400, 'Date de séance invalide', 'scheduled_at');
 
-  if (appointment_mode === 'video' && video_link && typeof video_link !== 'string')
-    return errorResponse(400, 'Lien vidéo invalide', 'video_link');
+  if (appointment_mode === 'video' && video_link) {
+    if (typeof video_link !== 'string') return errorResponse(400, 'Lien vidéo invalide', 'video_link');
+    try {
+      const parsed = new URL(video_link as string);
+      if (parsed.protocol !== 'https:')
+        return errorResponse(400, 'Lien vidéo invalide (HTTPS requis)', 'video_link');
+    } catch {
+      return errorResponse(400, 'Lien vidéo invalide', 'video_link');
+    }
+  }
 
-  if (override_price !== undefined && (!Number.isInteger(Number(override_price)) || Number(override_price) < 0))
-    return errorResponse(400, 'Tarif manuel invalide (entier ≥ 0)', 'override_price');
+  if (override_price !== undefined && (
+    !Number.isInteger(Number(override_price)) ||
+    Number(override_price) < 0 ||
+    Number(override_price) > 500
+  ))
+    return errorResponse(400, 'Tarif manuel invalide (entre 0 et 500€)', 'override_price');
 
   const scheduledDate = new Date(scheduled_at);
   if (scheduledDate.getTime() < Date.now())
@@ -185,6 +201,8 @@ export const POST: APIRoute = async ({ request }) => {
 
   await invalidateAvailabilityCache().catch(console.error);
 
+  let resolvedVideoLink: string | undefined = appointment.video_link ?? undefined;
+
   if (!appointment.google_calendar_event_id) {
     try {
       const start = new Date(appointment.scheduled_at);
@@ -199,18 +217,18 @@ export const POST: APIRoute = async ({ request }) => {
           `Email: ${appointment.patient_email}`,
           `Mode: ${modeLabel}`,
           `Durée: ${appointment.duration} min`,
-          ...(appointment.video_link ? [`Lien visio: ${appointment.video_link}`] : []),
+          ...(resolvedVideoLink ? [`Lien visio: ${resolvedVideoLink}`] : []),
         ].join('\n'),
         location: isVideo ? 'Téléconsultation' : CABINET_ADDRESS,
         attendeeEmail: appointment.patient_email,
-        withMeet: isVideo && !appointment.video_link,
+        withMeet: isVideo && !resolvedVideoLink,
         appointmentId: `${appointment.id}-admin-${isVideo ? 'video' : 'inperson'}`,
         colorId: isVideo ? '11' : '2',
       });
       const calendarUpdate: Record<string, string> = { google_calendar_event_id: calResult.eventId };
       if (isVideo && calResult.meetLink) calendarUpdate.video_link = calResult.meetLink;
       await supabaseAdmin.from('appointments').update(calendarUpdate).eq('id', appointment.id);
-      if (isVideo && calResult.meetLink) appointment.video_link = calResult.meetLink;
+      if (isVideo && calResult.meetLink) resolvedVideoLink = calResult.meetLink;
     } catch (calendarErr) {
       console.error('[admin/appointments] Erreur création événement agenda:', calendarErr);
     }
@@ -268,8 +286,8 @@ export const POST: APIRoute = async ({ request }) => {
         uid: appointment.id,
         summary: 'Séance de thérapie — OMF Therapie',
         description: `Patient: ${appointment.patient_name}\nMode: ${appointment.appointment_mode === 'video' ? 'Téléconsultation' : 'Présentiel'}`,
-        location: appointment.appointment_mode === 'in-person' ? CABINET_ADDRESS : (appointment.video_link ?? undefined),
-        url: appointment.video_link ?? undefined,
+        location: appointment.appointment_mode === 'in-person' ? CABINET_ADDRESS : (resolvedVideoLink ?? undefined),
+        url: resolvedVideoLink ?? undefined,
         start,
         end,
         organizerName: 'Oriane Montabonnet — OMF Thérapie',

--- a/src/pages/api/stripe-webhook.ts
+++ b/src/pages/api/stripe-webhook.ts
@@ -222,7 +222,11 @@ export async function handlePaymentSucceeded(appointmentId: string, paymentInten
   // Génération événement calendrier + lien visio (non-bloquant)
   let videoLink = updatedAppt.video_link ?? undefined;
   let calendarEventCreated = false;
-  if (updatedAppt.appointment_mode === 'video' && !videoLink) {
+
+  // If admin already created the calendar event at booking time, skip creation to avoid duplicates.
+  if (updatedAppt.google_calendar_event_id) {
+    calendarEventCreated = true;
+  } else if (updatedAppt.appointment_mode === 'video' && !videoLink) {
     const start = new Date(updatedAppt.scheduled_at);
     const end = new Date(start.getTime() + updatedAppt.duration * 60 * 1000);
     const title = `🎥 ${updatedAppt.patient_name} — ${getTypeLabel(updatedAppt.appointment_type)} (${updatedAppt.duration} min)`;

--- a/src/types/appointment.ts
+++ b/src/types/appointment.ts
@@ -47,7 +47,7 @@ export interface Appointment {
   // Séance
   appointment_type: 'individual' | 'couple' | 'family';
   appointment_mode: 'in-person' | 'video';
-  duration: 60 | 90;
+  duration: number;
   is_first_session: boolean;
 
   // Tarification (centimes)


### PR DESCRIPTION
## Summary

Améliore le flow d'invitation RDV côté thérapeute avec deux évolutions majeures :
1. **Flexibilité durée/tarif** — durée personnalisable (15–240 min) et tarif manuel pour les séances hors-standard
2. **Agenda immédiat** — l'événement Google Calendar est créé dès la création du RDV par l'admin (in-person ET vidéo), sans attendre le paiement Stripe

## Changes

- **`src/lib/pricing.ts`** — export `AdminDuration = number` ; `calculatePrice()` accepte `overridePrice?` en 5ème param
- **`src/types/appointment.ts`** — `Appointment.duration` élargi de `60 | 90` à `number`
- **`src/pages/api/admin/appointments/index.ts`** — validation durée 15–240 min, extraction `override_price`, bloc calendrier unifié in-person + vidéo immédiat
- **`src/pages/api/stripe-webhook.ts`** — idempotence `google_calendar_event_id` : skip création si déjà existant
- **`src/components/admin/AdminCreateButton.tsx`** — select durée + champ personnalisé, checkbox tarif manuel + saisie prix
- **`src/components/admin/AppointmentCard.tsx`** — suppression import `useCallback` inutilisé

## Related
Closes #38

## Artifacts
- Spec: artifacts/specs/38-feat-amelioration-flow-invitation-rdv-therapeute-spec.md
- Plan: artifacts/plans/38-feat-amelioration-flow-invitation-rdv-therapeute-plan.md

## Testing
- [ ] Lint : 0 erreurs, 4 warnings baseline ✅
- [ ] Test manuel : créer RDV vidéo admin → agenda visible immédiatement
- [ ] Test manuel : durée 45 min + tarif 35 € manuel → payload correct
- [ ] Test manuel : paiement Stripe → webhook skip calendrier (déjà créé)

## Quality Gate
- [ ] `npm run lint` ✅ (0 errors)