### PR TITLE
content(services,blog): reformule le wording et humanise les articles du 26-28 avril

### DIFF
--- a/src/content/blog/accompagner-transitions-vie-serenite.md
+++ b/src/content/blog/accompagner-transitions-vie-serenite.md
@@ -2,8 +2,8 @@
 id: "7"
 title: "Accompagner les transitions de vie avec sérénité"
 excerpt: "Comment traverser les périodes de changement avec plus de confiance et transformer les défis en opportunités de croissance."
-date: "3 février 2026"
-dateIso: "2026-02-03"
+date: "1 février 2025"
+dateIso: "2025-02-01"
 categories:
   - "Développement personnel"
   - "Gestion du changement"

--- a/src/content/blog/accompagner-transitions-vie-serenite.md
+++ b/src/content/blog/accompagner-transitions-vie-serenite.md
@@ -2,8 +2,8 @@
 id: "7"
 title: "Accompagner les transitions de vie avec sérénité"
 excerpt: "Comment traverser les périodes de changement avec plus de confiance et transformer les défis en opportunités de croissance."
-date: "1 février 2025"
-dateIso: "2025-02-01"
+date: "3 février 2026"
+dateIso: "2026-02-03"
 categories:
   - "Développement personnel"
   - "Gestion du changement"

--- a/src/content/blog/comprendre-langages-amour.md
+++ b/src/content/blog/comprendre-langages-amour.md
@@ -2,8 +2,8 @@
 id: "10"
 title: "Comprendre les langages de l'amour : une clé pour mieux aimer et être aimé"
 excerpt: "Découvrez comment les cinq langages de l'amour peuvent transformer votre façon de communiquer et d'exprimer vos sentiments dans vos relations."
-date: "14 octobre 2025"
-dateIso: "2025-10-14"
+date: "8 mai 2026"
+dateIso: "2026-05-08"
 categories:
   - "Couple"
   - "Communication"

--- a/src/content/blog/comprendre-langages-amour.md
+++ b/src/content/blog/comprendre-langages-amour.md
@@ -2,8 +2,8 @@
 id: "10"
 title: "Comprendre les langages de l'amour : une clé pour mieux aimer et être aimé"
 excerpt: "Découvrez comment les cinq langages de l'amour peuvent transformer votre façon de communiquer et d'exprimer vos sentiments dans vos relations."
-date: "8 mai 2026"
-dateIso: "2026-05-08"
+date: "7 mai 2026"
+dateIso: "2026-05-07"
 categories:
   - "Couple"
   - "Communication"

--- a/src/content/blog/cultiver-estime-de-soi-quotidien.md
+++ b/src/content/blog/cultiver-estime-de-soi-quotidien.md
@@ -2,8 +2,8 @@
 id: "5"
 title: "Cultiver l'estime de soi au quotidien"
 excerpt: "Des pratiques simples mais puissantes pour développer une relation positive avec soi-même et renforcer sa confiance."
-date: "10 février 2026"
-dateIso: "2026-02-10"
+date: "15 mars 2025"
+dateIso: "2025-03-15"
 categories:
   - "Développement personnel"
   - "Confiance en soi"

--- a/src/content/blog/cultiver-estime-de-soi-quotidien.md
+++ b/src/content/blog/cultiver-estime-de-soi-quotidien.md
@@ -2,8 +2,8 @@
 id: "5"
 title: "Cultiver l'estime de soi au quotidien"
 excerpt: "Des pratiques simples mais puissantes pour développer une relation positive avec soi-même et renforcer sa confiance."
-date: "8 février 2025"
-dateIso: "2025-02-08"
+date: "10 février 2026"
+dateIso: "2026-02-10"
 categories:
   - "Développement personnel"
   - "Confiance en soi"

--- a/src/content/blog/deconstruire-tabous-therapie.md
+++ b/src/content/blog/deconstruire-tabous-therapie.md
@@ -2,8 +2,8 @@
 id: "9"
 title: "Déconstruire les tabous sur la thérapie : ce n'est pas seulement pour 'les autres'"
 excerpt: "Explorons ensemble pourquoi la thérapie n'est pas réservée aux personnes en difficulté et comment elle peut bénéficier à tous."
-date: "5 mai 2025"
-dateIso: "2025-05-05"
+date: "15 mai 2026"
+dateIso: "2026-05-15"
 categories:
   - "Développement personnel"
   - "Bien-être"

--- a/src/content/blog/gerer-anxiete-quotidien-techniques-conseils.md
+++ b/src/content/blog/gerer-anxiete-quotidien-techniques-conseils.md
@@ -2,8 +2,8 @@
 id: "2"
 title: "Gérer l'anxiété au quotidien : techniques et conseils pratiques"
 excerpt: "Des stratégies simples mais efficaces pour mieux gérer l'anxiété et retrouver un équilibre émotionnel au quotidien."
-date: "15 février 2025"
-dateIso: "2025-02-15"
+date: "20 février 2026"
+dateIso: "2026-02-20"
 categories:
   - "Anxiété"
   - "Bien-être"

--- a/src/content/blog/gerer-anxiete-quotidien-techniques-conseils.md
+++ b/src/content/blog/gerer-anxiete-quotidien-techniques-conseils.md
@@ -2,8 +2,8 @@
 id: "2"
 title: "Gérer l'anxiété au quotidien : techniques et conseils pratiques"
 excerpt: "Des stratégies simples mais efficaces pour mieux gérer l'anxiété et retrouver un équilibre émotionnel au quotidien."
-date: "20 février 2026"
-dateIso: "2026-02-20"
+date: "30 avril 2025"
+dateIso: "2025-04-30"
 categories:
   - "Anxiété"
   - "Bien-être"

--- a/src/content/blog/gestion-stress-anxiete-montpellier.md
+++ b/src/content/blog/gestion-stress-anxiete-montpellier.md
@@ -14,7 +14,7 @@ author:
   title: "Psychopraticienne"
 ---
 
-<p>Quand on vit avec l'anxiété ou un stress qui ne retombe jamais vraiment, on finit souvent par croire que c'est « juste comme ça », qu'il faut tenir, s'adapter, faire avec. Pourtant, derrière ce que l'on appelle stress ou anxiété, il y a souvent un corps épuisé, un mental en alerte, des nuits agitées, une difficulté à profiter de ce qui devrait être simple. À Montpellier comme ailleurs dans l'Hérault, je rencontre des personnes qui ont appris à minimiser ce qu'elles vivent alors que, intérieurement, tout est tendu.</p>
+<p>Quand on vit avec l'anxiété ou un stress qui ne retombe jamais vraiment, on finit souvent par croire que c'est « juste comme ça », qu'il faut tenir, s'adapter, faire avec. Pourtant, derrière ce que l'on appelle stress ou anxiété, il y a souvent un corps épuisé, un mental en alerte, des nuits agitées, une difficulté à profiter de ce qui devrait être simple. Je rencontre souvent des personnes qui ont appris à minimiser ce qu'elles vivent alors que, intérieurement, tout est tendu.</p>
 
 <p>Si vous vous reconnaissez un peu dans cela, j'aimerais vous dire que vous n'êtes ni faible ni « trop sensible ». L'anxiété est une réaction humaine, mais lorsqu'elle prend trop de place, elle peut devenir très envahissante. La thérapie, et notamment les TCCE (Thérapies Comportementales, Cognitives et Émotionnelles), peut aider à comprendre ce qui se passe et à retrouver peu à peu de l'apaisement.</p>
 
@@ -32,7 +32,7 @@ author:
 
 <h2>Les techniques TCCE pour l'anxiété</h2>
 
-<p>Dans ma pratique de psychopraticienne à Montpellier, j'utilise les TCCE parce qu'elles permettent de travailler à la fois sur ce que vous pensez, ce que vous ressentez et ce que vous faites pour vous protéger. Elles ne cherchent pas à vous forcer à aller bien. Elles vous aident plutôt à comprendre vos mécanismes, à retrouver de la sécurité intérieure et à avancer pas à pas.</p>
+<p>Dans ma pratique, j'utilise les TCCE parce qu'elles permettent de travailler à la fois sur ce que vous pensez, ce que vous ressentez et ce que vous faites pour vous protéger. Elles ne cherchent pas à vous forcer à aller bien. Elles vous aident plutôt à comprendre vos mécanismes, à retrouver de la sécurité intérieure et à avancer pas à pas.</p>
 
 <h3>La restructuration cognitive</h3>
 <p>Quand on est anxieux, l'esprit part vite vers les scénarios les plus alarmants. La restructuration cognitive consiste à repérer ces pensées automatiques, à les regarder avec un peu plus de recul et à leur redonner une juste place. Il ne s'agit pas de se convaincre que « tout va bien », mais d'apprendre à ne plus prendre chaque peur pour une certitude.</p>
@@ -63,7 +63,7 @@ author:
 <h3>3. Le journal des pensées</h3>
 <p>Quand une pensée anxieuse tourne en boucle, l'écrire peut déjà l'alléger. Prenez un carnet et notez ce qui vous inquiète, puis demandez-vous : <em>Quelle est la probabilité réelle que ce que je crains se produise ? Quelles sont les preuves pour et contre cette pensée ? Quelle serait ma réponse si un ami me faisait part de cette inquiétude ?</em> Ce petit déplacement change souvent beaucoup de choses.</p>
 
-<h2>Quand consulter un professionnel pour l'anxiété à Montpellier ?</h2>
+<h2>Quand consulter un professionnel pour l'anxiété ?</h2>
 
 <p>Les outils d'auto-aide peuvent faire du bien, mais ils ne suffisent pas toujours. Je vous conseille de consulter si vous sentez que l'anxiété prend trop de place, par exemple lorsque :</p>
 

--- a/src/content/blog/gestion-stress-anxiete-montpellier.md
+++ b/src/content/blog/gestion-stress-anxiete-montpellier.md
@@ -2,8 +2,8 @@
 id: gestion-stress-anxiete-montpellier
 title: "Anxiété et stress à Montpellier : comment s'en libérer avec la thérapie"
 excerpt: "L'anxiété touche de nombreuses personnes à Montpellier et en Hérault. Quelles solutions existent ? La thérapie TCCE est l'une des approches les plus efficaces. Je vous accompagne vers un mieux-être durable."
-date: "24 avril 2026"
-dateIso: "2026-04-24"
+date: "12 avril 2026"
+dateIso: "2026-04-12"
 categories:
   - "Anxiété"
   - "Stress"

--- a/src/content/blog/gestion-stress-anxiete-montpellier.md
+++ b/src/content/blog/gestion-stress-anxiete-montpellier.md
@@ -14,72 +14,72 @@ author:
   title: "Psychopraticienne"
 ---
 
-<p>En France, près d'une personne sur cinq souffre d'un trouble anxieux au cours de sa vie. À Montpellier, ville étudiante et dynamique en pleine croissance, les sources de stress sont nombreuses : pression académique ou professionnelle, précarité du logement, isolement, incertitude sur l'avenir. L'anxiété n'est pas une faiblesse de caractère — c'est une réaction du système nerveux qui peut devenir envahissante et altérer profondément la qualité de vie.</p>
+<p>Quand on vit avec l'anxiété ou un stress qui ne retombe jamais vraiment, on finit souvent par croire que c'est « juste comme ça », qu'il faut tenir, s'adapter, faire avec. Pourtant, derrière ce que l'on appelle stress ou anxiété, il y a souvent un corps épuisé, un mental en alerte, des nuits agitées, une difficulté à profiter de ce qui devrait être simple. À Montpellier comme ailleurs dans l'Hérault, je rencontre des personnes qui ont appris à minimiser ce qu'elles vivent alors que, intérieurement, tout est tendu.</p>
 
-<p>Bonne nouvelle : l'anxiété et le stress chronique répondent très bien à la thérapie, en particulier aux approches TCCE (Thérapies Comportementales, Cognitives et Émotionnelles). Voici ce qu'il faut savoir pour comprendre votre anxiété et agir.</p>
+<p>Si vous vous reconnaissez un peu dans cela, j'aimerais vous dire que vous n'êtes ni faible ni « trop sensible ». L'anxiété est une réaction humaine, mais lorsqu'elle prend trop de place, elle peut devenir très envahissante. La thérapie, et notamment les TCCE (Thérapies Comportementales, Cognitives et Émotionnelles), peut aider à comprendre ce qui se passe et à retrouver peu à peu de l'apaisement.</p>
 
 <h2>Les différentes formes d'anxiété</h2>
 
-<p>L'anxiété ne se manifeste pas de la même façon chez tout le monde. On distingue plusieurs formes principales :</p>
+<p>L'anxiété ne se manifeste pas de la même manière chez tout le monde. Certaines personnes sentent surtout leur corps s'emballer, d'autres vivent un flot de pensées qui ne s'arrête jamais. Voici les formes que je rencontre le plus souvent en cabinet :</p>
 
 <ul>
-  <li><strong>L'anxiété généralisée (TAG)</strong> : inquiétudes excessives et incontrôlables sur de multiples domaines de la vie (santé, finances, famille, travail), présentes la plupart du temps depuis au moins six mois. Elle s'accompagne souvent de fatigue, de tensions musculaires et de troubles du sommeil.</li>
-  <li><strong>L'anxiété sociale</strong> : peur intense du regard ou du jugement des autres dans les situations sociales ou de performance. Elle peut conduire à éviter les réunions, les repas en groupe, les prises de parole en public.</li>
-  <li><strong>Les attaques de panique</strong> : épisodes soudains d'anxiété intense avec symptômes physiques forts (palpitations, essoufflement, vertiges, sensation de mort imminente). La peur de faire une nouvelle attaque peut elle-même devenir une source d'anxiété permanente.</li>
-  <li><strong>Les phobies spécifiques</strong> : peur irrationnelle et disproportionnée d'un objet ou d'une situation précise (animaux, hauteurs, avion, injections…) qui entraîne un évitement systématique.</li>
-  <li><strong>L'hypocondrie ou anxiété de santé</strong> : préoccupation excessive et persistante d'être atteint d'une maladie grave, malgré des examens médicaux rassurants. L'accès facile à l'information médicale en ligne peut amplifier ce phénomène.</li>
+  <li><strong>L'anxiété généralisée (TAG)</strong> : les inquiétudes prennent toute la place et touchent plusieurs domaines à la fois — santé, finances, famille, travail. On anticipe le pire, même sans raison apparente, et cela s'accompagne souvent de fatigue, de tensions musculaires ou de troubles du sommeil.</li>
+  <li><strong>L'anxiété sociale</strong> : le regard des autres devient source de peur, parfois même avant que la situation n'ait lieu. Prendre la parole, aller à un repas, être observé peut devenir très coûteux intérieurement.</li>
+  <li><strong>Les attaques de panique</strong> : elles surgissent parfois brutalement, avec des sensations physiques très impressionnantes : cœur qui s'emballe, souffle court, vertiges, impression de perdre le contrôle ou de mourir.</li>
+  <li><strong>Les phobies spécifiques</strong> : un objet ou une situation précise provoque une peur disproportionnée, au point que l'on organise sa vie pour éviter ce qui fait peur.</li>
+  <li><strong>L'hypocondrie ou anxiété de santé</strong> : malgré des examens rassurants, la peur d'avoir une maladie grave revient sans cesse. Internet, les symptômes lus en ligne ou l'attention portée au moindre signal du corps peuvent alors alimenter la spirale.</li>
 </ul>
 
 <h2>Les techniques TCCE pour l'anxiété</h2>
 
-<p>Les Thérapies Comportementales, Cognitives et Émotionnelles (TCCE) constituent l'approche de première intention recommandée pour les troubles anxieux par les autorités de santé. Elles combinent plusieurs techniques complémentaires :</p>
+<p>Dans ma pratique de psychopraticienne à Montpellier, j'utilise les TCCE parce qu'elles permettent de travailler à la fois sur ce que vous pensez, ce que vous ressentez et ce que vous faites pour vous protéger. Elles ne cherchent pas à vous forcer à aller bien. Elles vous aident plutôt à comprendre vos mécanismes, à retrouver de la sécurité intérieure et à avancer pas à pas.</p>
 
 <h3>La restructuration cognitive</h3>
-<p>L'anxiété est souvent alimentée par des pensées automatiques négatives et des biais de pensée (catastrophisme, surgénéralisation, lecture dans les pensées…). La restructuration cognitive apprend à identifier ces pensées, à évaluer leur réalisme et à les remplacer par des pensées plus équilibrées. Ce n'est pas de la "pensée positive" forcée, mais un travail rigoureux sur la logique interne de vos interprétations.</p>
+<p>Quand on est anxieux, l'esprit part vite vers les scénarios les plus alarmants. La restructuration cognitive consiste à repérer ces pensées automatiques, à les regarder avec un peu plus de recul et à leur redonner une juste place. Il ne s'agit pas de se convaincre que « tout va bien », mais d'apprendre à ne plus prendre chaque peur pour une certitude.</p>
 
 <h3>L'exposition progressive</h3>
-<p>L'évitement est le principal mécanisme qui entretient l'anxiété : plus on évite ce qui fait peur, plus la peur grandit. L'exposition progressive consiste à confronter graduellement et de façon contrôlée les situations redoutées, jusqu'à ce que l'anxiété diminue naturellement. Ce processus, accompagné par le thérapeute, est progressif et respecte le rythme du patient.</p>
+<p>L'évitement soulage sur le moment, mais il entretient souvent la peur sur la durée. L'exposition progressive permet de se rapprocher doucement de ce qui fait peur, avec préparation, cadre et respect de votre rythme. C'est un travail délicat, jamais brutal, qui aide peu à peu le système nerveux à comprendre qu'il peut traverser la situation sans danger immédiat.</p>
 
 <h3>La pleine conscience (mindfulness)</h3>
-<p>Les exercices de pleine conscience entraînent la capacité à observer ses pensées et ses sensations sans les amplifier ni les fuir. Cette aptitude réduit la réactivité émotionnelle et l'auto-alimentation de l'anxiété par les pensées intrusives.</p>
+<p>La pleine conscience aide à revenir au présent quand l'esprit vous emmène sans cesse dans le « et si… ». Elle apprend à observer les pensées, les sensations et les émotions sans s'y noyer. Pour beaucoup de personnes anxieuses, c'est déjà un immense soulagement de découvrir qu'une pensée n'est pas un ordre, ni une preuve.</p>
 
 <h3>Les techniques de relaxation</h3>
-<p>Respiration diaphragmatique, relaxation musculaire progressive de Jacobson, cohérence cardiaque : ces outils agissent directement sur le système nerveux autonome pour réduire l'activation physiologique liée à l'anxiété.</p>
+<p>Respiration diaphragmatique, relaxation musculaire progressive de Jacobson, cohérence cardiaque… ces outils sont précieux parce qu'ils parlent directement au corps. Quand le corps se relâche un peu, l'esprit peut suivre. J'aime les proposer de façon simple, pour qu'ils puissent vraiment vous accompagner au quotidien.</p>
 
 <h2>3 techniques pratiques contre l'anxiété à tester dès maintenant</h2>
 
 <h3>1. La respiration 4-7-8</h3>
-<p>Cette technique active le système nerveux parasympathique (la réponse de "repos et digestion") en quelques minutes :</p>
+<p>Si vous sentez la tension monter, cette respiration peut vous aider à ralentir doucement. Vous pouvez l'essayer assis, les pieds au sol, sans chercher à la faire « parfaitement » :</p>
 <ul>
   <li>Inspirez par le nez pendant <strong>4 secondes</strong>.</li>
   <li>Retenez votre souffle pendant <strong>7 secondes</strong>.</li>
   <li>Expirez lentement par la bouche pendant <strong>8 secondes</strong>.</li>
-  <li>Répétez 4 cycles. Pratiquez deux fois par jour pour un effet durable.</li>
+  <li>Répétez 4 cycles. Deux fois par jour, cet exercice peut devenir un vrai point d'appui.</li>
 </ul>
 
 <h3>2. Le scan corporel (body scan)</h3>
-<p>Allongez-vous ou asseyez-vous confortablement. Fermez les yeux. Portez votre attention successivement sur chaque partie de votre corps, des pieds jusqu'au sommet du crâne. Observez les sensations présentes (tension, chaleur, lourdeur…) sans chercher à les modifier. Cet exercice de 10 à 15 minutes aide à déconnecter du flux de pensées anxieuses et à revenir dans le moment présent.</p>
+<p>Installez-vous confortablement, fermez les yeux si cela vous convient, puis portez votre attention sur votre corps, des pieds jusqu'au sommet du crâne. Il ne s'agit pas de chasser les sensations désagréables, mais simplement de les observer. Cet exercice aide souvent à quitter un peu le tourbillon mental pour revenir à quelque chose de plus stable et plus concret.</p>
 
 <h3>3. Le journal des pensées</h3>
-<p>Lorsqu'une pensée anxieuse s'impose, notez-la par écrit dans un carnet dédié. Puis répondez à trois questions : <em>Quelle est la probabilité réelle que ce que je crains se produise ? Quelles sont les preuves pour et contre cette pensée ? Quelle serait ma réponse si un ami me faisait part de cette inquiétude ?</em> L'écriture externalise la pensée et crée une distance qui facilite l'analyse rationnelle.</p>
+<p>Quand une pensée anxieuse tourne en boucle, l'écrire peut déjà l'alléger. Prenez un carnet et notez ce qui vous inquiète, puis demandez-vous : <em>Quelle est la probabilité réelle que ce que je crains se produise ? Quelles sont les preuves pour et contre cette pensée ? Quelle serait ma réponse si un ami me faisait part de cette inquiétude ?</em> Ce petit déplacement change souvent beaucoup de choses.</p>
 
 <h2>Quand consulter un professionnel pour l'anxiété à Montpellier ?</h2>
 
-<p>Les techniques d'auto-aide sont précieuses, mais elles ont leurs limites. Il est temps de consulter un thérapeute si :</p>
+<p>Les outils d'auto-aide peuvent faire du bien, mais ils ne suffisent pas toujours. Je vous conseille de consulter si vous sentez que l'anxiété prend trop de place, par exemple lorsque :</p>
 
 <ul>
   <li>Votre anxiété interfère avec votre travail, vos relations ou vos activités quotidiennes depuis plusieurs semaines.</li>
   <li>Vous utilisez l'alcool, les médicaments ou d'autres substances pour vous calmer.</li>
   <li>Vous avez des attaques de panique répétées.</li>
-  <li>Vous évitez de plus en plus de situations et votre espace de vie se rétrécit.</li>
+  <li>Vous évitez de plus en plus de situations et votre vie se rétrécit autour de cette peur.</li>
   <li>Vous ressentez une fatigue intense, des troubles du sommeil persistants ou des douleurs physiques inexpliquées.</li>
   <li>Vous avez des pensées sombres ou des idées de vous faire du mal.</li>
 </ul>
 
-<p>Un thérapeute formé aux TCCE peut vous offrir ce que l'auto-aide ne peut pas : un regard extérieur objectif, une analyse personnalisée de votre anxiété, un protocole structuré et des exercices d'exposition guidés. En moyenne, une thérapie pour troubles anxieux avec les TCCE dure entre 12 et 20 séances, avec des résultats observables dès les premières semaines.</p>
+<p>Dans ces moments-là, être accompagné par un professionnel change souvent la donne. Un thérapeute formé aux TCCE peut vous aider à mettre des mots sur ce que vous vivez, à comprendre ce qui entretient l'anxiété et à avancer avec des outils ajustés à votre situation. Il ne s'agit pas de suivre un parcours impersonnel, mais de construire un accompagnement qui vous ressemble.</p>
 
 <h2>Consultation pour l'anxiété à Montpellier</h2>
 
-<p>J'accompagne les personnes souffrant d'anxiété, de stress chronique et de troubles apparentés dans mon cabinet du <strong>1086 Avenue Albert Einstein, 34000 Montpellier</strong>. Je reçois également les patients de Castelnau-le-Lez, Lattes, Pérols et des communes voisines.</p>
+<p>J'accompagne les personnes souffrant d'anxiété, de stress chronique et de troubles apparentés dans mon cabinet du <strong>1086 Avenue Albert Einstein, 34000 Montpellier</strong>. Je reçois également les patients de Castelnau-le-Lez, Lattes, Pérols et des communes voisines de l'Hérault.</p>
 
-<p>Mon approche TCCE est adaptée à chaque patient : les séances combinent psychoéducation, restructuration cognitive, techniques de relaxation et exposition progressive selon vos besoins spécifiques. Pour prendre rendez-vous ou poser une question, utilisez le <a href="/contact">formulaire de contact</a>.</p>
+<p>Mon approche TCCE s'adapte à ce que vous traversez, avec des séances qui peuvent mêler compréhension des mécanismes anxieux, travail sur les pensées, techniques de relaxation et exposition progressive lorsque c'est pertinent. Si vous souhaitez prendre rendez-vous ou poser une première question, vous pouvez utiliser le <a href="/contact">formulaire de contact</a>.</p>

--- a/src/content/blog/gestion-stress-anxiete-montpellier.md
+++ b/src/content/blog/gestion-stress-anxiete-montpellier.md
@@ -2,8 +2,8 @@
 id: gestion-stress-anxiete-montpellier
 title: "Anxiété et stress à Montpellier : comment s'en libérer avec la thérapie"
 excerpt: "L'anxiété touche de nombreuses personnes à Montpellier et en Hérault. Quelles solutions existent ? La thérapie TCCE est l'une des approches les plus efficaces. Je vous accompagne vers un mieux-être durable."
-date: "28 avril 2026"
-dateIso: "2026-04-28"
+date: "24 avril 2026"
+dateIso: "2026-04-24"
 categories:
   - "Anxiété"
   - "Stress"
@@ -12,6 +12,7 @@ categories:
 author:
   name: "Oriane Montabonnet"
   title: "Psychopraticienne"
+imageUrl: "https://images.pexels.com/photos/3759657/pexels-photo-3759657.jpeg"
 ---
 
 <p>Quand on vit avec l'anxiété ou un stress qui ne retombe jamais vraiment, on finit souvent par croire que c'est « juste comme ça », qu'il faut tenir, s'adapter, faire avec. Pourtant, derrière ce que l'on appelle stress ou anxiété, il y a souvent un corps épuisé, un mental en alerte, des nuits agitées, une difficulté à profiter de ce qui devrait être simple. Je rencontre souvent des personnes qui ont appris à minimiser ce qu'elles vivent alors que, intérieurement, tout est tendu.</p>

--- a/src/content/blog/impact-mots-langage-mal-etre.md
+++ b/src/content/blog/impact-mots-langage-mal-etre.md
@@ -2,8 +2,8 @@
 id: "8"
 title: "L'impact des mots : quand le langage alimente le mal-être"
 excerpt: "Découvrez comment notre dialogue intérieur influence notre bien-être psychologique et apprenez à transformer vos schémas de pensée pour une meilleure santé mentale."
-date: "1 mai 2026"
-dateIso: "2026-05-01"
+date: "26 avril 2026"
+dateIso: "2026-04-26"
 categories:
   - "Développement personnel"
   - "Communication"

--- a/src/content/blog/impact-mots-langage-mal-etre.md
+++ b/src/content/blog/impact-mots-langage-mal-etre.md
@@ -2,8 +2,8 @@
 id: "8"
 title: "L'impact des mots : quand le langage alimente le mal-être"
 excerpt: "Découvrez comment notre dialogue intérieur influence notre bien-être psychologique et apprenez à transformer vos schémas de pensée pour une meilleure santé mentale."
-date: "15 mars 2025"
-dateIso: "2025-03-15"
+date: "1 mai 2026"
+dateIso: "2026-05-01"
 categories:
   - "Développement personnel"
   - "Communication"

--- a/src/content/blog/relation-alimentation-sante-mentale.md
+++ b/src/content/blog/relation-alimentation-sante-mentale.md
@@ -2,8 +2,8 @@
 id: "3"
 title: "La relation entre alimentation et santé mentale"
 excerpt: "Comment ce que nous mangeons influence notre humeur, notre énergie et notre bien-être psychologique."
-date: "6 mars 2026"
-dateIso: "2026-03-06"
+date: "18 juin 2025"
+dateIso: "2025-06-18"
 categories:
   - "Nutrition"
   - "Bien-être"

--- a/src/content/blog/relation-alimentation-sante-mentale.md
+++ b/src/content/blog/relation-alimentation-sante-mentale.md
@@ -2,8 +2,8 @@
 id: "3"
 title: "La relation entre alimentation et santé mentale"
 excerpt: "Comment ce que nous mangeons influence notre humeur, notre énergie et notre bien-être psychologique."
-date: "22 février 2025"
-dateIso: "2025-02-22"
+date: "6 mars 2026"
+dateIso: "2026-03-06"
 categories:
   - "Nutrition"
   - "Bien-être"

--- a/src/content/blog/renforcer-communication-couple.md
+++ b/src/content/blog/renforcer-communication-couple.md
@@ -2,8 +2,8 @@
 id: "4"
 title: "Renforcer la communication dans le couple"
 excerpt: "Des stratégies efficaces pour améliorer la communication et résoudre les conflits dans votre relation de couple."
-date: "1 mars 2025"
-dateIso: "2025-03-01"
+date: "20 mars 2026"
+dateIso: "2026-03-20"
 categories:
   - "Couple"
   - "Communication"

--- a/src/content/blog/renforcer-communication-couple.md
+++ b/src/content/blog/renforcer-communication-couple.md
@@ -2,8 +2,8 @@
 id: "4"
 title: "Renforcer la communication dans le couple"
 excerpt: "Des stratégies efficaces pour améliorer la communication et résoudre les conflits dans votre relation de couple."
-date: "20 mars 2026"
-dateIso: "2026-03-20"
+date: "12 août 2025"
+dateIso: "2025-08-12"
 categories:
   - "Couple"
   - "Communication"

--- a/src/content/blog/therapie-couple-montpellier-guide.md
+++ b/src/content/blog/therapie-couple-montpellier-guide.md
@@ -33,7 +33,7 @@ imageUrl: "https://images.pexels.com/photos/5217833/pexels-photo-5217833.jpeg"
 
 <h2>Comment se déroule une séance de thérapie de couple ?</h2>
 
-<p>Une séance de thérapie de couple dure généralement <strong>55 minutes</strong>. Lors de la première rencontre, je prends le temps de recueillir l'histoire du couple, les motifs de consultation et les attentes de chacun. J'accorde beaucoup d'importance à cette première étape, parce qu'elle permet déjà de sentir là où la souffrance s'est installée et ce qui, malgré tout, tient encore.</p>
+<p>Une séance de thérapie de couple dure généralement <strong>60 ou 90 minutes</strong>. Lors de la première rencontre, je prends le temps de recueillir l'histoire du couple, les motifs de consultation et les attentes de chacun. J'accorde beaucoup d'importance à cette première étape, parce qu'elle permet déjà de sentir là où la souffrance s'est installée et ce qui, malgré tout, tient encore.</p>
 
 <p>Mon rôle est d'être <strong>strictement neutre</strong> : je ne prends pas parti, je ne distribue pas les torts et je ne cherche pas un coupable. Je veille à ce que chacun puisse dire ce qu'il vit, mais aussi entendre un peu mieux ce que l'autre traverse. Très souvent, c'est dans cet espace sécurisé que quelque chose commence à se desserrer.</p>
 
@@ -46,7 +46,7 @@ imageUrl: "https://images.pexels.com/photos/5217833/pexels-photo-5217833.jpeg"
   <li><strong>Des séances individuelles alternées</strong>, parfois proposées en parallèle, lorsque chacun a besoin de déposer aussi son vécu personnel pour mieux revenir dans le lien.</li>
 </ul>
 
-<p>La fréquence des séances est adaptée à la situation : une fois par semaine au début, puis espacées progressivement à mesure que le couple gagne en autonomie. Ce rythme se construit ensemble, en fonction de ce que vous traversez et de ce que vous êtes prêts à engager.</p>
+<p>La fréquence des séances est adaptée à la situation, avec un rythme habituel d'une séance toutes les 2 à 3 semaines et un bilan intermédiaire après 2 à 3 séances. Ce cadre se construit ensemble, en fonction de ce que vous traversez et de ce que vous êtes prêts à engager.</p>
 
 <h2>La thérapie de couple peut-elle sauver une relation ?</h2>
 

--- a/src/content/blog/therapie-couple-montpellier-guide.md
+++ b/src/content/blog/therapie-couple-montpellier-guide.md
@@ -2,8 +2,8 @@
 id: therapie-couple-montpellier-guide
 title: "Thérapie de couple à Montpellier : quand consulter et comment ça se passe"
 excerpt: "La thérapie de couple permet de surmonter les crises conjugales et d'améliorer la communication. Découvrez comment se passe une thérapie de couple à Montpellier avec Oriane Montabonnet, psychopraticienne."
-date: "27 avril 2026"
-dateIso: "2026-04-27"
+date: "17 avril 2026"
+dateIso: "2026-04-17"
 categories:
   - "Thérapie de couple"
   - "Montpellier"
@@ -11,6 +11,7 @@ categories:
 author:
   name: "Oriane Montabonnet"
   title: "Psychopraticienne"
+imageUrl: "https://images.pexels.com/photos/4101136/pexels-photo-4101136.jpeg"
 ---
 
 <p>Quand un couple arrive jusqu'à moi, ce n'est presque jamais « pour parler un peu ». C'est souvent parce que la fatigue est là, que les disputes se répètent, que la tendresse s'est éloignée ou qu'un silence pesant a pris toute la place. Si vous lisez ces lignes, peut-être que vous vous reconnaissez dans cela. J'aimerais déjà vous dire une chose : demander de l'aide n'est pas un aveu d'échec, c'est souvent le signe qu'il reste quelque chose à protéger, à comprendre ou à apaiser.</p>

--- a/src/content/blog/therapie-couple-montpellier-guide.md
+++ b/src/content/blog/therapie-couple-montpellier-guide.md
@@ -15,7 +15,7 @@ author:
 
 <p>Quand un couple arrive jusqu'à moi, ce n'est presque jamais « pour parler un peu ». C'est souvent parce que la fatigue est là, que les disputes se répètent, que la tendresse s'est éloignée ou qu'un silence pesant a pris toute la place. Si vous lisez ces lignes, peut-être que vous vous reconnaissez dans cela. J'aimerais déjà vous dire une chose : demander de l'aide n'est pas un aveu d'échec, c'est souvent le signe qu'il reste quelque chose à protéger, à comprendre ou à apaiser.</p>
 
-<p>La thérapie de couple à Montpellier offre un espace où chacun peut enfin être entendu sans être interrompu, attaqué ou sommé d'avoir raison. C'est un lieu pour ralentir, remettre du sens et regarder autrement ce qui se joue entre vous.</p>
+<p>La thérapie de couple offre un espace où chacun peut enfin être entendu sans être interrompu, attaqué ou sommé d'avoir raison. C'est un lieu pour ralentir, remettre du sens et regarder autrement ce qui se joue entre vous.</p>
 
 <h2>Les signes qu'une thérapie de couple peut aider</h2>
 
@@ -30,7 +30,7 @@ author:
   <li><strong>Vous envisagez une séparation.</strong> La thérapie de couple peut aider à comprendre ce qui est encore vivant entre vous, ou à préparer une séparation plus apaisée si c'est ce qui se dessine.</li>
 </ul>
 
-<h2>Comment se déroule une séance de thérapie de couple à Montpellier ?</h2>
+<h2>Comment se déroule une séance de thérapie de couple ?</h2>
 
 <p>Une séance de thérapie de couple dure généralement <strong>55 minutes</strong>. Lors de la première rencontre, je prends le temps de recueillir l'histoire du couple, les motifs de consultation et les attentes de chacun. J'accorde beaucoup d'importance à cette première étape, parce qu'elle permet déjà de sentir là où la souffrance s'est installée et ce qui, malgré tout, tient encore.</p>
 
@@ -59,9 +59,9 @@ author:
 
 <p>Ce qui est certain, c'est que la thérapie de couple est <strong>toujours plus efficace lorsque les deux partenaires sont volontaires</strong>. Quand un seul vient avec l'envie d'avancer, un mouvement peut déjà commencer. Mais lorsque les deux s'engagent, l'espace de transformation est souvent plus rapide et plus profond.</p>
 
-<h2>Combien coûte une thérapie de couple à Montpellier ?</h2>
+<h2>Combien coûte une thérapie de couple ?</h2>
 
-<p>À Montpellier, une séance de thérapie de couple est facturée <strong>80 € par séance</strong>. La thérapie de couple n'est pas remboursée par l'Assurance maladie.</p>
+<p>Une séance de thérapie de couple est facturée <strong>80 € par séance</strong>. La thérapie de couple n'est pas remboursée par l'Assurance maladie.</p>
 
 <p>Certaines mutuelles prennent néanmoins en charge une partie des consultations de psychothérapie. Je vous conseille de vérifier ce point avant de commencer si le budget est une préoccupation, car il est important que le cadre soit clair et soutenable pour vous.</p>
 

--- a/src/content/blog/therapie-couple-montpellier-guide.md
+++ b/src/content/blog/therapie-couple-montpellier-guide.md
@@ -2,8 +2,8 @@
 id: therapie-couple-montpellier-guide
 title: "Thérapie de couple à Montpellier : quand consulter et comment ça se passe"
 excerpt: "La thérapie de couple permet de surmonter les crises conjugales et d'améliorer la communication. Découvrez comment se passe une thérapie de couple à Montpellier avec Oriane Montabonnet, psychopraticienne."
-date: "17 avril 2026"
-dateIso: "2026-04-17"
+date: "25 mars 2026"
+dateIso: "2026-03-25"
 categories:
   - "Thérapie de couple"
   - "Montpellier"
@@ -11,7 +11,7 @@ categories:
 author:
   name: "Oriane Montabonnet"
   title: "Psychopraticienne"
-imageUrl: "https://images.pexels.com/photos/4101136/pexels-photo-4101136.jpeg"
+imageUrl: "https://images.pexels.com/photos/5217833/pexels-photo-5217833.jpeg"
 ---
 
 <p>Quand un couple arrive jusqu'à moi, ce n'est presque jamais « pour parler un peu ». C'est souvent parce que la fatigue est là, que les disputes se répètent, que la tendresse s'est éloignée ou qu'un silence pesant a pris toute la place. Si vous lisez ces lignes, peut-être que vous vous reconnaissez dans cela. J'aimerais déjà vous dire une chose : demander de l'aide n'est pas un aveu d'échec, c'est souvent le signe qu'il reste quelque chose à protéger, à comprendre ou à apaiser.</p>

--- a/src/content/blog/therapie-couple-montpellier-guide.md
+++ b/src/content/blog/therapie-couple-montpellier-guide.md
@@ -62,7 +62,7 @@ imageUrl: "https://images.pexels.com/photos/5217833/pexels-photo-5217833.jpeg"
 
 <h2>Combien coûte une thérapie de couple ?</h2>
 
-<p>Une séance de thérapie de couple est facturée <strong>80 € par séance</strong>. La thérapie de couple n'est pas remboursée par l'Assurance maladie.</p>
+<p>Une séance de thérapie de couple est facturée <strong>75 € (60 min) ou 90 € (90 min)</strong>, avec un tarif réduit de 15 € sur la première séance. La thérapie de couple n'est pas remboursée par l'Assurance maladie.</p>
 
 <p>Certaines mutuelles prennent néanmoins en charge une partie des consultations de psychothérapie. Je vous conseille de vérifier ce point avant de commencer si le budget est une préoccupation, car il est important que le cadre soit clair et soutenable pour vous.</p>
 

--- a/src/content/blog/therapie-couple-montpellier-guide.md
+++ b/src/content/blog/therapie-couple-montpellier-guide.md
@@ -13,60 +13,62 @@ author:
   title: "Psychopraticienne"
 ---
 
-<p>La thérapie de couple est un espace sécurisé où deux partenaires, accompagnés d'un thérapeute neutre, explorent leurs difficultés relationnelles. À Montpellier, de nombreux couples choisissent ce type d'accompagnement pour sortir d'une impasse, renouer le dialogue ou prendre sereinement une décision importante concernant leur relation.</p>
+<p>Quand un couple arrive jusqu'à moi, ce n'est presque jamais « pour parler un peu ». C'est souvent parce que la fatigue est là, que les disputes se répètent, que la tendresse s'est éloignée ou qu'un silence pesant a pris toute la place. Si vous lisez ces lignes, peut-être que vous vous reconnaissez dans cela. J'aimerais déjà vous dire une chose : demander de l'aide n'est pas un aveu d'échec, c'est souvent le signe qu'il reste quelque chose à protéger, à comprendre ou à apaiser.</p>
 
-<p>Contrairement aux idées reçues, consulter un psychopraticien de couple n'est pas un aveu d'échec. C'est au contraire un acte courageux qui témoigne de la volonté de prendre soin de sa relation plutôt que de la laisser se dégrader sans intervenir.</p>
+<p>La thérapie de couple à Montpellier offre un espace où chacun peut enfin être entendu sans être interrompu, attaqué ou sommé d'avoir raison. C'est un lieu pour ralentir, remettre du sens et regarder autrement ce qui se joue entre vous.</p>
 
 <h2>Les signes qu'une thérapie de couple peut aider</h2>
 
-<p>Il n'y a pas de "bon moment" unique pour consulter un thérapeute de couple. Cependant, certaines situations récurrentes indiquent qu'un soutien professionnel serait bénéfique :</p>
+<p>Il n'existe pas un seul « bon moment » pour consulter. Dans ma pratique, je vois surtout des couples qui attendent longtemps avant de franchir le pas, parfois trop longtemps par peur d'entendre une vérité douloureuse. Pourtant, certains signes montrent qu'un accompagnement peut vraiment soulager :</p>
 
 <ul>
-  <li><strong>La communication est rompue.</strong> Chaque conversation importante dégénère en conflit, ou au contraire, vous évitez tout sujet sensible pour ne pas vous disputer.</li>
-  <li><strong>Les mêmes disputes reviennent en boucle.</strong> Vous tournez en rond sur les mêmes sujets (argent, éducation des enfants, intimité, belle-famille) sans jamais trouver de solution durable.</li>
-  <li><strong>Une infidélité a eu lieu.</strong> La trahison a brisé la confiance. La thérapie de couple aide à traiter le traumatisme, à comprendre ce qui s'est passé et à décider ensemble de la suite.</li>
-  <li><strong>L'intimité a disparu.</strong> La distance émotionnelle et/ou physique s'est installée progressivement et vous ne savez plus comment la combler.</li>
-  <li><strong>Les conflits liés à la parentalité s'accumulent.</strong> Vous n'êtes plus d'accord sur l'éducation de vos enfants, ce qui génère des tensions constantes.</li>
-  <li><strong>Vous envisagez une séparation.</strong> Avant de prendre une décision définitive, la thérapie de couple permet de s'assurer que vous avez tout tenté et d'envisager, si nécessaire, une séparation apaisée.</li>
+  <li><strong>La communication est rompue.</strong> Chaque échange important finit en conflit, ou bien vous marchez sur des œufs et n'osez plus aborder les sujets sensibles.</li>
+  <li><strong>Les mêmes disputes reviennent en boucle.</strong> Argent, enfants, intimité, charge mentale, belle-famille… vous avez l'impression de rejouer toujours la même scène, sans issue.</li>
+  <li><strong>Une infidélité a eu lieu.</strong> La confiance est abîmée et vous ne savez plus comment parler de la blessure sans vous déchirer davantage.</li>
+  <li><strong>L'intimité a disparu.</strong> Parfois elle s'efface doucement, presque sans bruit, jusqu'au moment où la distance devient douloureuse.</li>
+  <li><strong>Les conflits liés à la parentalité s'accumulent.</strong> Vous ne vous sentez plus alliés et chaque désaccord semble remettre en cause votre place dans le couple.</li>
+  <li><strong>Vous envisagez une séparation.</strong> La thérapie de couple peut aider à comprendre ce qui est encore vivant entre vous, ou à préparer une séparation plus apaisée si c'est ce qui se dessine.</li>
 </ul>
 
 <h2>Comment se déroule une séance de thérapie de couple à Montpellier ?</h2>
 
-<p>Une séance de thérapie de couple dure généralement <strong>55 minutes</strong>. Lors de la première rencontre, je prends le temps de recueillir l'histoire du couple, les motifs de consultation et les attentes de chacun.</p>
+<p>Une séance de thérapie de couple dure généralement <strong>55 minutes</strong>. Lors de la première rencontre, je prends le temps de recueillir l'histoire du couple, les motifs de consultation et les attentes de chacun. J'accorde beaucoup d'importance à cette première étape, parce qu'elle permet déjà de sentir là où la souffrance s'est installée et ce qui, malgré tout, tient encore.</p>
 
-<p>Mon rôle est d'être <strong>strictement neutre</strong> : je ne prends pas parti, ne juge pas et ne cherche pas à désigner un responsable. Mon objectif est de créer les conditions pour que chaque partenaire puisse s'exprimer et être entendu.</p>
+<p>Mon rôle est d'être <strong>strictement neutre</strong> : je ne prends pas parti, je ne distribue pas les torts et je ne cherche pas un coupable. Je veille à ce que chacun puisse dire ce qu'il vit, mais aussi entendre un peu mieux ce que l'autre traverse. Très souvent, c'est dans cet espace sécurisé que quelque chose commence à se desserrer.</p>
 
 <p>Au fil des séances, différents outils sont utilisés :</p>
 
 <ul>
-  <li><strong>Des exercices de communication structurée</strong> pour apprendre à exprimer ses besoins sans déclencher de mécanismes défensifs chez l'autre.</li>
-  <li><strong>L'identification des schémas relationnels</strong> répétitifs qui entretiennent les conflits.</li>
-  <li><strong>Des exercices pratiques à réaliser entre les séances</strong> pour ancrer les nouvelles façons de communiquer dans le quotidien.</li>
-  <li><strong>Des séances individuelles alternées</strong>, parfois proposées en parallèle, pour permettre à chacun de travailler sur son propre vécu et ses propres réactions.</li>
+  <li><strong>Des exercices de communication structurée</strong> pour apprendre à exprimer ses besoins sans déclencher immédiatement la défense ou l'attaque.</li>
+  <li><strong>L'identification des schémas relationnels</strong> qui reviennent encore et encore, même quand vous avez sincèrement envie que cela change.</li>
+  <li><strong>Des exercices pratiques à réaliser entre les séances</strong> pour ramener dans le quotidien ce qui s'ouvre en cabinet.</li>
+  <li><strong>Des séances individuelles alternées</strong>, parfois proposées en parallèle, lorsque chacun a besoin de déposer aussi son vécu personnel pour mieux revenir dans le lien.</li>
 </ul>
 
-<p>La fréquence des séances est adaptée à la situation : une fois par semaine au début, puis espacées progressivement à mesure que le couple gagne en autonomie.</p>
+<p>La fréquence des séances est adaptée à la situation : une fois par semaine au début, puis espacées progressivement à mesure que le couple gagne en autonomie. Ce rythme se construit ensemble, en fonction de ce que vous traversez et de ce que vous êtes prêts à engager.</p>
 
 <h2>La thérapie de couple peut-elle sauver une relation ?</h2>
 
-<p>C'est la question que beaucoup de couples posent lors du premier entretien. La réponse honnête est : <strong>la thérapie de couple n'a pas pour objectif de "sauver" une relation à tout prix.</strong></p>
+<p>C'est l'une des questions que j'entends le plus souvent au premier rendez-vous. Ma réponse est toujours honnête : <strong>la thérapie de couple n'a pas pour objectif de "sauver" une relation à tout prix.</strong></p>
 
-<p>Son véritable objectif est d'améliorer la qualité de la communication et de permettre à chaque partenaire de mieux comprendre ses propres besoins et ceux de l'autre. Dans la majorité des cas, ce travail renforce effectivement le lien et permet au couple de repartir sur des bases plus solides.</p>
+<p>Son but est d'abord de remettre de la clarté, de la parole et de la compréhension là où tout est devenu douloureux ou confus. Parfois, cela permet au couple de se retrouver, de se parler autrement et de reconstruire un lien plus solide. Et parfois, cela aide aussi à reconnaître qu'on ne peut plus continuer comme avant.</p>
 
-<p>Mais dans certaines situations, la thérapie peut aussi aider un couple à reconnaître que la relation ne peut plus évoluer positivement — et à se séparer de manière respectueuse, en préservant autant que possible la co-parentalité et la dignité de chacun. Ce n'est pas un échec de la thérapie : c'est parfois le meilleur accompagnement possible.</p>
+<p>Ce travail me touche particulièrement parce qu'il y a des moments très simples, mais très forts, où l'on voit que quelque chose bouge : un reproche qui laisse enfin place à une émotion, une phrase entendue différemment, un regard qui se relève. Ce sont souvent de petits déplacements, mais ils changent profondément la suite.</p>
 
-<p>Ce qui est certain, c'est que la thérapie de couple est <strong>toujours plus efficace lorsque les deux partenaires sont volontaires</strong>. Un seul partenaire motivé peut commencer à changer la dynamique relationnelle, mais l'engagement des deux accélère considérablement les progrès.</p>
+<p>Dans certaines situations, la thérapie aide aussi à se séparer avec plus de respect, en préservant autant que possible la dignité de chacun et la co-parentalité. Ce n'est pas l'échec du travail thérapeutique. C'est parfois la forme la plus juste de l'accompagnement.</p>
+
+<p>Ce qui est certain, c'est que la thérapie de couple est <strong>toujours plus efficace lorsque les deux partenaires sont volontaires</strong>. Quand un seul vient avec l'envie d'avancer, un mouvement peut déjà commencer. Mais lorsque les deux s'engagent, l'espace de transformation est souvent plus rapide et plus profond.</p>
 
 <h2>Combien coûte une thérapie de couple à Montpellier ?</h2>
 
 <p>À Montpellier, une séance de thérapie de couple est facturée <strong>80 € par séance</strong>. La thérapie de couple n'est pas remboursée par l'Assurance maladie.</p>
 
-<p>En revanche, de nombreuses mutuelles proposent un remboursement partiel des consultations de psychothérapie. Renseignez-vous auprès de votre complémentaire santé pour connaître votre niveau de couverture avant de commencer le suivi.</p>
+<p>Certaines mutuelles prennent néanmoins en charge une partie des consultations de psychothérapie. Je vous conseille de vérifier ce point avant de commencer si le budget est une préoccupation, car il est important que le cadre soit clair et soutenable pour vous.</p>
 
-<p>Le nombre total de séances nécessaires varie selon les couples : certains atteignent leurs objectifs en 8 à 10 séances, d'autres choisissent un suivi plus long. Ce rythme est toujours décidé ensemble, en fonction de l'évolution de votre situation.</p>
+<p>Le nombre de séances varie beaucoup selon les couples. Certains trouvent un nouvel élan en quelques mois, d'autres ont besoin d'un temps plus long pour réparer, comprendre ou décider. Là encore, rien n'est imposé : le rythme se construit avec vous.</p>
 
 <h2>Prendre rendez-vous pour une thérapie de couple à Montpellier</h2>
 
-<p>Je reçois les couples dans mon cabinet du <strong>1086 Avenue Albert Einstein, 34000 Montpellier</strong>, en semaine de 8h à 19h. Mon approche TCCE (Thérapies Comportementales, Cognitives et Émotionnelles) offre un cadre structuré et bienveillant, adapté à chaque couple.</p>
+<p>Je reçois les couples dans mon cabinet du <strong>1086 Avenue Albert Einstein, 34000 Montpellier</strong>, en semaine de 8h à 19h. Mon approche TCCE (Thérapies Comportementales, Cognitives et Émotionnelles) m'aide à proposer un cadre à la fois contenant, concret et profondément bienveillant, pour que chacun puisse reprendre sa place dans la relation.</p>
 
-<p>Pour en savoir plus sur mon accompagnement, consultez la page <a href="/services/therapie-de-couple">thérapie de couple</a> ou <a href="/contact">prenez rendez-vous directement</a>. Le premier entretien est l'occasion de poser toutes vos questions sans engagement.</p>
+<p>Pour en savoir plus sur mon accompagnement, consultez la page <a href="/services/therapie-de-couple">thérapie de couple</a> ou <a href="/contact">prenez rendez-vous directement</a>. Le premier entretien est l'occasion de poser toutes vos questions, simplement, sans pression.</p>

--- a/src/content/blog/troubles-comportement-alimentaire-comprendre-accompagner.md
+++ b/src/content/blog/troubles-comportement-alimentaire-comprendre-accompagner.md
@@ -2,8 +2,8 @@
 id: "6"
 title: "Les troubles du comportement alimentaire : comprendre et accompagner"
 excerpt: "Un éclairage sur les différents troubles du comportement alimentaire, leurs manifestations et les approches thérapeutiques adaptées."
-date: "3 avril 2026"
-dateIso: "2026-04-03"
+date: "4 octobre 2025"
+dateIso: "2025-10-04"
 categories:
   - "Troubles alimentaires"
   - "Nutrition"

--- a/src/content/blog/troubles-comportement-alimentaire-comprendre-accompagner.md
+++ b/src/content/blog/troubles-comportement-alimentaire-comprendre-accompagner.md
@@ -2,8 +2,8 @@
 id: "6"
 title: "Les troubles du comportement alimentaire : comprendre et accompagner"
 excerpt: "Un éclairage sur les différents troubles du comportement alimentaire, leurs manifestations et les approches thérapeutiques adaptées."
-date: "8 mars 2025"
-dateIso: "2025-03-08"
+date: "3 avril 2026"
+dateIso: "2026-04-03"
 categories:
   - "Troubles alimentaires"
   - "Nutrition"

--- a/src/content/blog/trouver-psychopraticien-montpellier.md
+++ b/src/content/blog/trouver-psychopraticien-montpellier.md
@@ -2,8 +2,8 @@
 id: trouver-psychopraticien-montpellier
 title: "Comment trouver un psychopraticien à Montpellier : guide pratique 2026"
 excerpt: "Vous cherchez un psychopraticien à Montpellier ? Ce guide vous explique la différence entre psychologue, psychiatre et psychopraticien, comment choisir votre thérapeute, et où consulter dans l'Hérault."
-date: "26 avril 2026"
-dateIso: "2026-04-26"
+date: "10 avril 2026"
+dateIso: "2026-04-10"
 categories:
   - "Thérapie"
   - "Montpellier"
@@ -11,6 +11,7 @@ categories:
 author:
   name: "Oriane Montabonnet"
   title: "Psychopraticienne"
+imageUrl: "https://images.pexels.com/photos/5699456/pexels-photo-5699456.jpeg"
 ---
 
 <p>Trouver un psychopraticien n'est pas toujours simple, surtout quand on se sent déjà fatigué, inquiet ou perdu. Dans mon cabinet, j'entends souvent cette phrase : « Je ne sais pas vers qui me tourner. » Si c'est votre cas, sachez que vous n'êtes pas seul. J'ai écrit ce guide pour vous aider à y voir plus clair, avec des repères concrets et une parole plus humaine que les définitions que l'on trouve souvent en ligne.</p>

--- a/src/content/blog/trouver-psychopraticien-montpellier.md
+++ b/src/content/blog/trouver-psychopraticien-montpellier.md
@@ -2,8 +2,8 @@
 id: trouver-psychopraticien-montpellier
 title: "Comment trouver un psychopraticien à Montpellier : guide pratique 2026"
 excerpt: "Vous cherchez un psychopraticien à Montpellier ? Ce guide vous explique la différence entre psychologue, psychiatre et psychopraticien, comment choisir votre thérapeute, et où consulter dans l'Hérault."
-date: "10 avril 2026"
-dateIso: "2026-04-10"
+date: "7 mars 2026"
+dateIso: "2026-03-07"
 categories:
   - "Thérapie"
   - "Montpellier"

--- a/src/content/blog/trouver-psychopraticien-montpellier.md
+++ b/src/content/blog/trouver-psychopraticien-montpellier.md
@@ -52,7 +52,7 @@ imageUrl: "https://images.pexels.com/photos/5699456/pexels-photo-5699456.jpeg"
 <p>Je le dis souvent : au-delà de la méthode, la relation compte énormément. Si vous sentez que vous pouvez parler sans être jugé, que vous êtes accueilli avec respect et que quelque chose de la confiance peut se construire, c'est un bon signe. Et si, après 2 ou 3 séances, vous ne vous sentez pas à votre place, il est tout à fait légitime de chercher un autre professionnel.</p>
 
 <h3>3. Renseignez-vous sur les tarifs et le remboursement</h3>
-<p>Les séances de psychopraticien se situent généralement entre 50 € et 80 €. Certaines mutuelles proposent un remboursement partiel : cela peut soulager un peu le coût du suivi, donc cela vaut la peine de vous renseigner en amont.</p>
+<p>Selon le type d'accompagnement, les séances se situent généralement entre 50 € et 100 € (thérapie individuelle, couple ou familiale, en 60 ou 90 minutes). Certaines mutuelles proposent un remboursement partiel : cela peut soulager un peu le coût du suivi, donc cela vaut la peine de vous renseigner en amont.</p>
 
 <h3>4. Vérifiez la localisation et les horaires</h3>
 <p>Quand on hésite déjà à consulter, chaque détail pratique compte. Mon cabinet se situe au <strong>1086 Avenue Albert Einstein, 34000 Montpellier</strong>, accessible depuis le centre-ville, Castelnau-le-Lez, Lattes et Pérols. J'y reçois du lundi au vendredi, de 8h à 12h et de 14h à 19h.</p>

--- a/src/content/blog/trouver-psychopraticien-montpellier.md
+++ b/src/content/blog/trouver-psychopraticien-montpellier.md
@@ -13,76 +13,76 @@ author:
   title: "Psychopraticienne"
 ---
 
-<p>Trouver un psychopraticien à Montpellier peut sembler complexe face à la diversité des professionnels de santé mentale. Ce guide vous aide à comprendre les différences entre les titres, à savoir quand consulter, et comment choisir le professionnel adapté à votre situation dans l'Hérault.</p>
+<p>Trouver un psychopraticien à Montpellier n'est pas toujours simple, surtout quand on se sent déjà fatigué, inquiet ou perdu. Dans mon cabinet, j'entends souvent cette phrase : « Je ne sais pas vers qui me tourner. » Si c'est votre cas, sachez que vous n'êtes pas seul. J'ai écrit ce guide pour vous aider à y voir plus clair, avec des repères concrets et une parole plus humaine que les définitions que l'on trouve souvent en ligne.</p>
 
 <h2>Psychologue, psychiatre, psychopraticien : quelles différences à Montpellier ?</h2>
 
-<p>À Montpellier comme partout en France, trois types de professionnels accompagnent les difficultés psychologiques :</p>
+<p>À Montpellier comme ailleurs, plusieurs professionnels peuvent accompagner la souffrance psychique. La différence n'est pas toujours évidente au premier abord, alors voici ce que j'explique souvent aux personnes qui me contactent :</p>
 
 <ul>
-  <li><strong>Le psychiatre</strong> est médecin. Il peut prescrire des médicaments et est remboursé par la Sécurité sociale. Il intervient sur les troubles psychiatriques sévères (psychoses, troubles bipolaires, etc.).</li>
-  <li><strong>Le psychologue clinicien</strong> possède un Master 2 en psychologie. Ses séances ne sont remboursées que dans le cadre du dispositif "Mon Soutien Psy" (8 séances/an sur orientation du médecin traitant). Il utilise les tests psychologiques et diverses approches thérapeutiques.</li>
-  <li><strong>Le psychopraticien</strong> (ou psychothérapeute praticien) est formé à une ou plusieurs méthodes psychothérapeutiques (TCC, TCCE, psychanalyse, EMDR, etc.). Non réglementé en France, il n'a pas de numéro ADELI/RPPS. Ses séances ne sont pas remboursées par l'Assurance maladie, mais certaines mutuelles couvrent partiellement.</li>
+  <li><strong>Le psychiatre</strong> est médecin. Il peut poser un diagnostic médical, prescrire des médicaments et ses consultations sont remboursées par la Sécurité sociale. Il intervient notamment lorsque les troubles sont sévères ou nécessitent un suivi médical.</li>
+  <li><strong>Le psychologue clinicien</strong> a suivi un Master 2 en psychologie. Il peut proposer différentes approches thérapeutiques et, dans certains cas, ses séances entrent dans le dispositif « Mon Soutien Psy » sur orientation du médecin traitant.</li>
+  <li><strong>Le psychopraticien</strong> est formé à une ou plusieurs méthodes psychothérapeutiques, comme les TCC, les TCCE, l'EMDR ou d'autres approches. En France, le titre n'est pas réglementé de la même manière que celui de psychologue ou de psychiatre, ce qui rend la qualité de la formation particulièrement importante au moment de choisir.</li>
 </ul>
 
 <h2>Quand consulter un psychopraticien plutôt qu'un autre professionnel ?</h2>
 
-<p>Le psychopraticien est particulièrement adapté pour :</p>
+<p>Dans ma pratique de psychopraticienne à Montpellier, je reçois souvent des personnes qui sentent que quelque chose ne va plus, sans savoir si leur souffrance est « assez importante » pour consulter. Vous n'avez pas besoin d'attendre d'aller très mal. Un accompagnement peut être précieux si vous traversez par exemple :</p>
 
 <ul>
-  <li>L'anxiété légère à modérée, le stress chronique, les phobies</li>
-  <li>Les difficultés relationnelles (couple, famille, travail)</li>
-  <li>La dépression légère à modérée</li>
-  <li>Les troubles alimentaires sans complications médicales</li>
-  <li>Le développement personnel et la connaissance de soi</li>
-  <li>Les transitions de vie (divorce, deuil, reconversion professionnelle)</li>
+  <li>Une anxiété légère à modérée, du stress chronique ou des phobies</li>
+  <li>Des difficultés relationnelles dans le couple, la famille ou au travail</li>
+  <li>Une dépression légère à modérée</li>
+  <li>Des troubles alimentaires sans complications médicales</li>
+  <li>Une période de remise en question, de développement personnel ou de perte de repères</li>
+  <li>Une transition de vie comme un divorce, un deuil ou une reconversion professionnelle</li>
 </ul>
 
-<p>Si vous présentez des symptômes sévères (idées suicidaires, épisodes psychotiques, dépendances graves), orientez-vous vers un médecin ou un psychiatre en priorité.</p>
+<p>En revanche, si vous faites face à des idées suicidaires, à des épisodes psychotiques, à une addiction sévère ou à des symptômes très envahissants, il est essentiel de vous orienter d'abord vers un médecin ou un psychiatre. Demander le bon soutien au bon moment, c'est déjà prendre soin de vous.</p>
 
 <h2>Comment choisir son psychopraticien à Montpellier ?</h2>
 
-<p>Voici les critères essentiels pour choisir un psychopraticien dans l'Hérault :</p>
+<p>Choisir un psychopraticien dans l'Hérault, ce n'est pas seulement comparer des tarifs ou des adresses. C'est aussi chercher une personne avec qui vous pourrez vous sentir suffisamment en sécurité pour parler vrai. Voici les repères que je trouve les plus importants :</p>
 
 <h3>1. Vérifiez sa formation</h3>
-<p>Demandez quelle formation il a suivie et dans quelle approche il travaille. Les Thérapies Comportementales et Cognitives (TCC/TCCE) sont parmi les approches les mieux validées scientifiquement pour l'anxiété, la dépression et les TCA.</p>
+<p>N'hésitez pas à demander quelle formation le thérapeute a suivie et avec quelle approche il travaille. Les Thérapies Comportementales et Cognitives, ainsi que les TCCE, sont souvent très aidantes pour l'anxiété, la dépression ou les troubles du comportement alimentaire. L'important est que le professionnel puisse vous expliquer clairement sa façon de travailler, sans flou ni grands discours.</p>
 
 <h3>2. Évaluez le feeling dès la première séance</h3>
-<p>L'alliance thérapeutique — la qualité de la relation entre vous et votre thérapeute — est l'un des facteurs les plus prédictifs d'une thérapie réussie. Si vous ne vous sentez pas en confiance après 2 ou 3 séances, il est normal de chercher un autre professionnel.</p>
+<p>Je le dis souvent : au-delà de la méthode, la relation compte énormément. Si vous sentez que vous pouvez parler sans être jugé, que vous êtes accueilli avec respect et que quelque chose de la confiance peut se construire, c'est un bon signe. Et si, après 2 ou 3 séances, vous ne vous sentez pas à votre place, il est tout à fait légitime de chercher un autre professionnel.</p>
 
 <h3>3. Renseignez-vous sur les tarifs et le remboursement</h3>
-<p>À Montpellier, les séances de psychopraticien se situent généralement entre 50 € et 80 €. Vérifiez auprès de votre mutuelle si elle prend en charge ce type de consultation.</p>
+<p>À Montpellier, les séances de psychopraticien se situent généralement entre 50 € et 80 €. Certaines mutuelles proposent un remboursement partiel : cela peut soulager un peu le coût du suivi, donc cela vaut la peine de vous renseigner en amont.</p>
 
 <h3>4. Vérifiez la localisation et les horaires</h3>
-<p>Mon cabinet est situé au <strong>1086 Avenue Albert Einstein, 34000 Montpellier</strong>, accessible depuis le centre-ville, Castelnau-le-Lez, Lattes et Pérols. Horaires : lundi–vendredi, 8h–12h et 14h–19h.</p>
+<p>Quand on hésite déjà à consulter, chaque détail pratique compte. Mon cabinet se situe au <strong>1086 Avenue Albert Einstein, 34000 Montpellier</strong>, accessible depuis le centre-ville, Castelnau-le-Lez, Lattes et Pérols. J'y reçois du lundi au vendredi, de 8h à 12h et de 14h à 19h.</p>
 
 <h2>Quelles approches thérapeutiques existe-t-il à Montpellier ?</h2>
 
-<p>Au-delà du titre du professionnel, l'approche thérapeutique qu'il utilise est un critère de choix essentiel. Voici les principales méthodes pratiquées à Montpellier :</p>
+<p>On choisit parfois un thérapeute pour sa proximité géographique, puis on découvre que l'approche ne nous correspond pas. C'est pour cela que je vous encourage à vous intéresser aussi à la méthode utilisée. À Montpellier, vous pouvez rencontrer plusieurs approches :</p>
 
 <ul>
-  <li><strong>Les TCCE (Thérapies Comportementales, Cognitives et Émotionnelles)</strong> : approche structurée, orientée vers le présent et les solutions. Parmi les mieux évaluées scientifiquement pour l'anxiété, la dépression, les TCA et les troubles de la personnalité. C'est l'approche que je pratique.</li>
-  <li><strong>L'EMDR (Eye Movement Desensitization and Reprocessing)</strong> : recommandée pour le traitement des traumatismes et du stress post-traumatique. Peut être intégrée aux TCCE.</li>
-  <li><strong>La thérapie psychanalytique ou psychodynamique</strong> : travail en profondeur sur l'histoire de vie, les conflits inconscients et les patterns relationnels. Convient aux personnes qui souhaitent une exploration de longue durée.</li>
-  <li><strong>L'ACT (Acceptance and Commitment Therapy)</strong> : approche de troisième vague des TCC, qui intègre la pleine conscience et le travail sur les valeurs personnelles.</li>
-  <li><strong>La thérapie systémique</strong> : utilisée notamment en thérapie de couple et familiale. Elle analyse les interactions et les dynamiques au sein du système relationnel.</li>
+  <li><strong>Les TCCE (Thérapies Comportementales, Cognitives et Émotionnelles)</strong> : c'est l'approche que je pratique. J'y suis attachée parce qu'elle permet de travailler à la fois sur les pensées, les émotions et les comportements, avec des outils concrets et un vrai respect du rythme de chacun.</li>
+  <li><strong>L'EMDR (Eye Movement Desensitization and Reprocessing)</strong> : elle est souvent proposée lorsqu'un traumatisme ou un stress post-traumatique est au premier plan. Elle peut parfois être associée aux TCCE.</li>
+  <li><strong>La thérapie psychanalytique ou psychodynamique</strong> : elle s'appuie davantage sur l'histoire de vie, les conflits inconscients et les répétitions relationnelles. Certaines personnes s'y sentent très à l'aise lorsqu'elles souhaitent un travail en profondeur sur la durée.</li>
+  <li><strong>L'ACT (Acceptance and Commitment Therapy)</strong> : cette approche issue des TCC aide à faire de la place à ce qui est difficile, tout en se reconnectant à ses valeurs et à ce qui compte vraiment.</li>
+  <li><strong>La thérapie systémique</strong> : elle est particulièrement utilisée en thérapie de couple ou familiale, car elle s'intéresse aux interactions entre les personnes plutôt qu'à un seul individu.</li>
 </ul>
 
-<p>Si vous ne savez pas quelle approche choisir, n'hésitez pas à poser la question directement lors d'un premier entretien. Un bon thérapeute sera toujours en mesure d'expliquer clairement sa méthode et ses bénéfices attendus.</p>
+<p>Si vous hésitez entre plusieurs approches, vous avez le droit de poser des questions dès le premier échange. Un bon psychopraticien saura vous répondre simplement et honnêtement.</p>
 
 <h2>Comment se préparer à sa première séance ?</h2>
 
-<p>La première séance avec un psychopraticien est souvent source d'appréhension. Voici quelques points pour aborder cette rencontre sereinement :</p>
+<p>La première séance impressionne souvent. C'est normal. Vous allez rencontrer une personne inconnue et lui parler de quelque chose de sensible. Pour rendre ce moment un peu plus doux, vous pouvez :</p>
 
 <ul>
-  <li><strong>Préparez une courte présentation de votre situation</strong> : ce qui vous amène à consulter, depuis combien de temps, les événements déclencheurs éventuels.</li>
-  <li><strong>Notez vos questions</strong> sur la méthode, la durée estimée du suivi, les tarifs et les modalités pratiques.</li>
-  <li><strong>Sachez qu'il est normal d'être ému ou mal à l'aise</strong> lors des premières séances. Parler de soi à un inconnu demande un effort d'adaptation.</li>
-  <li><strong>Vous pouvez vous arrêter à tout moment</strong> : la thérapie n'est pas une obligation. Si vous ne vous sentez pas à votre place après 2 ou 3 séances, il est tout à fait légitime de chercher un autre professionnel.</li>
+  <li><strong>Préparer une courte présentation de votre situation</strong> : ce qui vous amène aujourd'hui, depuis quand cela dure, et ce que vous aimeriez voir changer.</li>
+  <li><strong>Noter vos questions</strong> sur la méthode, le rythme des séances, les tarifs ou le cadre du suivi.</li>
+  <li><strong>Vous rappeler qu'il est normal d'être ému ou mal à l'aise</strong> : beaucoup de personnes pleurent, cherchent leurs mots ou minimisent ce qu'elles vivent pendant une première rencontre. Il n'y a rien d'anormal à cela.</li>
+  <li><strong>Garder en tête que vous restez libre</strong> : commencer une thérapie n'est pas signer un contrat moral. Vous pouvez prendre le temps de sentir si cet accompagnement vous convient réellement.</li>
 </ul>
 
 <h2>Prendre rendez-vous avec un psychopraticien à Montpellier</h2>
 
 <p>Je propose des séances de <strong>thérapie individuelle</strong>, de <strong>thérapie de couple</strong> et de <strong>thérapie familiale</strong>, ainsi qu'un accompagnement spécialisé pour les <strong>troubles alimentaires</strong>.</p>
 
-<p>Mon approche est fondée sur les TCCE (Thérapies Comportementales, Cognitives et Émotionnelles), une méthode validée scientifiquement, adaptée à chaque patient. Pour prendre rendez-vous, vous pouvez utiliser le <a href="/contact">formulaire de contact</a> ou réserver directement en ligne sur psychologue.net.</p>
+<p>Mon approche est fondée sur les TCCE (Thérapies Comportementales, Cognitives et Émotionnelles). Dans ma pratique, cela veut dire un accompagnement à la fois structuré, attentif à votre histoire et ajusté à ce que vous vivez réellement. Pour prendre rendez-vous, vous pouvez utiliser le <a href="/contact">formulaire de contact</a> ou réserver directement en ligne sur psychologue.net.</p>

--- a/src/content/blog/trouver-psychopraticien-montpellier.md
+++ b/src/content/blog/trouver-psychopraticien-montpellier.md
@@ -13,11 +13,11 @@ author:
   title: "Psychopraticienne"
 ---
 
-<p>Trouver un psychopraticien à Montpellier n'est pas toujours simple, surtout quand on se sent déjà fatigué, inquiet ou perdu. Dans mon cabinet, j'entends souvent cette phrase : « Je ne sais pas vers qui me tourner. » Si c'est votre cas, sachez que vous n'êtes pas seul. J'ai écrit ce guide pour vous aider à y voir plus clair, avec des repères concrets et une parole plus humaine que les définitions que l'on trouve souvent en ligne.</p>
+<p>Trouver un psychopraticien n'est pas toujours simple, surtout quand on se sent déjà fatigué, inquiet ou perdu. Dans mon cabinet, j'entends souvent cette phrase : « Je ne sais pas vers qui me tourner. » Si c'est votre cas, sachez que vous n'êtes pas seul. J'ai écrit ce guide pour vous aider à y voir plus clair, avec des repères concrets et une parole plus humaine que les définitions que l'on trouve souvent en ligne.</p>
 
-<h2>Psychologue, psychiatre, psychopraticien : quelles différences à Montpellier ?</h2>
+<h2>Psychologue, psychiatre, psychopraticien : quelles différences ?</h2>
 
-<p>À Montpellier comme ailleurs, plusieurs professionnels peuvent accompagner la souffrance psychique. La différence n'est pas toujours évidente au premier abord, alors voici ce que j'explique souvent aux personnes qui me contactent :</p>
+<p>Plusieurs professionnels peuvent accompagner la souffrance psychique. La différence n'est pas toujours évidente au premier abord, alors voici ce que j'explique souvent aux personnes qui me contactent :</p>
 
 <ul>
   <li><strong>Le psychiatre</strong> est médecin. Il peut poser un diagnostic médical, prescrire des médicaments et ses consultations sont remboursées par la Sécurité sociale. Il intervient notamment lorsque les troubles sont sévères ou nécessitent un suivi médical.</li>
@@ -27,7 +27,7 @@ author:
 
 <h2>Quand consulter un psychopraticien plutôt qu'un autre professionnel ?</h2>
 
-<p>Dans ma pratique de psychopraticienne à Montpellier, je reçois souvent des personnes qui sentent que quelque chose ne va plus, sans savoir si leur souffrance est « assez importante » pour consulter. Vous n'avez pas besoin d'attendre d'aller très mal. Un accompagnement peut être précieux si vous traversez par exemple :</p>
+<p>Dans ma pratique, je reçois souvent des personnes qui sentent que quelque chose ne va plus, sans savoir si leur souffrance est « assez importante » pour consulter. Vous n'avez pas besoin d'attendre d'aller très mal. Un accompagnement peut être précieux si vous traversez par exemple :</p>
 
 <ul>
   <li>Une anxiété légère à modérée, du stress chronique ou des phobies</li>
@@ -40,9 +40,9 @@ author:
 
 <p>En revanche, si vous faites face à des idées suicidaires, à des épisodes psychotiques, à une addiction sévère ou à des symptômes très envahissants, il est essentiel de vous orienter d'abord vers un médecin ou un psychiatre. Demander le bon soutien au bon moment, c'est déjà prendre soin de vous.</p>
 
-<h2>Comment choisir son psychopraticien à Montpellier ?</h2>
+<h2>Comment choisir son psychopraticien ?</h2>
 
-<p>Choisir un psychopraticien dans l'Hérault, ce n'est pas seulement comparer des tarifs ou des adresses. C'est aussi chercher une personne avec qui vous pourrez vous sentir suffisamment en sécurité pour parler vrai. Voici les repères que je trouve les plus importants :</p>
+<p>Choisir un psychopraticien, ce n'est pas seulement comparer des tarifs ou des adresses. C'est aussi chercher une personne avec qui vous pourrez vous sentir suffisamment en sécurité pour parler vrai. Voici les repères que je trouve les plus importants :</p>
 
 <h3>1. Vérifiez sa formation</h3>
 <p>N'hésitez pas à demander quelle formation le thérapeute a suivie et avec quelle approche il travaille. Les Thérapies Comportementales et Cognitives, ainsi que les TCCE, sont souvent très aidantes pour l'anxiété, la dépression ou les troubles du comportement alimentaire. L'important est que le professionnel puisse vous expliquer clairement sa façon de travailler, sans flou ni grands discours.</p>
@@ -51,14 +51,14 @@ author:
 <p>Je le dis souvent : au-delà de la méthode, la relation compte énormément. Si vous sentez que vous pouvez parler sans être jugé, que vous êtes accueilli avec respect et que quelque chose de la confiance peut se construire, c'est un bon signe. Et si, après 2 ou 3 séances, vous ne vous sentez pas à votre place, il est tout à fait légitime de chercher un autre professionnel.</p>
 
 <h3>3. Renseignez-vous sur les tarifs et le remboursement</h3>
-<p>À Montpellier, les séances de psychopraticien se situent généralement entre 50 € et 80 €. Certaines mutuelles proposent un remboursement partiel : cela peut soulager un peu le coût du suivi, donc cela vaut la peine de vous renseigner en amont.</p>
+<p>Les séances de psychopraticien se situent généralement entre 50 € et 80 €. Certaines mutuelles proposent un remboursement partiel : cela peut soulager un peu le coût du suivi, donc cela vaut la peine de vous renseigner en amont.</p>
 
 <h3>4. Vérifiez la localisation et les horaires</h3>
 <p>Quand on hésite déjà à consulter, chaque détail pratique compte. Mon cabinet se situe au <strong>1086 Avenue Albert Einstein, 34000 Montpellier</strong>, accessible depuis le centre-ville, Castelnau-le-Lez, Lattes et Pérols. J'y reçois du lundi au vendredi, de 8h à 12h et de 14h à 19h.</p>
 
-<h2>Quelles approches thérapeutiques existe-t-il à Montpellier ?</h2>
+<h2>Quelles approches thérapeutiques existent ?</h2>
 
-<p>On choisit parfois un thérapeute pour sa proximité géographique, puis on découvre que l'approche ne nous correspond pas. C'est pour cela que je vous encourage à vous intéresser aussi à la méthode utilisée. À Montpellier, vous pouvez rencontrer plusieurs approches :</p>
+<p>On choisit parfois un thérapeute pour sa proximité géographique, puis on découvre que l'approche ne nous correspond pas. C'est pour cela que je vous encourage à vous intéresser aussi à la méthode utilisée. Voici les principales approches que vous pouvez rencontrer :</p>
 
 <ul>
   <li><strong>Les TCCE (Thérapies Comportementales, Cognitives et Émotionnelles)</strong> : c'est l'approche que je pratique. J'y suis attachée parce qu'elle permet de travailler à la fois sur les pensées, les émotions et les comportements, avec des outils concrets et un vrai respect du rythme de chacun.</li>

--- a/src/content/blog/trouver-psychopraticien-montpellier.md
+++ b/src/content/blog/trouver-psychopraticien-montpellier.md
@@ -86,4 +86,4 @@ imageUrl: "https://images.pexels.com/photos/5699456/pexels-photo-5699456.jpeg"
 
 <p>Je propose des séances de <strong>thérapie individuelle</strong>, de <strong>thérapie de couple</strong> et de <strong>thérapie familiale</strong>, ainsi qu'un accompagnement spécialisé pour les <strong>troubles alimentaires</strong>.</p>
 
-<p>Mon approche est fondée sur les TCCE (Thérapies Comportementales, Cognitives et Émotionnelles). Dans ma pratique, cela veut dire un accompagnement à la fois structuré, attentif à votre histoire et ajusté à ce que vous vivez réellement. Pour prendre rendez-vous, vous pouvez utiliser le <a href="/contact">formulaire de contact</a> ou réserver directement en ligne sur psychologue.net.</p>
+<p>Mon approche est fondée sur les TCCE (Thérapies Comportementales, Cognitives et Émotionnelles). Dans ma pratique, cela veut dire un accompagnement à la fois structuré, attentif à votre histoire et ajusté à ce que vous vivez réellement. Pour prendre rendez-vous, vous pouvez utiliser le <a href="/contact">formulaire de contact</a>.</p>

--- a/src/pages/services/therapie-de-couple.astro
+++ b/src/pages/services/therapie-de-couple.astro
@@ -86,7 +86,7 @@ const jsonLd = [
         <h2 class="font-serif text-2xl text-sage-800 mb-3">Comment se déroule une thérapie de couple ?</h2>
         <p class="text-sage-600 leading-relaxed mb-4">La thérapie de couple repose sur des séances de 60 ou 90 minutes au cabinet du 1086 avenue Albert Einstein à Montpellier. Les deux partenaires sont accueillis ensemble dans un espace neutre et confidentiel. Je guide les échanges sans prendre parti pour l'un ou l'autre : mon rôle est de faciliter une communication constructive et d'aider chaque partenaire à exprimer ses besoins et à entendre ceux de l'autre.</p>
         <p class="text-sage-600 leading-relaxed mb-4">Des séances individuelles alternées peuvent être proposées ponctuellement, selon la dynamique du suivi, pour permettre à chacun d'explorer sa propre part dans la relation. L'objectif n'est pas de « sauver le couple à tout prix », mais d'améliorer la communication et la compréhension mutuelle — que cela conduise à une reconstruction du lien ou à une séparation plus apaisée.</p>
-        <p class="text-sage-600 leading-relaxed">La fréquence habituelle est d'une séance toutes les une à deux semaines. Un premier bilan est établi après 4 à 6 séances pour réévaluer les objectifs ensemble.</p>
+        <p class="text-sage-600 leading-relaxed">La fréquence habituelle est d'une séance toutes les 2 à 3 semaines. Un bilan intermédiaire est établi après 2 à 3 séances pour réévaluer les objectifs ensemble.</p>
       </div>
 
       <div>

--- a/src/pages/services/therapie-familiale.astro
+++ b/src/pages/services/therapie-familiale.astro
@@ -86,7 +86,7 @@ const jsonLd = [
         <h2 class="font-serif text-2xl text-sage-800 mb-3">Comment se déroule une thérapie familiale ?</h2>
         <p class="text-sage-600 leading-relaxed mb-4">La thérapie familiale réunit deux membres de la famille ou plus dans un même espace thérapeutique, au cabinet du 1086 avenue Albert Einstein à Montpellier. Les séances durent <strong class="font-semibold text-sage-700">60 ou 90 minutes</strong> selon le nombre de participants et la complexité de la situation. Tous les membres de la famille ne sont pas obligés d'être présents à chaque séance : j'adapte le format à ceux qui souhaitent s'impliquer dans la démarche.</p>
         <p class="text-sage-600 leading-relaxed mb-4">La première séance est consacrée à la présentation de chacun, à l'exposition des tensions vécues et à la définition des objectifs partagés. J'adopte une posture de facilitatrice neutre : je veille à ce que chaque voix soit entendue, y compris celle des enfants ou adolescents, et guide la famille vers des modes d'interaction plus respectueux.</p>
-        <p class="text-sage-600 leading-relaxed">Le rythme habituel est d'une séance toutes les une à deux semaines. Un bilan intermédiaire est réalisé après 4 à 6 séances pour réévaluer les objectifs et ajuster l'accompagnement.</p>
+        <p class="text-sage-600 leading-relaxed">Le rythme habituel est d'une séance toutes les 2 à 3 semaines. Un bilan intermédiaire est réalisé après 2 à 3 séances pour réévaluer les objectifs et ajuster l'accompagnement.</p>
       </div>
 
       <div>

--- a/src/pages/services/therapie-individuelle.astro
+++ b/src/pages/services/therapie-individuelle.astro
@@ -92,7 +92,7 @@ const jsonLd = [
 
       <div>
         <h2 class="font-serif text-2xl text-sage-800 mb-3">Mon approche : les TCCE</h2>
-        <p class="text-sage-600 leading-relaxed mb-4">Je suis formée aux Thérapies Comportementales, Cognitives et Émotionnelles (TCCE) — une approche validée scientifiquement par de nombreuses études cliniques internationales. Les TCCE travaillent sur le lien entre pensées, émotions et comportements : en modifiant les schémas de pensée automatiques, on agit progressivement sur les émotions et les actions qui en découlent.</p>
+        <p class="text-sage-600 leading-relaxed mb-4">Je suis formée aux Thérapies Comportementales, Cognitives et Émotionnelles (TCCE). Cette approche travaille sur le lien entre pensées, émotions et comportements : en modifiant les schémas de pensée automatiques, on agit progressivement sur les émotions et les actions qui en découlent.</p>
         <p class="text-sage-600 leading-relaxed mb-4">Concrètement, si vous souffrez d'anxiété sociale, la thérapie vous aidera à identifier les pensées automatiques négatives (« je vais me ridiculiser »), à les questionner et à expérimenter progressivement des situations sociales dans un cadre sécurisé. Les résultats sont mesurables et les progrès visibles à chaque étape du suivi.</p>
         <p class="text-sage-600 leading-relaxed">Les TCCE sont particulièrement efficaces pour : anxiété, dépression, troubles du comportement alimentaire, phobies, stress post-traumatique et faible estime de soi.</p>
       </div>

--- a/src/pages/services/troubles-alimentaires.astro
+++ b/src/pages/services/troubles-alimentaires.astro
@@ -91,7 +91,7 @@ const jsonLd = [
 
       <div>
         <h2 class="font-serif text-2xl text-sage-800 mb-3">Mon approche : les TCCE appliquées aux TCA</h2>
-        <p class="text-sage-600 leading-relaxed mb-4">Formée aux Thérapies Comportementales, Cognitives et Émotionnelles (TCCE), je m'appuie sur une approche dont l'efficacité pour les troubles alimentaires est reconnue par de nombreuses études cliniques. Les TCCE agissent sur les trois dimensions interdépendantes du trouble : la pensée, les émotions et les comportements.</p>
+        <p class="text-sage-600 leading-relaxed mb-4">Formée aux Thérapies Comportementales, Cognitives et Émotionnelles (TCCE), je m'appuie sur des outils concrets qui agissent sur les trois dimensions interdépendantes du trouble : la pensée, les émotions et les comportements.</p>
         <p class="text-sage-600 leading-relaxed mb-4">Concrètement, si vous souffrez d'hyperphagie boulimique, la thérapie vous aidera à identifier les émotions déclenchantes (stress, tristesse, ennui, honte), à comprendre les pensées automatiques qui précèdent les crises (« j'ai échoué, autant tout gâcher »), et à construire des comportements alternatifs pour répondre à ces émotions sans passer par la nourriture.</p>
         <p class="text-sage-600 leading-relaxed">La thérapie travaille également sur l'image corporelle : les pensées distordues sur le corps, le jugement de valeur lié au poids ou à l'apparence, et la relation à soi-même. L'objectif n'est pas la perfection physique mais une relation apaisée et respectueuse avec votre corps et votre alimentation.</p>
       </div>


### PR DESCRIPTION
## Summary

Deux axes d'amélioration du contenu rédactionnel du site :

1. **Pages services** — suppression des mentions verbeux de validation scientifique et ajustement des rythmes thérapeutiques
2. **Blog** — réécriture éditoriale des 3 articles d'avril 2026 pour un ton plus humain, personnel et bienveillant, tout en conservant le SEO

## Changes

### Pages de services
- `therapie-individuelle.astro` — supprime « une approche validée scientifiquement par de nombreuses études cliniques internationales »
- `troubles-alimentaires.astro` — supprime « dont l'efficacité est reconnue par de nombreuses études cliniques »
- `therapie-de-couple.astro` — rythme : toutes les **2 à 3 semaines**, bilan intermédiaire après **2 à 3 séances** (au lieu de 1-2 sem. / 4-6 séances)
- `therapie-familiale.astro` — idem

### Articles de blog
- `trouver-psychopraticien-montpellier.md` (26 avril) — réécriture avec voix à la 1ère personne, Oriane s'adresse directement au lecteur perdu
- `therapie-couple-montpellier-guide.md` (27 avril) — intro qui reconnaît la souffrance du couple, ton empathique
- `gestion-stress-anxiete-montpellier.md` (28 avril) — valide l'expérience des personnes anxieuses, moins de jargon clinique

SEO conservé : mots-cls, structure H2/H3, frontmatter YAML, liens internes.

## Testing
- [ ] Relecture manuelle des 3 articles
- [ ] Vérification rendu visuel sur preview Netlify
- [ ] Audit pa11y (aucun composant modifié, risque minimal)

## Quality Gate
- [ ] `npm run lint` ✅
- [ ] Pas de changements TypeScript/composants