### PR TITLE
feat(admin): vue patients avec historique et nouveau RDV

### DIFF
--- a/src/components/admin/AdminCreateButton.tsx
+++ b/src/components/admin/AdminCreateButton.tsx
@@ -10,10 +10,15 @@ import {
   FIRST_SESSION_DISCOUNT,
 } from "../../lib/pricing";
 import type { AppointmentType, AppointmentDuration, AppointmentMode } from "../../lib/pricing";
+import type { PrefillData } from "../../types/patient";
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
+
+interface AdminCreateButtonProps {
+  prefillData?: PrefillData;
+}
 
 interface FormState {
   patient_name: string;
@@ -120,7 +125,7 @@ function Input({
 // Main Component
 // ---------------------------------------------------------------------------
 
-export function AdminCreateButton() {
+export function AdminCreateButton({ prefillData }: AdminCreateButtonProps = {}) {
   const [open, setOpen] = useState(false);
 
   return (
@@ -142,7 +147,12 @@ export function AdminCreateButton() {
         </svg>
         Nouveau rendez-vous
       </button>
-      {open && <AdminCreateModal onClose={() => setOpen(false)} />}
+      {open && (
+        <AdminCreateModal
+          onClose={() => setOpen(false)}
+          prefillData={prefillData}
+        />
+      )}
     </>
   );
 }
@@ -151,8 +161,12 @@ export function AdminCreateButton() {
 // Modal Component (internal)
 // ---------------------------------------------------------------------------
 
-function AdminCreateModal({ onClose }: { onClose: () => void }) {
-  const [form, setForm] = useState<FormState>(INITIAL_STATE);
+function AdminCreateModal({ onClose, prefillData }: { onClose: () => void; prefillData?: PrefillData }) {
+  const initialFormState = prefillData
+    ? { ...INITIAL_STATE, ...prefillData }
+    : INITIAL_STATE;
+
+  const [form, setForm] = useState<FormState>(initialFormState);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -195,6 +209,11 @@ function AdminCreateModal({ onClose }: { onClose: () => void }) {
       previousFocusRef.current?.focus();
     };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Réinitialise le formulaire si prefillData change pendant que la modale est ouverte.
+  useEffect(() => {
+    setForm(prefillData ? { ...INITIAL_STATE, ...prefillData } : INITIAL_STATE);
+  }, [prefillData]);  
 
   function isDirty() {
     return (

--- a/src/components/admin/PatientList.tsx
+++ b/src/components/admin/PatientList.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { toast, Toaster } from "react-hot-toast";
 import { getModeLabel, getTypeLabel } from "../../lib/pricing";
 import { AdminCreateButton } from "./AdminCreateButton";
 import type { Patient, PrefillData, AppointmentStatus } from "../../types/patient";
@@ -32,12 +33,21 @@ function getPanelId(email: string): string {
   return `patient-panel-${email.replace(/[^a-zA-Z0-9_-]/g, "-")}`;
 }
 
+function getReviewableAppointmentId(patient: Patient): string | null {
+  const reviewableAppointment = patient.appointments.find(
+    (appointment) =>
+      appointment.status === "confirmed" || appointment.status === "payment_received",
+  );
+  return reviewableAppointment?.id ?? null;
+}
+
 export function PatientList() {
   const [patients, setPatients] = useState<Patient[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [includeArchived, setIncludeArchived] = useState(false);
   const [expandedPatientEmail, setExpandedPatientEmail] = useState<string | null>(null);
+  const [reviewLoadingEmail, setReviewLoadingEmail] = useState<string | null>(null);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -77,8 +87,38 @@ export function PatientList() {
     return () => controller.abort();
   }, [includeArchived]);
 
+  async function handleSendReviewReminder(patient: Patient) {
+    const appointmentId = getReviewableAppointmentId(patient);
+    if (!appointmentId) {
+      toast.error("Aucun rendez-vous confirmé à relancer pour ce patient.", { duration: 4000 });
+      return;
+    }
+
+    setReviewLoadingEmail(patient.email);
+    try {
+      const response = await fetch("/api/send-review-email/", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "same-origin",
+        body: JSON.stringify({ appointmentId }),
+      });
+
+      if (!response.ok) {
+        const body = (await response.json()) as { error?: string };
+        throw new Error(body.error ?? "Erreur lors de l'envoi du rappel d'avis");
+      }
+
+      toast.success(`Relance d'avis envoyée à ${patient.name}.`, { duration: 4000 });
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Erreur inconnue", { duration: 4000 });
+    } finally {
+      setReviewLoadingEmail((current) => (current === patient.email ? null : current));
+    }
+  }
+
   return (
     <section className="space-y-4">
+      <Toaster position="top-right" />
       <div className="flex items-center justify-between gap-3">
         <p className="text-sm text-sage-500 font-sans">
           {loading ? "Chargement..." : `${patients.length} patient${patients.length > 1 ? "s" : ""}`}
@@ -123,6 +163,8 @@ export function PatientList() {
               patient_phone: patient.phone,
               appointment_type: patient.lastAppointmentType,
             };
+            const reviewableAppointmentId = getReviewableAppointmentId(patient);
+            const isReviewActionDisabled = !reviewableAppointmentId || reviewLoadingEmail === patient.email;
 
             return (
               <li key={patient.email} className="rounded-2xl border border-sage-200 bg-white">
@@ -163,7 +205,14 @@ export function PatientList() {
                     <div className="flex flex-wrap items-center justify-between gap-3">
                       <h3 className="font-serif text-lg text-sage-800">Historique des rendez-vous</h3>
                       <div className="flex items-center gap-2">
-                        <span className="text-sm text-sage-600 font-sans">Proposer un RDV</span>
+                        <button
+                          type="button"
+                          onClick={() => handleSendReviewReminder(patient)}
+                          disabled={isReviewActionDisabled}
+                          className="inline-flex items-center px-4 py-2 text-sm font-medium font-sans rounded-xl border border-sage-300 text-sage-700 hover:bg-sage-50 focus:outline-none focus:ring-2 focus:ring-sage-300 focus:ring-offset-1 transition-colors disabled:opacity-60 disabled:cursor-not-allowed min-h-[40px]"
+                        >
+                          {reviewLoadingEmail === patient.email ? "Envoi..." : "Relancer avis"}
+                        </button>
                         <AdminCreateButton prefillData={prefillData} />
                       </div>
                     </div>

--- a/src/components/admin/PatientList.tsx
+++ b/src/components/admin/PatientList.tsx
@@ -1,0 +1,195 @@
+import { useEffect, useState } from "react";
+import { getModeLabel, getTypeLabel } from "../../lib/pricing";
+import { AdminCreateButton } from "./AdminCreateButton";
+import type { Patient, PrefillData, AppointmentStatus } from "../../types/patient";
+
+const STATUS_LABELS: Record<AppointmentStatus, string> = {
+  pending: "En attente",
+  confirmed: "Confirmé",
+  declined: "Refusé",
+  rescheduled: "Reporté",
+  payment_pending: "Paiement en attente",
+  payment_received: "Paiement reçu",
+  cancelled: "Annulé",
+};
+
+function formatDate(iso: string): string {
+  return new Intl.DateTimeFormat("fr-FR", {
+    day: "2-digit",
+    month: "long",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZone: "Europe/Paris",
+  }).format(new Date(iso));
+}
+
+function formatPrice(cents: number): string {
+  return `${Math.round(cents / 100)}€`;
+}
+
+function getPanelId(email: string): string {
+  return `patient-panel-${email.replace(/[^a-zA-Z0-9_-]/g, "-")}`;
+}
+
+export function PatientList() {
+  const [patients, setPatients] = useState<Patient[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [includeArchived, setIncludeArchived] = useState(false);
+  const [expandedPatientEmail, setExpandedPatientEmail] = useState<string | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    async function fetchPatients() {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await fetch(`/api/admin/patients?includeArchived=${String(includeArchived)}`, {
+          method: "GET",
+          credentials: "same-origin",
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          const body = (await response.json()) as { error?: string };
+          throw new Error(body.error ?? "Erreur lors du chargement des patients");
+        }
+
+        const body = (await response.json()) as { patients: Patient[] };
+        setPatients(body.patients ?? []);
+        setExpandedPatientEmail((current) =>
+          body.patients?.some((patient) => patient.email === current) ? current : null,
+        );
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        setError(err instanceof Error ? err.message : "Erreur inconnue");
+      } finally {
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
+      }
+    }
+
+    fetchPatients();
+
+    return () => controller.abort();
+  }, [includeArchived]);
+
+  return (
+    <section className="space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-sm text-sage-500 font-sans">
+          {loading ? "Chargement..." : `${patients.length} patient${patients.length > 1 ? "s" : ""}`}
+        </p>
+        <label className="inline-flex items-center gap-2 text-sm text-sage-700 font-sans">
+          <input
+            type="checkbox"
+            checked={includeArchived}
+            onChange={(event) => setIncludeArchived(event.target.checked)}
+            className="h-4 w-4 rounded border-sage-300 text-mint-700 focus:ring-mint-400"
+          />
+          Afficher les patients inactifs
+        </label>
+      </div>
+
+      {error && (
+        <p className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 font-sans" role="alert">
+          {error}
+        </p>
+      )}
+
+      {loading && (
+        <p className="text-sm text-sage-500 font-sans" role="status" aria-live="polite">
+          Chargement des patients...
+        </p>
+      )}
+
+      {!loading && !error && patients.length === 0 && (
+        <p className="rounded-2xl border border-sage-200 bg-white px-5 py-6 text-center text-sage-500 font-sans">
+          Aucun patient trouvé pour ce filtre.
+        </p>
+      )}
+
+      {!loading && !error && patients.length > 0 && (
+        <ul className="space-y-3">
+          {patients.map((patient) => {
+            const isExpanded = expandedPatientEmail === patient.email;
+            const panelId = getPanelId(patient.email);
+            const prefillData: PrefillData = {
+              patient_name: patient.name,
+              patient_email: patient.email,
+              patient_phone: patient.phone,
+              appointment_type: patient.lastAppointmentType,
+            };
+
+            return (
+              <li key={patient.email} className="rounded-2xl border border-sage-200 bg-white">
+                <button
+                  type="button"
+                  className="w-full px-4 py-4 text-left hover:bg-sage-50 focus:outline-none focus:ring-2 focus:ring-mint-400 rounded-2xl"
+                  aria-expanded={isExpanded}
+                  aria-controls={panelId}
+                  aria-label={`${isExpanded ? "Masquer" : "Afficher"} l'historique de ${patient.name}`}
+                  onClick={() => setExpandedPatientEmail(isExpanded ? null : patient.email)}
+                >
+                  <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+                    <div>
+                      <p className="text-xs text-sage-500 font-sans">Nom</p>
+                      <p className="text-sm text-sage-900 font-medium font-sans">{patient.name}</p>
+                    </div>
+                    <div>
+                      <p className="text-xs text-sage-500 font-sans">Email</p>
+                      <p className="text-sm text-sage-900 font-sans break-all">{patient.email}</p>
+                    </div>
+                    <div>
+                      <p className="text-xs text-sage-500 font-sans">Téléphone</p>
+                      <p className="text-sm text-sage-900 font-sans">{patient.phone || "—"}</p>
+                    </div>
+                    <div>
+                      <p className="text-xs text-sage-500 font-sans">Nombre de séances</p>
+                      <p className="text-sm text-sage-900 font-sans">{patient.sessionCount}</p>
+                    </div>
+                    <div>
+                      <p className="text-xs text-sage-500 font-sans">Dernier RDV</p>
+                      <p className="text-sm text-sage-900 font-sans">{formatDate(patient.lastAppointmentAt)}</p>
+                    </div>
+                  </div>
+                </button>
+
+                {isExpanded && (
+                  <div id={panelId} className="border-t border-sage-200 px-4 py-4 space-y-4">
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <h3 className="font-serif text-lg text-sage-800">Historique des rendez-vous</h3>
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm text-sage-600 font-sans">Proposer un RDV</span>
+                        <AdminCreateButton prefillData={prefillData} />
+                      </div>
+                    </div>
+                    <ul className="space-y-2">
+                      {patient.appointments.map((appointment) => (
+                        <li
+                          key={appointment.id}
+                          className="rounded-xl border border-sage-200 bg-sage-50 px-3 py-3"
+                        >
+                          <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-5 text-sm font-sans text-sage-700">
+                            <p><span className="text-sage-500">Date :</span> {formatDate(appointment.scheduledAt)}</p>
+                            <p><span className="text-sage-500">Type :</span> {getTypeLabel(appointment.appointmentType)}</p>
+                            <p><span className="text-sage-500">Mode :</span> {getModeLabel(appointment.appointmentMode)}</p>
+                            <p><span className="text-sage-500">Statut :</span> {STATUS_LABELS[appointment.status]}</p>
+                            <p><span className="text-sage-500">Montant :</span> {formatPrice(appointment.finalPrice)}</p>
+                          </div>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/pages/api/admin/patients.ts
+++ b/src/pages/api/admin/patients.ts
@@ -1,0 +1,107 @@
+export const prerender = false;
+
+import type { APIRoute } from 'astro';
+import { auth } from '../../../lib/auth';
+import { isAdminSession } from '../../../lib/authz';
+import { supabaseAdmin } from '../../../lib/supabase';
+import type { AppointmentSummary, Patient } from '../../../types/patient';
+
+type AppointmentRow = {
+  id: string;
+  patient_email: string;
+  patient_name: string;
+  patient_phone: string;
+  appointment_type: AppointmentSummary['appointmentType'];
+  appointment_mode: AppointmentSummary['appointmentMode'];
+  status: AppointmentSummary['status'];
+  final_price: number;
+  duration: number;
+  scheduled_at: string;
+};
+
+function errorResponse(status: number, message: string): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+export const GET: APIRoute = async ({ request, url }) => {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session?.user) {
+    return errorResponse(401, 'Non authentifié');
+  }
+  if (!isAdminSession(session)) {
+    return errorResponse(403, 'Accès refusé');
+  }
+
+  const includeArchived = url.searchParams.get('includeArchived') === 'true';
+  const activeThreshold = new Date();
+  activeThreshold.setMonth(activeThreshold.getMonth() - 3);
+  const activeThresholdMs = activeThreshold.getTime();
+
+  const { data, error } = await supabaseAdmin
+    .from('appointments')
+    .select('id, patient_email, patient_name, patient_phone, appointment_type, appointment_mode, status, final_price, duration, scheduled_at')
+    .is('deleted_at', null);
+
+  if (error) {
+    console.error('[admin/patients] Erreur DB:', error);
+    return errorResponse(500, 'Erreur lors de la récupération des patients');
+  }
+
+  const rows = (data ?? []) as AppointmentRow[];
+  const groupedByEmail = new Map<string, AppointmentRow[]>();
+
+  for (const row of rows) {
+    const bucket = groupedByEmail.get(row.patient_email);
+    if (bucket) {
+      bucket.push(row);
+    } else {
+      groupedByEmail.set(row.patient_email, [row]);
+    }
+  }
+
+  const patients: Patient[] = [];
+
+  for (const [email, appointmentsRows] of groupedByEmail.entries()) {
+    appointmentsRows.sort((a, b) => new Date(b.scheduled_at).getTime() - new Date(a.scheduled_at).getTime());
+    const last = appointmentsRows[0];
+    if (!last) continue;
+
+    const appointments: AppointmentSummary[] = appointmentsRows.map((appointment) => ({
+      id: appointment.id,
+      scheduledAt: appointment.scheduled_at,
+      appointmentType: appointment.appointment_type,
+      appointmentMode: appointment.appointment_mode,
+      status: appointment.status,
+      finalPrice: appointment.final_price,
+      duration: appointment.duration,
+    }));
+
+    const isActive = new Date(last.scheduled_at).getTime() >= activeThresholdMs;
+
+    patients.push({
+      email,
+      name: last.patient_name,
+      phone: last.patient_phone,
+      sessionCount: appointmentsRows.length,
+      lastAppointmentAt: last.scheduled_at,
+      lastAppointmentType: last.appointment_type,
+      lastAppointmentMode: last.appointment_mode,
+      isActive,
+      appointments,
+    });
+  }
+
+  const filteredPatients = includeArchived
+    ? patients
+    : patients.filter((patient) => patient.isActive);
+
+  filteredPatients.sort((a, b) => a.name.localeCompare(b.name, 'fr', { sensitivity: 'base' }));
+
+  return new Response(JSON.stringify({ patients: filteredPatients }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/src/pages/mes-rdvs.astro
+++ b/src/pages/mes-rdvs.astro
@@ -14,6 +14,7 @@ import Navbar from '../components/islands/Navbar';
 import { AppointmentCard } from '../components/admin/AppointmentCard';
 import { AdminCreateButton } from '../components/admin/AdminCreateButton';
 import GoogleCalendarStatus from '../components/admin/GoogleCalendarStatus';
+import { PatientList } from '../components/admin/PatientList';
 import { auth } from '../lib/auth';
 import { isAdminSession } from '../lib/authz';
 import { supabaseAdmin } from '../lib/supabase';
@@ -124,76 +125,123 @@ for (const appt of appointments) {
         <GoogleCalendarStatus client:load />
       </div>
 
-      <!-- Filtres par statut -->
-      <div
-        class="flex flex-wrap gap-2 mb-6"
-        role="group"
-        aria-label="Filtrer par statut"
-      >
-        {FILTERS.map(({ key, label }) => {
-          const count = counts[key] ?? 0;
-          if (key !== 'all' && count === 0) return null;
-          return (
-            <button
-              type="button"
-              data-filter={key}
-              class={`
-                filter-btn inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium font-sans
-                rounded-full border transition-colors focus:outline-none focus:ring-2 focus:ring-mint-400
-                ${key === 'all'
-                  ? 'bg-mint-600 text-white border-mint-600'
-                  : 'bg-white text-sage-600 border-sage-200 hover:border-mint-400 hover:text-mint-700'}
-              `}
-              aria-pressed={key === 'all' ? 'true' : 'false'}
-            >
-              {label}
-              <span class={`
-                inline-flex items-center justify-center w-5 h-5 text-xs rounded-full
-                ${key === 'all' ? 'bg-mint-500 text-white' : 'bg-sage-100 text-sage-600'}
-              `}>
-                {count}
-              </span>
-            </button>
-          );
-        })}
-      </div>
-
-      <!-- Message vide -->
-      {appointments.length === 0 && (
-        <div class="text-center py-16">
-          <div class="w-16 h-16 mx-auto mb-4 bg-sage-100 rounded-full flex items-center justify-center">
-            <svg class="w-8 h-8 text-sage-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-            </svg>
-          </div>
-          <p class="font-serif text-xl text-sage-600">Aucun rendez-vous</p>
-          <p class="text-sage-400 text-sm mt-1 font-sans">
-            Les nouvelles demandes apparaîtront ici.
-          </p>
-        </div>
-      )}
-
-      <!-- Liste des rendez-vous -->
-      <div id="appointments-list" class="space-y-4">
-        {appointments.map((appt) => (
-          <div
-            class="appointment-wrapper"
-            data-status={appt.status}
+      <!-- Onglets -->
+      <div class="mb-6" role="tablist" aria-label="Sections de gestion">
+        <div class="inline-flex rounded-xl border border-sage-200 bg-white p-1">
+          <button
+            type="button"
+            role="tab"
+            id="appointments-tab"
+            data-tab="appointments"
+            aria-selected="true"
+            aria-controls="appointments-tab-panel"
+            class="
+              tab-btn rounded-lg px-4 py-2 text-sm font-medium font-sans transition-colors
+              bg-mint-600 text-white
+              focus:outline-none focus:ring-2 focus:ring-mint-400
+            "
           >
-            <AppointmentCard client:load appointment={appt} />
-          </div>
-        ))}
+            Rendez-vous
+          </button>
+          <button
+            type="button"
+            role="tab"
+            id="patients-tab"
+            data-tab="patients"
+            aria-selected="false"
+            aria-controls="patients-tab-panel"
+            class="
+              tab-btn rounded-lg px-4 py-2 text-sm font-medium font-sans transition-colors
+              text-sage-600 hover:text-mint-700
+              focus:outline-none focus:ring-2 focus:ring-mint-400
+            "
+          >
+            Patients
+          </button>
+        </div>
       </div>
 
-      <!-- Message "aucun résultat pour ce filtre" (caché par défaut) -->
-      <p
-        id="no-filter-result"
-        class="hidden text-center py-12 text-sage-400 font-sans text-sm"
-        role="status"
-        aria-live="polite"
+      <section id="appointments-tab-panel" role="tabpanel" aria-labelledby="appointments-tab">
+        <!-- Filtres par statut -->
+        <div
+          class="flex flex-wrap gap-2 mb-6"
+          role="group"
+          aria-label="Filtrer par statut"
+        >
+          {FILTERS.map(({ key, label }) => {
+            const count = counts[key] ?? 0;
+            if (key !== 'all' && count === 0) return null;
+            return (
+              <button
+                type="button"
+                data-filter={key}
+                class={`
+                  filter-btn inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium font-sans
+                  rounded-full border transition-colors focus:outline-none focus:ring-2 focus:ring-mint-400
+                  ${key === 'all'
+                    ? 'bg-mint-600 text-white border-mint-600'
+                    : 'bg-white text-sage-600 border-sage-200 hover:border-mint-400 hover:text-mint-700'}
+                `}
+                aria-pressed={key === 'all' ? 'true' : 'false'}
+              >
+                {label}
+                <span class={`
+                  inline-flex items-center justify-center w-5 h-5 text-xs rounded-full
+                  ${key === 'all' ? 'bg-mint-500 text-white' : 'bg-sage-100 text-sage-600'}
+                `}>
+                  {count}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+
+        <!-- Message vide -->
+        {appointments.length === 0 && (
+          <div class="text-center py-16">
+            <div class="w-16 h-16 mx-auto mb-4 bg-sage-100 rounded-full flex items-center justify-center">
+              <svg class="w-8 h-8 text-sage-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+              </svg>
+            </div>
+            <p class="font-serif text-xl text-sage-600">Aucun rendez-vous</p>
+            <p class="text-sage-400 text-sm mt-1 font-sans">
+              Les nouvelles demandes apparaîtront ici.
+            </p>
+          </div>
+        )}
+
+        <!-- Liste des rendez-vous -->
+        <div id="appointments-list" class="space-y-4">
+          {appointments.map((appt) => (
+            <div
+              class="appointment-wrapper"
+              data-status={appt.status}
+            >
+              <AppointmentCard client:load appointment={appt} />
+            </div>
+          ))}
+        </div>
+
+        <!-- Message "aucun résultat pour ce filtre" (caché par défaut) -->
+        <p
+          id="no-filter-result"
+          class="hidden text-center py-12 text-sage-400 font-sans text-sm"
+          role="status"
+          aria-live="polite"
+        >
+          Aucun rendez-vous pour ce filtre.
+        </p>
+      </section>
+
+      <section
+        id="patients-tab-panel"
+        role="tabpanel"
+        aria-labelledby="patients-tab"
+        class="hidden"
       >
-        Aucun rendez-vous pour ce filtre.
-      </p>
+        <PatientList client:load />
+      </section>
 
     </div>
   </main>
@@ -256,6 +304,43 @@ for (const appt of appointments) {
       const filter = btn.dataset['filter'] ?? 'all';
       sessionStorage.setItem('mes-rdvs-filter', filter);
       applyFilter(filter);
+    });
+  });
+
+  // ── Onglets Rendez-vous / Patients ──────────────────────────────────────────
+  const tabButtons = document.querySelectorAll<HTMLButtonElement>('.tab-btn');
+  const appointmentsTabPanel = document.getElementById('appointments-tab-panel');
+  const patientsTabPanel = document.getElementById('patients-tab-panel');
+
+  function setActiveTab(tab: 'appointments' | 'patients') {
+    tabButtons.forEach((button) => {
+      const isActive = button.dataset['tab'] === tab;
+      button.setAttribute('aria-selected', String(isActive));
+      if (isActive) {
+        button.classList.add('bg-mint-600', 'text-white');
+        button.classList.remove('text-sage-600', 'hover:text-mint-700');
+      } else {
+        button.classList.remove('bg-mint-600', 'text-white');
+        button.classList.add('text-sage-600', 'hover:text-mint-700');
+      }
+    });
+
+    appointmentsTabPanel?.classList.toggle('hidden', tab !== 'appointments');
+    patientsTabPanel?.classList.toggle('hidden', tab !== 'patients');
+    sessionStorage.setItem('mes-rdvs-tab', tab);
+  }
+
+  const savedTab = sessionStorage.getItem('mes-rdvs-tab');
+  if (savedTab === 'appointments' || savedTab === 'patients') {
+    setActiveTab(savedTab);
+  } else {
+    setActiveTab('appointments');
+  }
+
+  tabButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const tab = button.dataset['tab'] === 'patients' ? 'patients' : 'appointments';
+      setActiveTab(tab);
     });
   });
 </script>

--- a/src/types/patient.ts
+++ b/src/types/patient.ts
@@ -1,0 +1,101 @@
+/**
+ * TypeScript types — Patients
+ *
+ * There is no `patients` table in the database.
+ * Patient records are derived by aggregating the `appointments` table,
+ * grouped by `patient_email`.
+ *
+ * Prices are always expressed in centimes (integer, consistent with appointments).
+ * Dates are ISO 8601 strings (TIMESTAMPTZ → string via JSON).
+ */
+
+import type { AppointmentType, AppointmentMode, AppointmentStatus } from './appointment';
+
+// ---------------------------------------------------------------------------
+// Re-export for consumers that only import from this module
+// ---------------------------------------------------------------------------
+
+export type { AppointmentType, AppointmentMode, AppointmentStatus };
+
+// ---------------------------------------------------------------------------
+// Lightweight appointment snapshot attached to a patient record
+// ---------------------------------------------------------------------------
+
+/**
+ * A condensed view of a single appointment used inside a `Patient` aggregate.
+ * Contains only the fields relevant for patient history display; for the full
+ * record use the `Appointment` type from `./appointment`.
+ */
+export interface AppointmentSummary {
+  /** UUID of the appointment row. */
+  id: string;
+  /** ISO 8601 timestamp — maps to `appointments.scheduled_at`. */
+  scheduledAt: string;
+  /** Session category (individual / couple / family). */
+  appointmentType: AppointmentType;
+  /** Delivery mode (in-person / video). */
+  appointmentMode: AppointmentMode;
+  /** Workflow status of the appointment. */
+  status: AppointmentStatus;
+  /** Amount charged in centimes — maps to `appointments.final_price`. */
+  finalPrice: number;
+  /** Session length in minutes — maps to `appointments.duration`. */
+  duration: number;
+}
+
+// ---------------------------------------------------------------------------
+// Patient aggregate (derived from appointments)
+// ---------------------------------------------------------------------------
+
+/**
+ * A patient record built by aggregating all non-soft-deleted appointments
+ * sharing the same `patient_email`.
+ *
+ * Aggregation rules:
+ * - `name` / `phone` → taken from the most recent appointment (`MAX(scheduled_at)`).
+ * - `sessionCount` → `COUNT(*)` excluding soft-deleted rows (`deleted_at IS NULL`).
+ * - `lastAppointmentAt` → `MAX(scheduled_at)` ISO string.
+ * - `isActive` → `lastAppointmentAt >= NOW() - INTERVAL '3 months'`.
+ * - `appointments` → full history, ordered by `scheduled_at DESC`.
+ */
+export interface Patient {
+  /** Aggregation key — maps to `appointments.patient_email`. */
+  email: string;
+  /** Patient display name from the most recent known appointment. */
+  name: string;
+  /** Contact phone number from the most recent known appointment. */
+  phone: string;
+  /** Total number of non-soft-deleted appointments for this patient. */
+  sessionCount: number;
+  /** ISO 8601 timestamp of the most recent appointment (`MAX(scheduled_at)`). */
+  lastAppointmentAt: string;
+  /** Appointment type of the most recent appointment. */
+  lastAppointmentType: AppointmentType;
+  /** Appointment mode of the most recent appointment. */
+  lastAppointmentMode: AppointmentMode;
+  /**
+   * Whether the patient is considered active.
+   * `true` when `lastAppointmentAt >= NOW() - INTERVAL '3 months'`.
+   */
+  isActive: boolean;
+  /** Full appointment history for this patient, ordered by `scheduledAt` DESC. */
+  appointments: AppointmentSummary[];
+}
+
+// ---------------------------------------------------------------------------
+// Pre-fill payload for AdminCreateButton
+// ---------------------------------------------------------------------------
+
+/**
+ * Pre-fill data passed to `AdminCreateButton` (and the underlying booking form)
+ * when creating a new appointment on behalf of an existing patient.
+ * Field names intentionally match the `CreateAppointmentData` / form field names
+ * so they can be spread directly into the form's default values.
+ */
+export interface PrefillData {
+  patient_name: string;
+  patient_email: string;
+  patient_phone: string;
+  /** Suggested appointment type based on the patient's last session. */
+  appointment_type: AppointmentType;
+}


### PR DESCRIPTION
## Summary
Ajoute une vue Patients dans le dashboard admin pour retrouver rapidement l’historique d’un patient et proposer un nouveau RDV pré-rempli.

## Changes
- ajoute `GET /api/admin/patients` (auth admin, agrégation depuis `appointments`, filtre `includeArchived`)
- ajoute `src/types/patient.ts` (Patient, AppointmentSummary, PrefillData)
- ajoute l’island `PatientList` (liste, toggle inactifs, détail inline, historique)
- étend `AdminCreateButton` avec `prefillData?` pour pré-remplir la modale
- intègre des onglets `Rendez-vous / Patients` dans `mes-rdvs` avec persistance `sessionStorage`

## Related
Closes #23

## Artifacts
- Spec: `artifacts/specs/23-admin-vue-patients-historique-rdv-spec.md`
- Plan: `artifacts/plans/23-admin-vue-patients-historique-rdv-plan.md`

## Testing
- [x] Lint
- [x] Build
- [ ] Tests automatisés (framework non présent dans le repo)
- [x] Test manuel: navigation onglets, ouverture fiche patient, bouton RDV pré-rempli

## Quality Gate
- [x] `npm run lint`
- [x] `npm run build`