### PR TITLE
fix(calendar): résoudre CalendarAuthError quand GOOGLE_OAUTH_REFRESH_TOKEN est mis à jour

### DIFF
--- a/artifacts/analyses/46-ameliorer-seo-top3-therapeute-montpellier-analysis.md
+++ b/artifacts/analyses/46-ameliorer-seo-top3-therapeute-montpellier-analysis.md
@@ -1,0 +1,287 @@
+---
+issue: 46
+title: "Améliorer le SEO pour cibler le top 3 sur 'thérapeute Montpellier' et termes associés"
+type: feature
+complexity: L
+tier: F-full
+---
+
+## Problem
+
+Le site omf-therapie.fr est invisible sur les requêtes Google à fort intent commercial dans la zone Montpellier. Malgré un socle technique correct (meta, OG, JSON-LD, canonical, sitemap), plusieurs lacunes structurelles empêchent d'atteindre le top 3.
+
+---
+
+## Current State — Audit SEO Complet
+
+### ✅ Points forts existants
+
+| Élément | État |
+|---------|------|
+| Meta title/description | ✅ Présents et optimisés avec "Montpellier" |
+| Canonical URLs | ✅ Définis sur toutes les pages |
+| Open Graph | ✅ Complet |
+| JSON-LD (LocalBusiness, Person, Service, FAQ) | ✅ Présent — avantage vs concurrents |
+| Sitemap.xml | ✅ Auto-généré par @astrojs/sitemap |
+| robots.txt | ✅ Présent, correctement configuré |
+| HTTPS | ✅ Netlify |
+| Mobile-first | ✅ Tailwind responsive |
+| Blog | ✅ 12 articles, 2 ciblés Montpellier |
+| Pages de service dédiées | ✅ 4 services (individuel, couple, famille, TCA) |
+| Google Search Console | ✅ Configurée |
+| Google Business Profile | ✅ Configuré |
+
+### 🔴 Lacunes critiques identifiées
+
+#### 1. Schema.org — Type à vérifier selon statut professionnel
+```
+Actuel  : "@type": "HealthAndBeautyBusiness"
+```
+
+> ⚠️ **Attention au statut :** Le type `Psychologist` serait inapproprié car Oriane est **psychopraticienne** (non réglementée), pas psychologue (titre réglementé). Utiliser `Psychologist` en schema.org pourrait créer une confusion et une incohérence avec le contenu.
+
+Le type `HealthAndBeautyBusiness` est acceptable mais peut être enrichi avec :
+- `additionalType` pointant vers `https://schema.org/LocalBusiness`
+- Une `description` précise incluant "psychopraticienne TCCE"
+
+**Schemas manquants (sans ambiguïté de statut) :**
+- `AggregateRating` dans LocalBusiness (avis Google → rich snippet étoiles)
+- `BreadcrumbList` sur toutes les pages (breadcrumbs HTML existent mais pas en schema)
+- `WebSite` avec `SearchAction` (sitelinks search box)
+- `serviceType` et `termsOfService` enrichis dans les schemas de service
+
+#### 2. Page "Anxiété" inexistante
+La requête "anxiété aide psy" / "thérapeute anxiété Montpellier" n'a **aucune landing page dédiée**. Il n'existe qu'un article de blog généraliste. Or :
+- L'anxiété est la spécialité la plus recherchée en thérapie (60%+ des consultations)
+- Une page `/services/anxiete-montpellier` avec 1500+ mots capterait cette requête
+- Les concurrents n'ont pas non plus cette page → opportunité de first-mover
+
+#### 3. Profondeur de contenu insuffisante sur les pages de service
+| Page | Mots de contenu (hors HTML) |
+|------|---------------------------|
+| therapie-individuelle.astro | ~788 mots |
+| therapie-de-couple.astro | ~856 mots |
+| Concurrents top 3 | ~2 353–3 308 mots/page |
+
+Google valorise la **profondeur sémantique**. Les pages de service doivent atteindre **1 200–1 500 mots** pour compétir sur les requêtes transactionnelles.
+
+#### 4. COMPANY_DESCRIPTION générique (impact E-E-A-T)
+```typescript
+// src/config/global.config.ts — actuel
+export const COMPANY_DESCRIPTION = "Thérapeute professionnelle dédiée à votre bien-être et à votre développement personnel."
+```
+Cette description ne mentionne ni "Montpellier", ni la spécialité TCCE, ni les services clés. Elle alimente le schema `Person.description` et affecte le Knowledge Graph Google.
+
+#### 5. E-E-A-T insuffisant pour le secteur YMYL (santé)
+Google applique les critères E-E-A-T (Experience, Expertise, Authoritativeness, Trustworthiness) avec la plus grande rigueur dans le secteur santé (contenu YMYL — "Your Money or Your Life").
+
+**Manque sur le site :**
+- Numéro ADELI ou équivalent non mentionné (signal de légitimité professionnelle en France)
+- Associations/syndicats professionnels non mentionnés
+- Aucun témoignage patient (même anonymisé avec consentement)
+- Author bio insuffisante dans les articles de blog (pas de lien vers la page À propos)
+- `Person.hasCredential` en schema.ts présent mais trop vague (pas d'institution précise)
+
+#### 6. Absence de citations locales (off-page local SEO)
+Google Map Pack (3-pack local) requiert une présence dans les annuaires de confiance.
+
+> ⚠️ **Note importante — statut professionnel :** Oriane est **psychopraticienne** (profession non réglementée) et non psychothérapeute ni psychologue (titres réglementés en France). **Doctolib est donc exclu** (réservé aux professions réglementées et secteur médical). Les annuaires cibles sont ceux du bien-être / paramédicaux.
+
+| Annuaire | Présence actuelle | Impact |
+|----------|-------------------|--------|
+| therapeutes.com | ❓ Inconnu | 🔴 Élevé — spécifique psychopraticiens |
+| annuaire-therapeutes.com | ❓ Inconnu | 🔴 Élevé |
+| resalib.fr | ❓ Inconnu | 🟠 Élevé — agenda en ligne + annuaire |
+| medoucine.com | ❓ Inconnu | 🟠 Élevé — médecines douces / bien-être |
+| PagesJaunes.fr | ❓ Inconnu | 🟠 Élevé — fort signal local Google |
+| psychologue.net | ❓ Inconnu | 🟠 Moyen — ouvert aux psychopraticiens |
+| Instagram omf.therapie | ✅ Présent | 🟡 Moyen — signal sameAs |
+| LinkedIn professionnel | ❓ Inconnu | 🟡 Moyen |
+
+La cohérence NAP (Nom, Adresse, Téléphone) entre ces sources et le site est un facteur de ranking local majeur.
+
+#### 7. Liaison interne (internal linking) incomplète
+- Un seul article de blog (`therapie-couple-montpellier-guide.md`) pointe vers `/services/`
+- Les 11 autres articles ne créent aucun lien entrant vers les pages de service
+- Les pages de service ne se lient pas entre elles (ex : thérapie individuelle ne propose pas la thérapie de couple)
+- Pas de lien depuis le blog vers `/contact` ou `/rendez-vous`
+
+#### 8. Google Business Profile — optimisation partielle probable
+Le GBP est configuré mais potentiellement sous-optimisé :
+- Catégorie principale : devrait être "Psychothérapeute" ou "Psychologue" (pas "Thérapeute")
+- Photos du cabinet (intérieur, extérieur) → signal de confiance
+- Posts GBP mensuels → signal d'activité
+- Gestion des avis → critical ranking factor pour le Local Pack
+
+---
+
+## Analyse concurrentielle
+
+| Site | Title | Schema | Mots | Avantage clé |
+|------|-------|--------|------|-------------|
+| therapie-montpellier.com | Psychothérapie intégrative à Montpellier | ❌ | ~2 353 | Contenu riche, domaine ancré |
+| therapeute-montpellier.fr | **Thérapeute Montpellier** - Hicham Hassa | ❌ | ~3 194 | **Exact keyword domain** (EMD) |
+| gorana-psy-montpellier.com | Psychothérapeute à Montpellier | ❌ | ~3 308 | Domaine ancré, autorité |
+| **omf-therapie.fr** | Oriane Montabonnet — Psychopraticienne | ✅ | ~800 | **JSON-LD complet, SSG, UX** |
+
+**Constat :** Aucun concurrent n'utilise schema.org → avantage technique unique à consolider. Leur force réside dans l'ancienneté du domaine, les backlinks accumulés, et la profondeur de contenu.
+
+---
+
+## Impact
+
+- **Utilisateurs affectés :** Patients potentiels à Montpellier ne trouvant pas le site
+- **Sévérité :** high
+- **Revenus affectés :** Directement (prise de RDV = CA)
+- **Fichiers affectés :**
+  - `src/utils/schema.ts` (schema.org)
+  - `src/config/global.config.ts` (COMPANY_DESCRIPTION)
+  - `src/pages/services/` (nouvelles pages + enrichissement)
+  - `src/content/blog/` (liaison interne + nouveaux articles)
+  - `src/pages/index.astro` (schema WebSite)
+  - Toutes les pages `.astro` (BreadcrumbList schema)
+
+---
+
+## Approach Options
+
+### Option A — Quick wins techniques (2–3 semaines)
+**Périmètre :** Uniquement les modifications de code.
+1. Fix schema.org : `Psychologist` + `AggregateRating` + `BreadcrumbList` + `WebSite`
+2. COMPANY_DESCRIPTION optimisée
+3. Nouvelle page `/services/anxiete-montpellier`
+4. Enrichissement des meta titles (ajouter "thérapeute" sur la home)
+5. Liens internes blog → services
+
+**Pros :** Rapide, impact mesurable en 4–8 semaines, ne dépend que du développeur.
+**Cons :** N'adresse pas l'autorité de domaine ni le gap de contenu.
+**Risk :** medium — améliore le classement mais insuffisant seul pour le top 3.
+
+### Option B — SEO Stack complet (2–6 mois) ⭐ RECOMMANDÉ
+**Périmètre :** Option A + contenu + off-page.
+
+**Phase 1 (semaines 1–2) — Technique :** Option A en intégralité
+**Phase 2 (semaines 3–6) — Contenu :**
+- Enrichissement pages de service → 1 500 mots
+- Plan de blog : 1 article/mois ciblé requête locale (ex : "thérapie de couple Montpellier", "anxiété traitement Montpellier")
+- Amélioration page À propos : ADELI, certifications précises, photo récente
+
+**Phase 3 (mois 2–3) — Off-page :**
+- Inscription therapeutes.com, resalib.fr, medoucine.com, PagesJaunes (NAP cohérent)
+- Optimisation GBP : catégorie précise "psychopraticienne", photos, posts mensuels, demande d'avis aux patients consentants
+
+**Phase 4 (mois 3–6) — Autorité :**
+- Partenariats avec médecins généralistes locaux pour backlinks
+- Articles invités sur blogs santé/bien-être Montpellier
+- Associations professionnelles (FF2P, SNPPsy)
+
+**Pros :** Stratégie complète pour le top 3. Traite les 3 piliers SEO (technique, contenu, autorité).
+**Cons :** Nécessite implication de la praticienne (contenu). Timeline 6 mois.
+**Risk :** low — best practice industry pour YMYL.
+
+### Option C — Content-first (3–4 mois)
+**Périmètre :** Expansion massive du contenu sans toucher au technique.
+- 20+ articles de blog longue traîne
+- Pages de service 2 000+ mots
+- Vidéos de présentation intégrées
+
+**Pros :** Autorité thématique forte long terme.
+**Cons :** Impact plus lent, ne corrige pas les défauts techniques schema.
+**Risk :** medium — Google peut ne pas valoriser le contenu sans fixes techniques.
+
+---
+
+## Recommendation
+
+**Option B — SEO Stack complet**, avec priorité absolue sur la Phase 1 (technique) car elle génère un impact immédiat sans dépendances externes.
+
+La clé du top 3 requiert les 3 leviers simultanément :
+- **Technique :** schema `Psychologist` + page anxiété (différenciateur technique unique vs concurrents)
+- **Contenu :** profondeur sémantique ≥ 1 500 mots (niveau des top 3 actuels)
+- **Off-page :** Doctolib + annuaires (autorité locale, Map Pack)
+
+---
+
+## Analyse des mots-clés longue traîne
+
+### Requêtes cibles principales (head terms)
+
+| Requête | Intention | Concurrence estimée |
+|---------|-----------|---------------------|
+| thérapeute Montpellier | Transactionnelle | 🔴 Élevée |
+| thérapie de couple Montpellier | Transactionnelle | 🟠 Moyenne |
+| psychopraticienne Montpellier | Transactionnelle | 🟢 Faible (niche) |
+
+### Longue traîne — opportunités faible concurrence
+
+**Anxiété & stress (page à créer) :**
+- "aide anxiété Montpellier" — intent fort, peu de landing pages dédiées
+- "thérapie anxiété sociale adulte Montpellier"
+- "thérapeute pour panique Montpellier"
+- "accompagnement anxiété TCCE Montpellier"
+- "comment gérer anxiété Montpellier"
+
+**Couple :**
+- "thérapie de couple Montpellier prix séance"
+- "psychopraticien couple Montpellier"
+- "thérapie conjugale après infidélité Montpellier"
+- "communication couple thérapeute Montpellier"
+
+**Famille & adolescents :**
+- "thérapie familiale adolescent Montpellier"
+- "thérapeute adolescent difficile Montpellier"
+- "médiation familiale Montpellier séparation"
+
+**Troubles alimentaires :**
+- "aide troubles alimentaires Montpellier"
+- "psychopraticien TCA Montpellier"
+- "alimentation émotionnelle thérapeute Montpellier"
+- "accompagnement boulimie Montpellier"
+
+**Informationnel (blog) — capturer les "People Also Ask" :**
+- "différence psychopraticien psychologue psychothérapeute"
+- "comment choisir son thérapeute Montpellier"
+- "thérapie TCCE c'est quoi"
+- "thérapeute remboursé mutuelle Montpellier"
+- "séance thérapie individuelle combien de temps"
+- "thérapie couple sauver relation"
+
+**Géographique (longue traîne locale) :**
+- "thérapeute Castelnau-le-Lez"
+- "psychopraticien Lattes"
+- "thérapeute Pérols Hérault"
+- "cabinet thérapie quartier Albert Einstein Montpellier"
+
+### Stratégie de contenu par requête
+
+| Type | Action | Requêtes ciblées |
+|------|--------|-----------------|
+| Page service | Créer `/services/anxiete-montpellier` | anxiété + Montpellier (head + longue traîne) |
+| Page service | Enrichir `/services/therapie-de-couple` | couple Montpellier longue traîne |
+| Blog article | "Psychopraticien vs psychologue : quelle différence ?" | différenciation + crédibilité |
+| Blog article | "Thérapie de couple à Montpellier : tout ce qu'il faut savoir" | longue traîne couple |
+| Blog article | "Aide pour l'anxiété à Montpellier : comprendre et trouver un soutien" | longue traîne anxiété locale |
+| Blog article | "Thérapeute remboursé mutuelle : ce qu'il faut savoir" | requête informationnelle forte |
+
+---
+
+## Priorité des tâches (ordre d'impact)
+
+| Priorité | Action | Impact | Effort | Délai effet |
+|----------|--------|--------|--------|-------------|
+| P0 | AggregateRating schema (avis → rich snippets) | 🔴 Élevé | Faible | 4–8 sem |
+| P1 | Page `/services/anxiete-montpellier` (1500 mots) | 🔴 Élevé | Moyen | 4–8 sem |
+| P2 | `BreadcrumbList` + `WebSite` schema | 🟠 Élevé | Faible | 4–8 sem |
+| P3 | Enrichissement pages service → 1500 mots | 🟠 Élevé | Fort | 6–12 sem |
+| P4 | COMPANY_DESCRIPTION + E-E-A-T about page | 🟠 Moyen | Faible | 4–8 sem |
+| P5 | Liaison interne blog → services | 🟡 Moyen | Faible | 4–8 sem |
+| P6 | GBP : photos + posts mensuels + catégorie | 🟠 Élevé | Moyen | 2–6 sem |
+| P7 | Annuaires (therapeutes.com, resalib, PagesJaunes) | 🟠 Élevé | Moyen | 4–12 sem |
+| P8 | Blog : 4 articles longue traîne locale/trimestre | 🟡 Moyen | Fort | 8–16 sem |
+
+---
+
+## Appetite
+
+Estimated tier: F-full
+Spike findings: Analyse concurrentielle directe réalisée (web scraping headers + schema audit). Aucun concurrent n'utilise JSON-LD — avantage à exploiter. Doctolib est LE premier résultat sur "thérapeute Montpellier" — présence indispensable.

--- a/artifacts/frames/46-ameliorer-seo-top3-therapeute-montpellier-frame.md
+++ b/artifacts/frames/46-ameliorer-seo-top3-therapeute-montpellier-frame.md
@@ -1,0 +1,71 @@
+---
+issue: 46
+title: "Améliorer le SEO pour cibler le top 3 sur 'thérapeute Montpellier' et termes associés"
+status: approved
+tier: F-full
+created: 2026-05-27
+---
+
+## Problem Statement
+
+Le site omf-therapie.fr est invisible sur les recherches Google les plus importantes pour attirer des patients à Montpellier : "thérapeute à Montpellier", "thérapie de couple", "anxiété aide psy". Cette invisibilité organique prive la praticienne de nouveaux patients alors que la concurrence locale est présente et visible.
+
+## Why This Matters
+
+- **Impact praticienne :** Pas de visibilité = pas de nouveaux patients via Google, canal d'acquisition principal dans le secteur de la santé mentale.
+- **Valeur business :** Un top 3 sur "thérapeute Montpellier" peut générer 10+ nouvelles demandes de contact/mois sans budget publicitaire récurrent.
+- **Enjeu concurrentiel :** Les premiers résultats Google captent 65–75 % des clics organiques ; être hors top 5 équivaut à être invisible.
+
+## Success Criteria
+
+- Apparaître en position 1–3 sur "thérapeute Montpellier" dans Google.fr en moins de 6 mois
+- Apparaître en top 5 sur "thérapie de couple Montpellier" et requêtes d'anxiété associées
+- Recevoir ≥10 nouvelles demandes de contact/mois provenant du trafic organique Google
+- Augmentation mesurable du trafic organique (Google Search Console)
+
+## Constraints
+
+- Site statique Astro 5 (SSG) — les modifications doivent rester compatibles avec le build static + Netlify
+- Pas de CMS headless pour l'instant — contenu managé via fichiers Markdown
+- Budget publicitaire limité (SEO organique uniquement, pas de Google Ads)
+- Calendrier : 6 mois pour atteindre les positions cibles
+- Praticienne = seule auteure du contenu — nécessite des templates/guidelines clairs
+
+## Out of Scope
+
+- Campagnes Google Ads / SEA
+- Refonte complète de l'architecture du site
+- Support multilingue
+- Portail patient ou espace membre
+- SEO hors France / hors Montpellier
+
+## Stakeholders
+
+- **Oriane Montabonnet** (praticienne) — bénéficiaire principale, source du contenu
+- **Patients potentiels à Montpellier** — audience cible des recherches
+- **Développeur** — responsable des optimisations techniques
+
+## Appetite
+
+Tier: F-full
+Reasoning: SEO implique plusieurs domaines interdépendants — technique (schema.org, meta, Core Web Vitals, sitemap), contenu (pages de service, blog, mots-clés longue traîne), et off-page (Google Business Profile, backlinks locaux). Chaque domaine est un chantier à part entière.
+
+## Open Questions
+
+- ~~Le site est-il indexé par Google (Search Console configurée) ?~~ ✓ Oui, configurée
+- ~~Existe-t-il déjà un profil Google Business Profile ?~~ ✓ Oui, configuré
+- ~~Quels sont les concurrents directs déjà positionnés en top 3 ?~~ ✓ Identifiés :
+  - https://therapie-montpellier.com/
+  - https://therapeute-montpellier.fr/
+  - https://www.gorana-psy-montpellier.com/
+- Y a-t-il des backlinks existants vers le site ?
+- Les Core Web Vitals actuels (LCP, CLS, FID/INP) sont-ils dans les seuils Google ?
+
+## Premise Validity
+
+**Success in 6 months:** Apparaître en position 1–3 sur 'thérapeute Montpellier' et recevoir 10 nouvelles demandes/mois via le site.
+
+**Failure in 6 months:** Toujours hors top 5 sur les 3 requêtes cibles après 6 mois d'optimisations et 0 augmentation du trafic organique.
+
+**Simplest alternative:** Publier une seule page optimisée 'Thérapeute Montpellier'.
+**Why not simplest:** Google privilégie les sites avec autorité de domaine, contenu riche et thématique cohérente, et backlinks de qualité. Une seule page ne construit pas l'autorité nécessaire pour dépasser les annuaires (Doctolib, PagesJaunes) et les concurrents établis.

--- a/artifacts/specs/46-ameliorer-seo-top3-therapeute-montpellier-spec.md
+++ b/artifacts/specs/46-ameliorer-seo-top3-therapeute-montpellier-spec.md
@@ -1,0 +1,137 @@
+---
+issue: 46
+title: "Améliorer le SEO pour cibler le top 3 sur 'thérapeute Montpellier' et termes associés"
+tier: F-full
+status: approved
+---
+
+## Goal
+
+Atteindre le top 3 Google sur "thérapeute Montpellier" et les requêtes associées (anxiété, thérapie de couple) en 6 mois, via 4 leviers : technique schema.org, nouvelles pages de service, enrichissement du contenu existant, et off-page (annuaires + GBP).
+
+## Context
+
+Le site omf-therapie.fr est construit avec Astro 5 (SSG), TypeScript, Tailwind. La gestion du SEO est centralisée dans :
+- `src/layouts/Layout.astro` — meta head, JSON-LD injection
+- `src/utils/schema.ts` — builders de schemas structurés
+- `src/config/global.config.ts` — métadonnées globales
+- `src/pages/services/*.astro` — pages de service (4 existantes)
+- `src/content/blog/*.md` — articles blog (12 existants)
+
+Les 3 concurrents top 3 n'utilisent **aucun schema.org** — avantage à consolider.
+Les avis clients existent déjà sur **Google Business Profile**, **psychologue.net** et **PagesJaunes** → AggregateRating activable immédiatement.
+La praticienne rédige le contenu ; le développeur intègre et optimise.
+
+---
+
+## Acceptance Criteria
+
+### Pilier 1 — Schema.org enrichi
+- [ ] **AC-S1** — Le schema `LocalBusiness` sur la homepage inclut un bloc `AggregateRating` avec `ratingValue`, `ratingCount` et `reviewCount` correspondant aux avis réels GBP
+- [ ] **AC-S2** — Chaque page avec breadcrumb HTML (services, blog, a-propos, contact) génère aussi un schema `BreadcrumbList` valide et vérifié dans le Rich Results Test de Google
+- [ ] **AC-S3** — La homepage expose un schema `WebSite` avec `SearchAction` (sitelinks search box)
+- [ ] **AC-S4** — Le schema `LocalBusiness` inclut un champ `description` enrichi ("psychopraticienne TCCE à Montpellier, spécialisée en thérapie individuelle, de couple, familiale et troubles alimentaires")
+- [ ] **AC-S5** — `COMPANY_DESCRIPTION` dans `global.config.ts` est mis à jour pour refléter la spécialité + localité
+
+### Pilier 2 — Nouvelle page "Anxiété"
+- [ ] **AC-P1** — La page `/services/anxiete-montpellier` existe et est accessible
+- [ ] **AC-P2** — La page contient ≥ 1 200 mots de contenu textuel (hors balises HTML)
+- [ ] **AC-P3** — La page a un `<title>` incluant "anxiété" et "Montpellier", une meta-description ≤ 160 caractères, et une URL canonique
+- [ ] **AC-P4** — La page expose un schema `Service` + `FAQPage` (≥ 4 questions)
+- [ ] **AC-P5** — La page est listée dans le sitemap généré par Astro
+- [ ] **AC-P6** — La page apparaît dans la navigation de `/services/index.astro`
+- [ ] **AC-P7** — Au moins 3 articles de blog existants traitant de l'anxiété pointent vers cette nouvelle page (lien interne)
+
+### Pilier 3 — Enrichissement contenu existant
+- [ ] **AC-C1** — La page `therapie-individuelle.astro` atteint ≥ 1 200 mots de contenu textuel (actuel : ~788)
+- [ ] **AC-C2** — La page `therapie-de-couple.astro` atteint ≥ 1 200 mots de contenu textuel (actuel : ~856)
+- [ ] **AC-C3** — La page `a-propos.astro` mentionne explicitement la spécialité TCCE, la ville Montpellier dans le H1 ou premier paragraphe, et l'approche intégrative
+- [ ] **AC-C4** — Les articles de blog qui mentionnent des services spécifiques contiennent au moins 1 lien interne vers la page de service correspondante
+- [ ] **AC-C5** — Chaque article de blog expose un lien vers `/contact` ou `/rendez-vous` en fin d'article (CTA)
+
+### Pilier 4 — Off-page (checklist / guide — non automatisable)
+- [ ] **AC-O1** — Un guide de référencement dans les annuaires est fourni (therapeutes.com, resalib.fr, medoucine.com, PagesJaunes) avec les informations NAP exactes à utiliser
+- [ ] **AC-O2** — La description du Google Business Profile est alignée avec la meta description de la homepage (cohérence NAP + wording)
+- [ ] **AC-O3** — Une checklist d'optimisation GBP est fournie (catégorie, photos, posts, réponse aux avis)
+
+---
+
+## Breadboard
+
+### Slice 1 — Schema enrichissements (technique)
+
+| Surface | Action | Handler | Données |
+|---------|--------|---------|---------|
+| `src/utils/schema.ts` | Ajouter `buildAggregateRatingSchema()` | `buildLocalBusinessSchema()` l'intègre | ratingValue, ratingCount, reviewCount |
+| `src/utils/schema.ts` | Ajouter `buildBreadcrumbSchema(items)` | Appelé dans chaque page `.astro` | `[{name, url}]` |
+| `src/utils/schema.ts` | Ajouter `buildWebSiteSchema()` | Appelé dans `index.astro` | SITE_URL, SearchAction |
+| `src/config/global.config.ts` | Mettre à jour `COMPANY_DESCRIPTION` | Utilisé dans schema Person | string |
+| `src/pages/index.astro` | Passer `buildWebSiteSchema()` dans `jsonLd` | Layout.astro injection | — |
+| `src/pages/services/*.astro` | Passer `buildBreadcrumbSchema()` dans `jsonLd` | Layout.astro injection | items breadcrumb |
+| `src/pages/a-propos.astro` | Passer `buildBreadcrumbSchema()` | Layout.astro injection | — |
+| `src/pages/contact.astro` | Passer `buildBreadcrumbSchema()` | Layout.astro injection | — |
+| `src/pages/blog/[slug].astro` | Passer `buildBreadcrumbSchema()` | Layout.astro injection | slug, title |
+
+### Slice 2 — Nouvelle page anxiété
+
+| Surface | Action | Handler | Données |
+|---------|--------|---------|---------|
+| `src/pages/services/anxiete-montpellier.astro` | Créer page complète | Layout.astro | meta, schema Service+FAQ, contenu ≥1200 mots |
+| `src/pages/services/index.astro` | Ajouter card "Anxiété" | ServicesSection component | lien /services/anxiete-montpellier |
+| `src/content/blog/gerer-anxiete-quotidien-*` | Ajouter lien interne | Markdown | lien vers /services/anxiete-montpellier |
+| `src/content/blog/gestion-stress-anxiete-*` | Ajouter lien interne | Markdown | lien vers /services/anxiete-montpellier |
+
+### Slice 3 — Enrichissement pages existantes
+
+| Surface | Action | Handler | Données |
+|---------|--------|---------|---------|
+| `src/pages/services/therapie-individuelle.astro` | Ajouter sections contenu | HTML inline | ~400 mots supplémentaires |
+| `src/pages/services/therapie-de-couple.astro` | Ajouter sections contenu | HTML inline | ~350 mots supplémentaires |
+| `src/pages/a-propos.astro` | Enrichir bio + TCCE mention | HTML inline | Montpellier dans H1 check |
+| `src/content/blog/*.md` | Ajouter liens internes + CTA | Markdown | 1 lien service + 1 CTA/article |
+
+### Slice 4 — Off-page guide
+
+| Surface | Action | Handler | Données |
+|---------|--------|---------|---------|
+| `docs/seo-offpage-guide.md` | Créer guide annuaires | — | NAP cohérent, checklist GBP |
+
+---
+
+## Slices (ordre d'exécution)
+
+**Slice 1 — Schema enrichissements** *(impact immédiat, 0 dépendances)*
+Fichiers : `src/utils/schema.ts`, `src/config/global.config.ts`, `src/pages/index.astro`, toutes les pages `.astro` existantes.
+Durée estimée : 2–3h. Peut être déployé indépendamment.
+
+**Slice 2 — Nouvelle page anxiété** *(dépend du contenu praticienne)*
+Fichiers : `src/pages/services/anxiete-montpellier.astro`, `src/pages/services/index.astro`, 2 articles blog.
+Durée estimée : 2–4h (dev) + rédaction praticienne.
+
+**Slice 3 — Enrichissement contenu existant** *(dépend du contenu praticienne)*
+Fichiers : 2 pages service, `a-propos.astro`, ~8 articles blog.
+Durée estimée : 1–2h (dev intégration) + rédaction praticienne.
+
+**Slice 4 — Off-page guide** *(autonome — ne bloque pas les autres)*
+Fichiers : `docs/seo-offpage-guide.md`.
+Durée estimée : 1h (rédaction guide).
+
+---
+
+## Out of Scope
+
+- Intégration Doctolib (profession non réglementée — non éligible)
+- Support multilingue
+- Refonte de l'architecture du site
+- Google Ads / SEA
+- Implémentation d'un CMS headless
+- Automated ranking tracking (outil tiers, hors code)
+- Modification du type schema `HealthAndBeautyBusiness` → `Psychologist` (titre réglementé en France)
+
+---
+
+## Open Questions
+
+- ~~[NEEDS CLARIFICATION: Combien d'avis existent sur GBP / note moyenne ?]~~ → **14 avis** — ratingValue à vérifier dans GBP avant déploiement (viser la valeur exacte pour AggregateRating)
+- ~~[NEEDS CLARIFICATION: La page `/services/index.astro` utilise `ServicesSection` — modifier le component ou la page ?]~~ → **Modifier la page Astro directement**
+- ~~[NEEDS CLARIFICATION: Contenu anxiété — praticienne d'abord ou IA draft ?]~~ → **IA génère un premier jet, praticienne valide avant déploiement**

--- a/src/lib/google-calendar.ts
+++ b/src/lib/google-calendar.ts
@@ -160,6 +160,18 @@ async function getPersistedOAuthClient(): Promise<Auth.OAuth2Client | null> {
     await supabaseAdmin.from('google_oauth_tokens').upsert(tokens);
   }
 
+  // 2b. Override stale refresh token if env var has been updated since last persist
+  const envRefreshToken = import.meta.env.GOOGLE_OAUTH_REFRESH_TOKEN;
+  if (envRefreshToken && envRefreshToken !== tokens.refresh_token) {
+    console.warn('[calendar] Refresh token overridden by GOOGLE_OAUTH_REFRESH_TOKEN env var');
+    tokens.refresh_token = envRefreshToken;
+    tokens.expiry_date = 0; // Force immediate refresh below
+    await supabaseAdmin
+      .from('google_oauth_tokens')
+      .update({ refresh_token: envRefreshToken, expiry_date: 0, updated_at: new Date().toISOString() })
+      .eq('id', 'therapist');
+  }
+
   // 3. Proactive refresh: refresh if token expires within 5 minutes
   if (!tokens.expiry_date || tokens.expiry_date < Date.now() + 5 * 60 * 1000) {
     oauth2Client.setCredentials({ refresh_token: tokens.refresh_token });


### PR DESCRIPTION
## Summary
Corrige le bug de production `CalendarAuthError: OAuth consent revoked` qui persistait même après avoir défini un nouveau `GOOGLE_OAUTH_REFRESH_TOKEN`.

## Root Cause

## Changes
- Après le chargement depuis la DB, compare `GOOGLE_OAUTH_REFRESH_TOKEN` au token persisté
- Si différent, met à jour la DB avec le nouveau token et force `expiry_date = 0` pour déclencher un refresh immédiat
- Log `console.warn` pour traçabilité dans les logs serveur

## Testing
- [ ] Reproduire avec un token révoqué en DB + nouveau token en env var → doit fonctionner au prochain appel
- [ ] Si env var == DB → aucune écriture superflue (guard sur l'égalité)

## Quality Gate
- [x] `npm run lint` ✅ (aucune nouvelle erreur)