### PR TITLE
fix(calendar): re-autorisation OAuth admin + alerte invalid_grant (AC-3)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,9 @@
   command = "npm run build"
   publish = "dist"
 
+[functions]
+  directory = "netlify/functions"
+
 [build.environment]
   NODE_VERSION = "20"
   # ---------------------------------------------------------------------------

--- a/netlify/functions/calendar-token-heartbeat.ts
+++ b/netlify/functions/calendar-token-heartbeat.ts
@@ -1,0 +1,179 @@
+/**
+ * Netlify Scheduled Function — calendar-token-heartbeat
+ *
+ * Runs weekly to proactively refresh the Google OAuth access token, preventing
+ * Google from revoking it due to inactivity (~6 months idle = automatic revocation).
+ *
+ * Schedule: @weekly (every Sunday at 00:00 UTC)
+ *
+ * ⚠️  Runtime: Node.js (Netlify Functions) — import.meta.env is NOT available.
+ *     All env vars are read via process.env.
+ *
+ * ⚠️  Dependencies — all already present in package.json:
+ *   "googleapis"           ✓
+ *   "@supabase/supabase-js" ✓
+ *   "@netlify/functions"   ✓ (devDependencies)
+ *   "react"                ✓
+ *   "@react-email/render"  ✓
+ *   "resend"               ✓
+ *
+ * Env vars required (configure in Netlify dashboard):
+ *   SUPABASE_DATABASE_URL     — Supabase REST URL
+ *   SUPABASE_SERVICE_ROLE_KEY — Supabase service-role key
+ *   GOOGLE_OAUTH_CLIENT_ID
+ *   GOOGLE_OAUTH_CLIENT_SECRET
+ *   GOOGLE_OAUTH_REDIRECT_URI (optional, fallback: https://developers.google.com/oauthplayground)
+ *   ADMIN_EMAIL               — alert recipient on invalid_grant
+ *   SITE_URL                  (optional, fallback: https://omf-therapie.fr)
+ *   RESEND_API_KEY            — for alert emails
+ *   RESEND_FROM_EMAIL         (optional, fallback: OMF Thérapie <contact@omf-therapie.fr>)
+ */
+
+import type { Config } from '@netlify/functions';
+import { createElement } from 'react';
+import { createClient } from '@supabase/supabase-js';
+import { google } from 'googleapis';
+import { Resend } from 'resend';
+import { render } from '@react-email/render';
+import CalendarAuthAlert from '../../src/emails/CalendarAuthAlert.js';
+
+// ---------------------------------------------------------------------------
+// Schedule config
+// ---------------------------------------------------------------------------
+
+export const config: Config = {
+  schedule: '@weekly',
+};
+
+// ---------------------------------------------------------------------------
+// Helper — send alert email on invalid_grant
+// ---------------------------------------------------------------------------
+
+async function sendInvalidGrantAlert(
+  adminEmail: string,
+  siteUrl: string,
+  resendApiKey: string,
+  fromEmail: string,
+): Promise<void> {
+  const reauthorizeUrl = `${siteUrl}/api/admin/google-oauth`;
+
+  try {
+    const resend = new Resend(resendApiKey);
+    const html = await render(
+      createElement(CalendarAuthAlert, { reauthorizeUrl }),
+    );
+    const { error } = await resend.emails.send({
+      from:    fromEmail,
+      to:      [adminEmail],
+      subject: '⚠️ Google Calendar — re-autorisation requise',
+      html,
+    });
+    if (error) {
+      console.error('[calendar-heartbeat] Alert email failed (Resend error):', error);
+    } else {
+      console.info('[calendar-heartbeat] Alert email sent to', adminEmail);
+    }
+  } catch (err: unknown) {
+    console.error(
+      '[calendar-heartbeat] Alert email exception:',
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export default async function handler(): Promise<void> {
+  // 1. Read and validate required env vars
+  const clientId    = process.env.GOOGLE_OAUTH_CLIENT_ID;
+  const clientSecret = process.env.GOOGLE_OAUTH_CLIENT_SECRET;
+  const redirectUri  = process.env.GOOGLE_OAUTH_REDIRECT_URI ?? 'https://developers.google.com/oauthplayground';
+  const supabaseUrl  = process.env.SUPABASE_DATABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const adminEmail   = process.env.ADMIN_EMAIL;
+  const siteUrl      = process.env.SITE_URL ?? 'https://omf-therapie.fr';
+  const resendApiKey = process.env.RESEND_API_KEY;
+  const fromEmail    = process.env.RESEND_FROM_EMAIL ?? 'OMF Thérapie <contact@omf-therapie.fr>';
+
+  if (!clientId || !clientSecret) {
+    console.warn('[calendar-heartbeat] GOOGLE_OAUTH_CLIENT_ID or GOOGLE_OAUTH_CLIENT_SECRET missing — skipping.');
+    return;
+  }
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    console.warn('[calendar-heartbeat] SUPABASE_DATABASE_URL or SUPABASE_SERVICE_ROLE_KEY missing — skipping.');
+    return;
+  }
+
+  // 2. Initialise clients
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const supabase = createClient<any>(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  const oauth2Client = new google.auth.OAuth2(clientId, clientSecret, redirectUri);
+
+  // 3. Load persisted token from DB
+  const { data: tokens, error: fetchError } = await supabase
+    .from('google_oauth_tokens')
+    .select('refresh_token, access_token, expiry_date')
+    .eq('id', 'therapist')
+    .single();
+
+  if (fetchError || !tokens) {
+    console.warn('[calendar-heartbeat] No token row found in DB — nothing to refresh. Connect Google Calendar first.');
+    return;
+  }
+
+  if (!tokens.refresh_token) {
+    console.warn('[calendar-heartbeat] Token row exists but refresh_token is null — re-authorization required.');
+    return;
+  }
+
+  // 4. Attempt proactive token refresh
+  oauth2Client.setCredentials({ refresh_token: tokens.refresh_token });
+
+  try {
+    const { credentials } = await oauth2Client.refreshAccessToken();
+
+    const updated = {
+      access_token:  credentials.access_token ?? '',
+      // Persist rotated refresh_token if Google returns one (token rotation policy)
+      refresh_token: credentials.refresh_token ?? tokens.refresh_token,
+      expiry_date:   credentials.expiry_date ?? (Date.now() + 3600 * 1000),
+      updated_at:    new Date().toISOString(),
+    };
+
+    const { error: updateError } = await supabase
+      .from('google_oauth_tokens')
+      .update(updated)
+      .eq('id', 'therapist');
+
+    if (updateError) {
+      console.error('[calendar-heartbeat] Failed to persist refreshed token:', updateError.message);
+      return;
+    }
+
+    console.info('[calendar-heartbeat] Token refreshed successfully');
+  } catch (err: unknown) {
+    // 5a. invalid_grant → token revoked, alert admin
+    const errData = (err as { response?: { data?: { error?: string } } })?.response?.data;
+    if (errData?.error === 'invalid_grant') {
+      console.error('[calendar-heartbeat] invalid_grant — token revoked. Sending alert to admin.');
+      if (adminEmail && resendApiKey) {
+        await sendInvalidGrantAlert(adminEmail, siteUrl, resendApiKey, fromEmail);
+      } else {
+        console.warn('[calendar-heartbeat] ADMIN_EMAIL or RESEND_API_KEY missing — cannot send alert.');
+      }
+      return;
+    }
+
+    // 5b. Other errors — log and exit cleanly (don't throw; scheduled functions shouldn't fail noisily)
+    console.error(
+      '[calendar-heartbeat] Token refresh failed:',
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}

--- a/netlify/functions/calendar-token-heartbeat.ts
+++ b/netlify/functions/calendar-token-heartbeat.ts
@@ -128,7 +128,10 @@ export default async function handler(): Promise<void> {
   }
 
   if (!tokens.refresh_token) {
-    console.warn('[calendar-heartbeat] Token row exists but refresh_token is null — re-authorization required.');
+    console.error('[calendar-heartbeat] Token row exists but refresh_token is null — re-authorization required.');
+    if (adminEmail && resendApiKey) {
+      await sendInvalidGrantAlert(adminEmail, siteUrl, resendApiKey, fromEmail);
+    }
     return;
   }
 
@@ -173,7 +176,7 @@ export default async function handler(): Promise<void> {
     // 5b. Other errors — log and exit cleanly (don't throw; scheduled functions shouldn't fail noisily)
     console.error(
       '[calendar-heartbeat] Token refresh failed:',
-      err instanceof Error ? err.message : String(err),
+      (err as { response?: { status?: number } })?.response?.status ?? (err instanceof Error ? err.message : String(err)),
     );
   }
 }

--- a/src/components/admin/GoogleCalendarStatus.tsx
+++ b/src/components/admin/GoogleCalendarStatus.tsx
@@ -1,0 +1,246 @@
+/**
+ * GoogleCalendarStatus — React island for the admin dashboard (/mes-rdvs)
+ *
+ * Displays the Google Calendar OAuth connection status and allows the admin
+ * to re-authorize when the token is expired or missing.
+ *
+ * Reads ?google_connected / ?google_error URL params after the OAuth callback
+ * and surfaces them as toast notifications, then cleans the URL.
+ */
+
+import { useState, useEffect } from "react";
+import toast, { Toaster } from "react-hot-toast";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface StatusResponse {
+  connected: boolean;
+  expiresAt: string | null;
+  updatedAt: string | null;
+  tokenValid: boolean;
+}
+
+type FetchState =
+  | { status: "loading" }
+  | { status: "success"; data: StatusResponse }
+  | { status: "error" };
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Format an ISO date string as "DD/MM/YYYY à HH:mm" in Paris timezone. */
+function formatDateTime(iso: string): string {
+  return new Intl.DateTimeFormat("fr-FR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZone: "Europe/Paris",
+  })
+    .format(new Date(iso))
+    .replace(",", " à");
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function LoadingSkeleton() {
+  return (
+    <div
+      className="flex items-center gap-3 px-4 py-3 bg-white rounded-xl border border-sage-200 shadow-sm animate-pulse"
+      aria-busy="true"
+      aria-label="Chargement du statut Google Calendar"
+    >
+      <div className="h-4 w-4 rounded-full bg-sage-200" />
+      <div className="h-3.5 w-40 rounded bg-sage-200" />
+      <div className="h-3 w-24 rounded bg-sage-100 ml-auto" />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export default function GoogleCalendarStatus() {
+  const [state, setState] = useState<FetchState>({ status: "loading" });
+
+  // ── Fetch status ────────────────────────────────────────────────────────────
+  async function fetchStatus() {
+    setState({ status: "loading" });
+    try {
+      const res = await fetch("/api/admin/google-oauth/status");
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data: StatusResponse = await res.json();
+      setState({ status: "success", data });
+    } catch {
+      setState({ status: "error" });
+    }
+  }
+
+  // ── Read OAuth callback URL params & show toasts ────────────────────────────
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const connected = params.get("google_connected");
+    const error = params.get("google_error");
+
+    if (connected === "true") {
+      toast.success("Google Calendar connecté avec succès !");
+    } else if (error === "access_denied") {
+      toast.error("Autorisation refusée. Réessayez.");
+    } else if (error) {
+      toast.error("Erreur de connexion Google Calendar.");
+    }
+
+    // Clean the URL if any param was present
+    if (connected || error) {
+      params.delete("google_connected");
+      params.delete("google_error");
+      const newSearch = params.toString();
+      const newUrl = newSearch
+        ? `${window.location.pathname}?${newSearch}`
+        : window.location.pathname;
+      window.history.replaceState({}, "", newUrl);
+    }
+
+    fetchStatus();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ── Loading ─────────────────────────────────────────────────────────────────
+  if (state.status === "loading") {
+    return (
+      <>
+        <Toaster position="top-right" />
+        <LoadingSkeleton />
+      </>
+    );
+  }
+
+  // ── Error ───────────────────────────────────────────────────────────────────
+  if (state.status === "error") {
+    return (
+      <>
+        <Toaster position="top-right" />
+        <div className="flex flex-wrap items-center gap-3 px-4 py-3 bg-white rounded-xl border border-red-200 shadow-sm">
+          <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-red-100 text-red-800">
+            ✗ Google Calendar
+          </span>
+          <p className="text-sm text-sage-500 font-sans">
+            Impossible de vérifier le statut.
+          </p>
+          <button
+            type="button"
+            onClick={fetchStatus}
+            className="
+              ml-auto text-xs font-medium font-sans px-3 py-1.5
+              rounded-lg border border-sage-200 text-sage-600
+              hover:bg-sage-50 hover:text-sage-800
+              focus:outline-none focus:ring-2 focus:ring-sage-300
+              transition-colors
+            "
+          >
+            Réessayer
+          </button>
+        </div>
+      </>
+    );
+  }
+
+  // ── Success ─────────────────────────────────────────────────────────────────
+  const { data } = state;
+
+  // Connected and token valid
+  if (data.connected && data.tokenValid) {
+    return (
+      <>
+        <Toaster position="top-right" />
+        <div className="flex flex-wrap items-center gap-3 px-4 py-3 bg-white rounded-xl border border-sage-200 shadow-sm">
+          <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800">
+            ● Google Calendar connecté
+          </span>
+          {data.updatedAt && (
+            <p className="text-xs text-sage-400 font-sans">
+              Mis à jour le {formatDateTime(data.updatedAt)}
+            </p>
+          )}
+          <a
+            href="/api/admin/google-oauth"
+            className="
+              ml-auto text-xs font-medium font-sans px-3 py-1.5
+              rounded-lg border border-sage-200 text-sage-600
+              hover:bg-sage-50 hover:text-sage-800
+              focus:outline-none focus:ring-2 focus:ring-sage-300
+              transition-colors
+            "
+          >
+            Reconnecter
+          </a>
+        </div>
+      </>
+    );
+  }
+
+  // Connected but token expired
+  if (data.connected && !data.tokenValid) {
+    return (
+      <>
+        <Toaster position="top-right" />
+        <div className="flex flex-wrap items-center gap-3 px-4 py-3 bg-white rounded-xl border border-yellow-200 shadow-sm">
+          <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">
+            ⚠ Token expiré
+          </span>
+          {data.expiresAt && (
+            <p className="text-xs text-sage-400 font-sans">
+              Expiré le {formatDateTime(data.expiresAt)}
+            </p>
+          )}
+          <a
+            href="/api/admin/google-oauth"
+            className="
+              ml-auto inline-flex items-center gap-1.5 text-xs font-medium font-sans px-3 py-1.5
+              rounded-lg bg-orange-500 text-white border border-orange-500
+              hover:bg-orange-600 hover:border-orange-600
+              focus:outline-none focus:ring-2 focus:ring-orange-400
+              transition-colors
+            "
+          >
+            Reconnecter
+          </a>
+        </div>
+      </>
+    );
+  }
+
+  // Not connected
+  return (
+    <>
+      <Toaster position="top-right" />
+      <div className="flex flex-wrap items-center gap-3 px-4 py-3 bg-white rounded-xl border border-red-200 shadow-sm">
+        <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-red-100 text-red-800">
+          ✗ Google Calendar déconnecté
+        </span>
+        <p className="text-xs text-sage-500 font-sans">
+          Action requise pour créer des rendez-vous avec lien Meet
+        </p>
+        <a
+          href="/api/admin/google-oauth"
+          className="
+            ml-auto inline-flex items-center gap-1.5 text-xs font-medium font-sans px-3 py-1.5
+            rounded-lg bg-red-500 text-white border border-red-500
+            hover:bg-red-600 hover:border-red-600
+            focus:outline-none focus:ring-2 focus:ring-red-400
+            transition-colors
+          "
+        >
+          Autoriser l'accès
+        </a>
+      </div>
+    </>
+  );
+}

--- a/src/components/admin/GoogleCalendarStatus.tsx
+++ b/src/components/admin/GoogleCalendarStatus.tsx
@@ -112,43 +112,53 @@ export default function GoogleCalendarStatus() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  return (
+    <>
+      <Toaster position="top-right" />
+      <StatusContent state={state} onRetry={fetchStatus} />
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Content — separated to keep GoogleCalendarStatus readable
+// ---------------------------------------------------------------------------
+
+interface ContentProps {
+  state: FetchState;
+  onRetry: () => void;
+}
+
+function StatusContent({ state, onRetry }: ContentProps) {
   // ── Loading ─────────────────────────────────────────────────────────────────
   if (state.status === "loading") {
-    return (
-      <>
-        <Toaster position="top-right" />
-        <LoadingSkeleton />
-      </>
-    );
+    return <LoadingSkeleton />;
   }
 
   // ── Error ───────────────────────────────────────────────────────────────────
   if (state.status === "error") {
     return (
-      <>
-        <Toaster position="top-right" />
-        <div className="flex flex-wrap items-center gap-3 px-4 py-3 bg-white rounded-xl border border-red-200 shadow-sm">
-          <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-red-100 text-red-800">
-            ✗ Google Calendar
-          </span>
-          <p className="text-sm text-sage-500 font-sans">
-            Impossible de vérifier le statut.
-          </p>
-          <button
-            type="button"
-            onClick={fetchStatus}
-            className="
-              ml-auto text-xs font-medium font-sans px-3 py-1.5
-              rounded-lg border border-sage-200 text-sage-600
-              hover:bg-sage-50 hover:text-sage-800
-              focus:outline-none focus:ring-2 focus:ring-sage-300
-              transition-colors
-            "
-          >
-            Réessayer
-          </button>
-        </div>
-      </>
+      <div className="flex flex-wrap items-center gap-3 px-4 py-3 bg-white rounded-xl border border-red-200 shadow-sm">
+        <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-red-100 text-red-800">
+          ✗ Google Calendar
+        </span>
+        <p className="text-sm text-sage-500 font-sans">
+          Impossible de vérifier le statut.
+        </p>
+        <button
+          type="button"
+          onClick={onRetry}
+          className="
+            ml-auto text-xs font-medium font-sans px-3 py-1.5
+            rounded-lg border border-sage-200 text-sage-600
+            hover:bg-sage-50 hover:text-sage-800
+            focus:outline-none focus:ring-2 focus:ring-sage-300
+            transition-colors
+          "
+        >
+          Réessayer
+        </button>
+      </div>
     );
   }
 
@@ -158,82 +168,74 @@ export default function GoogleCalendarStatus() {
   // Connected and token valid
   if (data.connected && data.tokenValid) {
     return (
-      <>
-        <Toaster position="top-right" />
-        <div className="flex flex-wrap items-center gap-3 px-4 py-3 bg-white rounded-xl border border-sage-200 shadow-sm">
-          <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800">
-            ● Google Calendar connecté
-          </span>
-          {data.updatedAt && (
-            <p className="text-xs text-sage-400 font-sans">
-              Mis à jour le {formatDateTime(data.updatedAt)}
-            </p>
-          )}
-          <a
-            href="/api/admin/google-oauth"
-            className="
-              ml-auto text-xs font-medium font-sans px-3 py-1.5
-              rounded-lg border border-sage-200 text-sage-600
-              hover:bg-sage-50 hover:text-sage-800
-              focus:outline-none focus:ring-2 focus:ring-sage-300
-              transition-colors
-            "
-          >
-            Reconnecter
-          </a>
-        </div>
-      </>
+      <div className="flex flex-wrap items-center gap-3 px-4 py-3 bg-white rounded-xl border border-sage-200 shadow-sm">
+        <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800">
+          ● Google Calendar connecté
+        </span>
+        {data.updatedAt && (
+          <p className="text-xs text-sage-400 font-sans">
+            Mis à jour le {formatDateTime(data.updatedAt)}
+          </p>
+        )}
+        <a
+          href="/api/admin/google-oauth"
+          className="
+            ml-auto text-xs font-medium font-sans px-3 py-1.5
+            rounded-lg border border-sage-200 text-sage-600
+            hover:bg-sage-50 hover:text-sage-800
+            focus:outline-none focus:ring-2 focus:ring-sage-300
+            transition-colors
+          "
+        >
+          Reconnecter
+        </a>
+      </div>
     );
   }
 
   // Connected but token expired
   if (data.connected && !data.tokenValid) {
     return (
-      <>
-        <Toaster position="top-right" />
-        <div className="flex flex-wrap items-center gap-3 px-4 py-3 bg-white rounded-xl border border-yellow-200 shadow-sm">
-          <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">
-            ⚠ Token expiré
-          </span>
-          {data.expiresAt && (
-            <p className="text-xs text-sage-400 font-sans">
-              Expiré le {formatDateTime(data.expiresAt)}
-            </p>
-          )}
-          <a
-            href="/api/admin/google-oauth"
-            className="
-              ml-auto inline-flex items-center gap-1.5 text-xs font-medium font-sans px-3 py-1.5
-              rounded-lg bg-orange-500 text-white border border-orange-500
-              hover:bg-orange-600 hover:border-orange-600
-              focus:outline-none focus:ring-2 focus:ring-orange-400
-              transition-colors
-            "
-          >
-            Reconnecter
-          </a>
-        </div>
-      </>
+      <div className="flex flex-wrap items-center gap-3 px-4 py-3 bg-white rounded-xl border border-yellow-200 shadow-sm">
+        <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">
+          ⚠ Token expiré
+        </span>
+        {data.expiresAt && (
+          <p className="text-xs text-sage-400 font-sans">
+            Expiré le {formatDateTime(data.expiresAt)}
+          </p>
+        )}
+        <a
+          href="/api/admin/google-oauth"
+          className="
+            ml-auto inline-flex items-center gap-1.5 text-xs font-medium font-sans px-3 py-1.5
+            rounded-lg bg-orange-500 text-white border border-orange-500
+            hover:bg-orange-600 hover:border-orange-600
+            focus:outline-none focus:ring-2 focus:ring-orange-400
+            transition-colors
+          "
+        >
+          Reconnecter
+        </a>
+      </div>
     );
   }
 
   // Not connected
   return (
-    <>
-      <Toaster position="top-right" />
-      <div className="flex flex-wrap items-center gap-3 px-4 py-3 bg-white rounded-xl border border-red-200 shadow-sm">
-        <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-red-100 text-red-800">
-          ✗ Google Calendar déconnecté
-        </span>
-        <p className="text-xs text-sage-500 font-sans">
-          Action requise pour créer des rendez-vous avec lien Meet
-        </p>
-        <a
-          href="/api/admin/google-oauth"
-          className="
-            ml-auto inline-flex items-center gap-1.5 text-xs font-medium font-sans px-3 py-1.5
-            rounded-lg bg-red-500 text-white border border-red-500
-            hover:bg-red-600 hover:border-red-600
+    <div className="flex flex-wrap items-center gap-3 px-4 py-3 bg-white rounded-xl border border-red-200 shadow-sm">
+      <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-red-100 text-red-800">
+        ✗ Google Calendar déconnecté
+      </span>
+      <p className="text-xs text-sage-500 font-sans">
+        Action requise pour créer des rendez-vous avec lien Meet
+      </p>
+      <a
+        href="/api/admin/google-oauth"
+        className="
+          ml-auto inline-flex items-center gap-1.5 text-xs font-medium font-sans px-3 py-1.5
+          rounded-lg bg-red-500 text-white border border-red-500
+          hover:bg-red-600 hover:border-red-600
             focus:outline-none focus:ring-2 focus:ring-red-400
             transition-colors
           "
@@ -241,6 +243,5 @@ export default function GoogleCalendarStatus() {
           Autoriser l'accès
         </a>
       </div>
-    </>
   );
 }

--- a/src/emails/CalendarAuthAlert.tsx
+++ b/src/emails/CalendarAuthAlert.tsx
@@ -1,0 +1,98 @@
+/**
+ * Template — CalendarAuthAlert
+ * Destinataire : Admin (alerte interne)
+ * Sujet : "⚠️ Google Calendar — re-autorisation requise"
+ */
+
+import { Button, Link, Section, Text } from '@react-email/components';
+import { BaseLayout } from './BaseLayout';
+import { COLORS, S, SectionDivider } from './_helpers';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface Props {
+  /** URL vers /api/admin/google-oauth pour déclencher le flux OAuth */
+  reauthorizeUrl: string;
+}
+
+// ---------------------------------------------------------------------------
+// Template
+// ---------------------------------------------------------------------------
+
+export default function CalendarAuthAlert({ reauthorizeUrl }: Props) {
+  return (
+    <BaseLayout preview="⚠️ Google Calendar déconnecté — action requise">
+
+      {/* Badge d'alerte */}
+      <Section style={{
+        backgroundColor: '#fff8ee',
+        border:          `1px solid ${COLORS.accent}`,
+        borderRadius:    '20px',
+        padding:         '5px 16px',
+        display:         'inline-block',
+        margin:          '0 0 16px',
+      }}>
+        <Text style={{
+          fontFamily:    'Inter, Arial, sans-serif',
+          fontSize:      '12px',
+          fontWeight:    '600',
+          color:         '#b45309',
+          margin:        '0',
+          letterSpacing: '0.06em',
+          textTransform: 'uppercase' as const,
+        }}>
+          ⚠️ Action requise
+        </Text>
+      </Section>
+
+      {/* Titre */}
+      <Text style={S.title}>Google Calendar déconnecté</Text>
+
+      {/* Corps */}
+      <Text style={S.body}>
+        Le token OAuth de Google Calendar a expiré ou a été révoqué
+        (<strong>invalid_grant</strong>). La synchronisation des rendez-vous
+        avec Google Agenda est actuellement <strong>interrompue</strong>.
+      </Text>
+
+      <Text style={S.body}>
+        Pour rétablir la connexion, cliquez sur le bouton ci-dessous afin de
+        ré-autoriser l'accès à Google Calendar. Vous serez redirigé vers la
+        page de consentement Google, puis automatiquement reconnecté.
+      </Text>
+
+      {/* CTA principal */}
+      <Section style={S.btnWrapper}>
+        <Button href={reauthorizeUrl} style={S.btnPrimary}>
+          🔗 Ré-autoriser Google Calendar
+        </Button>
+      </Section>
+
+      <Text style={{ ...S.small, textAlign: 'center' as const }}>
+        Lien direct :{' '}
+        <Link href={reauthorizeUrl} style={{ color: COLORS.mint600, fontSize: '13px' }}>
+          {reauthorizeUrl}
+        </Link>
+      </Text>
+
+      <SectionDivider />
+
+      {/* Note technique */}
+      <Section style={S.infoBox}>
+        <Text style={S.infoText}>
+          <strong>Pourquoi ce message ?</strong> Google révoque périodiquement
+          les tokens d'accès longue durée (refresh tokens) si le consentement
+          n'est pas renouvelé, ou suite à un changement de mot de passe.
+          Une nouvelle autorisation génère un nouveau refresh token valide.
+        </Text>
+      </Section>
+
+      <Text style={{ ...S.body, color: COLORS.sage600, fontStyle: 'italic', marginTop: '20px' }}>
+        Notification automatique — OMF Thérapie
+      </Text>
+
+    </BaseLayout>
+  );
+}

--- a/src/lib/google-calendar.ts
+++ b/src/lib/google-calendar.ts
@@ -7,6 +7,7 @@
 
 import { google, type Auth, type calendar_v3 } from 'googleapis';
 import { supabaseAdmin } from './supabase.js';
+import { sendEmail } from './resend.js';
 
 // ---------------------------------------------------------------------------
 // Erreur typée
@@ -181,6 +182,18 @@ async function getPersistedOAuthClient(): Promise<Auth.OAuth2Client | null> {
     } catch (err: unknown) {
       const errData = (err as { response?: { data?: { error?: string } } })?.response?.data;
       if (errData?.error === 'invalid_grant') {
+        // AC-3: alert admin — fire and forget (don't block the throw)
+        const adminEmail = import.meta.env.ADMIN_EMAIL as string | undefined;
+        const siteUrl = import.meta.env.SITE_URL ?? 'https://omf-therapie.fr';
+        if (adminEmail) {
+          const { createElement } = await import('react');
+          const { default: CalendarAuthAlert } = await import('../emails/CalendarAuthAlert');
+          sendEmail({
+            to: adminEmail,
+            subject: '⚠️ Google Calendar — re-autorisation requise',
+            react: createElement(CalendarAuthAlert, { reauthorizeUrl: `${siteUrl}/api/admin/google-oauth` }),
+          }).catch((e: unknown) => console.error('[calendar] Alert email failed:', e instanceof Error ? e.message : e));
+        }
         // Store only the safe error code — do NOT pass raw err (GaxiosError may
         // carry client_secret / refresh_token in response.config.data)
         throw new CalendarAuthError(

--- a/src/lib/google-calendar.ts
+++ b/src/lib/google-calendar.ts
@@ -203,7 +203,7 @@ async function getPersistedOAuthClient(): Promise<Auth.OAuth2Client | null> {
       }
       throw new CalendarNetworkError(
         'Token refresh failed',
-        { message: err instanceof Error ? err.message : String(err) },
+        { status: (err as { response?: { status?: number } })?.response?.status },
       );
     }
   }

--- a/src/pages/api/admin/google-oauth/callback.ts
+++ b/src/pages/api/admin/google-oauth/callback.ts
@@ -1,0 +1,121 @@
+export const prerender = false;
+
+/**
+ * GET /api/admin/google-oauth/callback
+ *
+ * Receives the OAuth callback from Google after admin consent.
+ * Exchanges the authorization code for tokens and persists them to Supabase.
+ *
+ * Security: no session check here — Google redirects to this URL without the
+ * admin session cookie. The state cookie (set by the authorize endpoint) is
+ * the CSRF protection mechanism.
+ *
+ * Flow:
+ *   1. Check for error param from Google
+ *   2. Verify CSRF state cookie against state query param
+ *   3. Exchange code → tokens via googleapis
+ *   4. Validate refresh_token is present
+ *   5. Upsert tokens into google_oauth_tokens (id = 'therapist')
+ *   6. Clear state cookie and redirect to /mes-rdvs?google_connected=true
+ */
+
+import type { APIRoute } from 'astro';
+import { google } from 'googleapis';
+import { supabaseAdmin } from '../../../../lib/supabase';
+
+export const GET: APIRoute = async ({ url, cookies }) => {
+  const code  = url.searchParams.get('code');
+  const state = url.searchParams.get('state');
+  const error = url.searchParams.get('error');
+
+  // 1. Handle Google-side error (e.g. user denied consent)
+  if (error) {
+    console.warn(`[google-oauth/callback] Google returned error: ${error}`);
+    return new Response(null, {
+      status:  302,
+      headers: { Location: `/mes-rdvs?google_error=${encodeURIComponent(error)}` },
+    });
+  }
+
+  // 2. CSRF state verification
+  const storedState = cookies.get('google_oauth_state')?.value;
+  if (!storedState || storedState !== state) {
+    console.error('[google-oauth/callback] CSRF state mismatch or missing cookie');
+    return new Response('Invalid state parameter', { status: 400 });
+  }
+
+  // 3. Validate required env vars
+  const clientId     = import.meta.env.GOOGLE_OAUTH_CLIENT_ID as string | undefined;
+  const clientSecret = import.meta.env.GOOGLE_OAUTH_CLIENT_SECRET as string | undefined;
+  const redirectUri  = import.meta.env.GOOGLE_OAUTH_REDIRECT_URI as string | undefined;
+
+  if (!clientId || !clientSecret || !redirectUri || !code) {
+    console.error('[google-oauth/callback] Missing env vars or code param');
+    return new Response(null, {
+      status:  302,
+      headers: { Location: '/mes-rdvs?google_error=token_exchange_failed' },
+    });
+  }
+
+  try {
+    // 4. Exchange authorization code for tokens
+    const oauth2Client = new google.auth.OAuth2(clientId, clientSecret, redirectUri);
+    const { tokens } = await oauth2Client.getToken(code);
+
+    // 5. Ensure refresh_token is present (safety net — should always be set when prompt=consent)
+    if (!tokens.refresh_token) {
+      console.warn(
+        '[google-oauth/callback] No refresh_token in response — ' +
+        'this should not happen when prompt=consent is used. ' +
+        'The user may need to revoke access in their Google account and try again.',
+      );
+      return new Response(null, {
+        status:  302,
+        headers: { Location: '/mes-rdvs?google_error=no_refresh_token' },
+      });
+    }
+
+    // 6. Persist tokens — upsert singleton row for the therapist
+    const { error: dbError } = await supabaseAdmin.from('google_oauth_tokens').upsert({
+      id:            'therapist',
+      access_token:  tokens.access_token ?? '',
+      refresh_token: tokens.refresh_token,
+      expiry_date:   tokens.expiry_date ?? (Date.now() + 3600 * 1000),
+      updated_at:    new Date().toISOString(),
+    });
+
+    if (dbError) {
+      console.error('[google-oauth/callback] DB upsert error:', dbError.message);
+      return new Response(null, {
+        status:  302,
+        headers: { Location: '/mes-rdvs?google_error=token_exchange_failed' },
+      });
+    }
+
+    // 7. Clear CSRF state cookie
+    cookies.set('google_oauth_state', '', {
+      httpOnly: true,
+      sameSite: 'lax',
+      secure:   true,
+      maxAge:   0,
+      path:     '/api/admin/google-oauth/callback',
+    });
+
+    console.info('[google-oauth/callback] Google Calendar successfully re-authorized');
+
+    return new Response(null, {
+      status:  302,
+      headers: { Location: '/mes-rdvs?google_connected=true' },
+    });
+
+  } catch (err: unknown) {
+    console.error(
+      '[google-oauth/callback] Token exchange failed:',
+      err instanceof Error ? err.message : err,
+    );
+    return new Response(null, {
+      status:  302,
+      headers: { Location: '/mes-rdvs?google_error=token_exchange_failed' },
+    });
+  }
+};

--- a/src/pages/api/admin/google-oauth/callback.ts
+++ b/src/pages/api/admin/google-oauth/callback.ts
@@ -28,20 +28,21 @@ export const GET: APIRoute = async ({ url, cookies }) => {
   const state = url.searchParams.get('state');
   const error = url.searchParams.get('error');
 
-  // 1. Handle Google-side error (e.g. user denied consent)
+  // 1. CSRF state verification — applies to ALL callback paths including error responses
+  // (RFC 6749 §4.1.2.1: state is returned by Google even on error responses)
+  const storedState = cookies.get('google_oauth_state')?.value;
+  if (!storedState || storedState !== state) {
+    console.error('[google-oauth/callback] CSRF state mismatch or missing cookie');
+    return new Response('Invalid state parameter', { status: 400 });
+  }
+
+  // 2. Handle Google-side error (e.g. user denied consent)
   if (error) {
     console.warn(`[google-oauth/callback] Google returned error: ${error}`);
     return new Response(null, {
       status:  302,
       headers: { Location: `/mes-rdvs?google_error=${encodeURIComponent(error)}` },
     });
-  }
-
-  // 2. CSRF state verification
-  const storedState = cookies.get('google_oauth_state')?.value;
-  if (!storedState || storedState !== state) {
-    console.error('[google-oauth/callback] CSRF state mismatch or missing cookie');
-    return new Response('Invalid state parameter', { status: 400 });
   }
 
   // 3. Validate required env vars

--- a/src/pages/api/admin/google-oauth/index.ts
+++ b/src/pages/api/admin/google-oauth/index.ts
@@ -1,0 +1,70 @@
+export const prerender = false;
+
+/**
+ * GET /api/admin/google-oauth
+ *
+ * Generates a Google OAuth authorization URL and redirects the admin to it.
+ * Protected — requires a valid admin session.
+ *
+ * Flow:
+ *   1. Verify admin session
+ *   2. Build OAuth URL with offline access + forced consent prompt
+ *   3. Set CSRF state cookie (5 min TTL)
+ *   4. Redirect to Google consent page
+ */
+
+import type { APIRoute } from 'astro';
+import { google } from 'googleapis';
+import { auth } from '../../../../lib/auth';
+import { isAdminSession } from '../../../../lib/authz';
+
+export const GET: APIRoute = async ({ request, cookies }) => {
+  // 1. Auth guard — admin only
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!isAdminSession(session)) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  // 2. Validate required env vars
+  const clientId     = import.meta.env.GOOGLE_OAUTH_CLIENT_ID as string | undefined;
+  const clientSecret = import.meta.env.GOOGLE_OAUTH_CLIENT_SECRET as string | undefined;
+  const redirectUri  = import.meta.env.GOOGLE_OAUTH_REDIRECT_URI as string | undefined;
+
+  if (!clientId || !clientSecret || !redirectUri) {
+    return new Response(
+      'Missing required environment variables: GOOGLE_OAUTH_CLIENT_ID, GOOGLE_OAUTH_CLIENT_SECRET, GOOGLE_OAUTH_REDIRECT_URI',
+      { status: 500, headers: { 'Content-Type': 'text/plain' } },
+    );
+  }
+
+  // 3. Build OAuth2 client and generate consent URL
+  const oauth2Client = new google.auth.OAuth2(clientId, clientSecret, redirectUri);
+
+  // CSRF state token — verified in the callback
+  const state = crypto.randomUUID();
+
+  const authorizationUrl = oauth2Client.generateAuthUrl({
+    access_type: 'offline',
+    prompt:      'consent', // Critical: forces Google to return a fresh refresh_token
+    scope: [
+      'https://www.googleapis.com/auth/calendar',
+      'https://www.googleapis.com/auth/calendar.events',
+    ],
+    state,
+  });
+
+  // 4. Persist CSRF state in a short-lived httpOnly cookie scoped to the callback path
+  cookies.set('google_oauth_state', state, {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure:   true,
+    maxAge:   300, // 5 minutes
+    path:     '/api/admin/google-oauth/callback',
+  });
+
+  // 5. Redirect admin to Google consent screen
+  return new Response(null, {
+    status:  302,
+    headers: { Location: authorizationUrl },
+  });
+};

--- a/src/pages/api/admin/google-oauth/index.ts
+++ b/src/pages/api/admin/google-oauth/index.ts
@@ -48,7 +48,6 @@ export const GET: APIRoute = async ({ request, cookies }) => {
     prompt:      'consent', // Critical: forces Google to return a fresh refresh_token
     scope: [
       'https://www.googleapis.com/auth/calendar',
-      'https://www.googleapis.com/auth/calendar.events',
     ],
     state,
   });

--- a/src/pages/api/admin/google-oauth/status.ts
+++ b/src/pages/api/admin/google-oauth/status.ts
@@ -1,0 +1,75 @@
+export const prerender = false;
+
+/**
+ * GET /api/admin/google-oauth/status
+ *
+ * Returns the current state of the Google OAuth token stored in Supabase.
+ * Consumed by the GoogleCalendarStatus React island on the /mes-rdvs page.
+ *
+ * Response shape:
+ *   { connected, expiresAt, updatedAt, tokenValid }
+ */
+
+import type { APIRoute } from 'astro';
+import { auth } from '../../../../lib/auth';
+import { isAdminSession } from '../../../../lib/authz';
+import { supabaseAdmin } from '../../../../lib/supabase';
+
+// ---------------------------------------------------------------------------
+// Response type
+// ---------------------------------------------------------------------------
+
+interface StatusResponse {
+  /** Whether a token row exists in the DB */
+  connected: boolean;
+  /** ISO string of access token expiry, null if unknown */
+  expiresAt: string | null;
+  /** ISO string of last token update */
+  updatedAt: string | null;
+  /** true if expiry_date is more than 5 minutes in the future */
+  tokenValid: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export const GET: APIRoute = async ({ request }) => {
+  // 1. Admin session guard
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!isAdminSession(session)) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  // 2. Query the persisted token row
+  const { data } = await supabaseAdmin
+    .from('google_oauth_tokens')
+    .select('refresh_token, access_token, expiry_date, updated_at')
+    .eq('id', 'therapist')
+    .single();
+
+  // 3. Build response
+  let body: StatusResponse;
+
+  if (!data) {
+    body = {
+      connected:  false,
+      expiresAt:  null,
+      updatedAt:  null,
+      tokenValid: false,
+    };
+  } else {
+    const expiryDate: number | null = data.expiry_date ?? null;
+    body = {
+      connected:  true,
+      expiresAt:  expiryDate !== null ? new Date(expiryDate).toISOString() : null,
+      updatedAt:  (data.updated_at as string | null) ?? null,
+      tokenValid: expiryDate !== null && expiryDate > Date.now() + 5 * 60 * 1000,
+    };
+  }
+
+  return new Response(JSON.stringify(body), {
+    status:  200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/src/pages/api/admin/google-oauth/status.ts
+++ b/src/pages/api/admin/google-oauth/status.ts
@@ -44,7 +44,7 @@ export const GET: APIRoute = async ({ request }) => {
   // 2. Query the persisted token row
   const { data } = await supabaseAdmin
     .from('google_oauth_tokens')
-    .select('refresh_token, access_token, expiry_date, updated_at')
+    .select('expiry_date, updated_at')
     .eq('id', 'therapist')
     .single();
 

--- a/src/pages/mes-rdvs.astro
+++ b/src/pages/mes-rdvs.astro
@@ -13,6 +13,7 @@ import Layout from '../layouts/Layout.astro';
 import Navbar from '../components/islands/Navbar';
 import { AppointmentCard } from '../components/admin/AppointmentCard';
 import { AdminCreateButton } from '../components/admin/AdminCreateButton';
+import GoogleCalendarStatus from '../components/admin/GoogleCalendarStatus';
 import { auth } from '../lib/auth';
 import { isAdminSession } from '../lib/authz';
 import { supabaseAdmin } from '../lib/supabase';
@@ -116,6 +117,11 @@ for (const appt of appointments) {
             Déconnexion
           </button>
         </div>
+      </div>
+
+      <!-- Statut connexion Google Calendar -->
+      <div class="mb-5">
+        <GoogleCalendarStatus client:load />
       </div>
 
       <!-- Filtres par statut -->


### PR DESCRIPTION
## Problème

`CalendarAuthError: OAuth consent revoked` — le refresh token est révoqué/expiré. `refreshAccessToken()` renouvelle uniquement l'access token (1h), pas le refresh token. Le refresh token nécessite un nouveau consentement OAuth.

Cause fréquente en prod : app Google Cloud en mode **Testing** → refresh tokens expirent après **7 jours**.

## Ce qui manquait (spec #36 AC-3 + flow re-auth)

- Aucun email d'alerte sur `invalid_grant`
- Aucun endpoint pour re-autoriser sans passer par OAuth Playground manuellement

## Changements

### `GET /api/admin/google-oauth`
Protégé session admin. Génère URL consent Google (`access_type=offline`, `prompt=consent`). Cookie CSRF httpOnly 5 min. → Redirige vers Google.

### `GET /api/admin/google-oauth/callback`
Reçoit code OAuth de Google. Vérifie state CSRF. Échange code → tokens. Upsert `google_oauth_tokens` (id = 'therapist'). → Redirige `/mes-rdvs?google_connected=true`.

### `src/emails/CalendarAuthAlert.tsx`
Template email admin avec bouton direct vers `/api/admin/google-oauth`.

### `src/lib/google-calendar.ts` (AC-3)
Sur `invalid_grant` : envoie email d'alerte en fire-and-forget avant de relancer `CalendarAuthError`.

## ⚠️ Config requise en production

`GOOGLE_OAUTH_REDIRECT_URI` doit être mis à jour :
```
GOOGLE_OAUTH_REDIRECT_URI=https://omf-therapie.fr/api/admin/google-oauth/callback
```
Et ajouter cette URI dans **Google Cloud Console → Identifiants → URI de redirection autorisés**.

## Pour re-autoriser maintenant

1. Mettre à jour `GOOGLE_OAUTH_REDIRECT_URI` (voir ci-dessus)
2. Visiter `/api/admin/google-oauth` en étant connecté admin
3. Approuver le consentement Google
4. Redirection automatique vers `/mes-rdvs?google_connected=true`

## Testing
- [ ] `/api/admin/google-oauth` sans session → 401
- [ ] `/api/admin/google-oauth` avec session admin → redirect Google
- [ ] Callback avec mauvais state → 400
- [ ] Callback succès → tokens en DB + redirect `/mes-rdvs?google_connected=true`
- [ ] `invalid_grant` → email reçu sur ADMIN_EMAIL