### PR TITLE
feat(admin): régénérer event Google Calendar et lien Meet depuis un RDV existant

### DIFF
--- a/artifacts/plans/53-regenerate-calendar-event-meet-plan.md
+++ b/artifacts/plans/53-regenerate-calendar-event-meet-plan.md
@@ -1,0 +1,65 @@
+---
+issue: 53
+tier: F-lite
+spec: artifacts/specs/53-regenerate-calendar-event-meet-spec.md
+status: approved
+---
+
+## Tasks
+
+| ID | Description | Agent | Files | Dependencies | Parallel? |
+|----|-------------|-------|-------|-------------|----------|
+| T1 | Créer l'endpoint `POST /api/admin/appointments/[id]/regenerate-calendar` | backend-dev | `src/pages/api/admin/appointments/[id]/regenerate-calendar.ts` (new) | — | N/A |
+| T2 | Ajouter bouton + handler dans `AppointmentCard` | frontend-dev | `src/components/admin/AppointmentCard.tsx` | T1 | N |
+
+## Budget
+
+### Per task
+
+| Task | Subject | Class | Est. ops |
+|------|---------|-------|----------|
+| T1 | calendar-api | bounded | ~4 |
+| T2 | admin-ui | bounded | ~5 |
+
+### Per agent instance
+
+| Instance | Tasks | Subjects | Est. ops | Action |
+|----------|-------|----------|----------|--------|
+| backend-dev | T1 | calendar-api | ~4 | — |
+| frontend-dev | T2 | admin-ui | ~5 | — |
+
+## Agent Slices
+
+**backend-dev — T1:**
+Créer `src/pages/api/admin/appointments/[id]/regenerate-calendar.ts` avec :
+- `export const prerender = false`
+- Guard `isAdminSession` (pattern identique à `admin/appointments/index.ts`)
+- `GET` du RDV par `id` via `supabaseAdmin` → 404 si absent
+- Vérification `appointment_mode === 'video'` → 400 sinon
+- Appel `createCalendarEvent({ title, start, end, description, location: 'Téléconsultation', attendeeEmail: appointment.patient_email, withMeet: true, appointmentId: \`${id}-regen\`, colorId: '11' })`
+- `supabaseAdmin.from('appointments').update({ google_calendar_event_id, video_link }).eq('id', id)`
+- Catch `CalendarAuthError` → 503 `{ error: 'oauth_required', message: '...' }`
+- Catch autres erreurs → 500
+- Réponse succès : `{ google_calendar_event_id, video_link }`
+
+**frontend-dev — T2:**
+Dans `src/components/admin/AppointmentCard.tsx` :
+- Ajouter state `const [calendarRegenerating, setCalendarRegenerating] = useState(false)`
+- Ajouter state local pour `calendarEventId` et `meetLink` (initialisés depuis `appointment`) pour masquer le bouton après succès sans rerender parent
+- Condition d'affichage : `appointment.appointment_mode === 'video' && (!meetLink || !calendarEventId)`
+- Handler `handleRegenerateCalendar` : POST `/api/admin/appointments/${appointment.id}/regenerate-calendar`, spinner, toast.success / toast.error
+- En cas de succès : mettre à jour les states locaux `calendarEventId` et `meetLink`
+- En cas d'erreur 503 (oauth_required) : toast.error avec message "Reconnectez Google Calendar via le tableau de bord"
+- Bouton placé dans la section actions existantes (en bas de la carte), visible uniquement dans les statuts non-terminaux (pas `declined`/`cancelled`)
+- Utiliser `react-hot-toast` (déjà importé via `AppointmentCard`)
+
+## Quality Gate
+
+```bash
+npm run lint
+```
+
+## Sequence
+
+1. T1 — endpoint backend (backend-dev)
+2. T2 — UI frontend (frontend-dev, aprs T1)

--- a/src/components/admin/AppointmentCard.tsx
+++ b/src/components/admin/AppointmentCard.tsx
@@ -312,6 +312,10 @@ export function AppointmentCard({ appointment }: AppointmentCardProps) {
       if (!res.ok) {
         if (res.status === 503 || data.error === 'oauth_required') {
           toast.error('Google Calendar non connecté — reconnectez via le tableau de bord');
+        } else if (res.status === 403 || data.error === 'permission_denied') {
+          toast.error('Permissions insuffisantes sur Google Calendar');
+        } else if (res.status === 429 || data.error === 'quota_exceeded') {
+          toast.error('Quota Google Calendar dépassé, réessayez plus tard');
         } else {
           toast.error(data.error ?? 'Erreur lors de la régénération');
         }
@@ -555,13 +559,14 @@ export function AppointmentCard({ appointment }: AppointmentCardProps) {
       )}
 
       {/* Bouton régénération Calendar / Meet (vidéo uniquement, si event ou lien manquant) */}
-      {appointment.appointment_mode === 'video' && (!meetLink || !calendarEventId) && (
+      {appointment.appointment_mode === 'video' && (!meetLink || !calendarEventId) && !isReadOnly && (
         <div className="flex flex-wrap gap-2 mb-4">
           <button
             onClick={handleRegenerateCalendar}
             disabled={isRegenerating}
             className="flex items-center gap-1.5 px-3 py-2 text-xs font-medium font-sans rounded-xl border border-sage-300 text-sage-700 hover:bg-sage-50 transition-colors disabled:opacity-60 min-h-[36px]"
             title="Régénérer l'événement Google Calendar et le lien Meet"
+            aria-label={isRegenerating ? 'Régénération en cours…' : "Régénérer l'événement Google Calendar et le lien Meet"}
           >
             {isRegenerating ? (
               <span className="inline-block w-3.5 h-3.5 border-2 border-sage-400 border-t-transparent rounded-full animate-spin" aria-hidden="true" />

--- a/src/components/admin/AppointmentCard.tsx
+++ b/src/components/admin/AppointmentCard.tsx
@@ -10,6 +10,7 @@
  */
 
 import { useState, useMemo, useRef, useEffect } from "react";
+import toast from "react-hot-toast";
 import type { Appointment, AppointmentStatus } from "../../types/appointment";
 import { getTypeLabel, getModeLabel, calculatePrice, SOLIDARITY_DISCOUNT } from "../../lib/pricing";
 
@@ -185,6 +186,11 @@ export function AppointmentCard({ appointment }: AppointmentCardProps) {
   const [overrideFirstSession, setOverrideFirstSession] = useState(appointment.is_first_session);
   const [isSolidarity, setIsSolidarity] = useState(false);
 
+  // États régénération Calendar / Meet
+  const [calendarEventId, setCalendarEventId] = useState(appointment.google_calendar_event_id ?? null);
+  const [meetLink, setMeetLink] = useState(appointment.video_link ?? null);
+  const [isRegenerating, setIsRegenerating] = useState(false);
+
   const livePrice = useMemo(
     () => calculatePrice(appointment.appointment_type, appointment.duration, overrideFirstSession, isSolidarity),
     [appointment.appointment_type, appointment.duration, overrideFirstSession, isSolidarity],
@@ -295,6 +301,32 @@ export function AppointmentCard({ appointment }: AppointmentCardProps) {
     }
   }
 
+  async function handleRegenerateCalendar() {
+    setIsRegenerating(true);
+    try {
+      const res = await fetch(`/api/admin/appointments/${appointment.id}/regenerate-calendar`, {
+        method: 'POST',
+        credentials: 'include',
+      });
+      const data = (await res.json()) as { google_calendar_event_id?: string; video_link?: string; error?: string };
+      if (!res.ok) {
+        if (res.status === 503 || data.error === 'oauth_required') {
+          toast.error('Google Calendar non connecté — reconnectez via le tableau de bord');
+        } else {
+          toast.error(data.error ?? 'Erreur lors de la régénération');
+        }
+        return;
+      }
+      if (data.google_calendar_event_id) setCalendarEventId(data.google_calendar_event_id);
+      if (data.video_link) setMeetLink(data.video_link);
+      toast.success('Événement Google Calendar régénéré');
+    } catch {
+      toast.error('Erreur réseau');
+    } finally {
+      setIsRegenerating(false);
+    }
+  }
+
   // ── Rendu ─────────────────────────────────────────────────────────────────
 
   return (
@@ -385,18 +417,18 @@ export function AppointmentCard({ appointment }: AppointmentCardProps) {
             </span>
           </div>
         )}
-        {appointment.video_link && (
+        {meetLink && (
           <div className="col-span-2 sm:col-span-3">
             <span className="block text-xs text-sage-400 mb-0.5">
               Lien visio
             </span>
             <a
-              href={appointment.video_link}
+              href={meetLink}
               target="_blank"
               rel="noopener noreferrer"
               className="text-mint-600 hover:text-mint-700 text-sm font-medium break-all"
             >
-              {appointment.video_link}
+              {meetLink}
             </a>
           </div>
         )}
@@ -519,6 +551,27 @@ export function AppointmentCard({ appointment }: AppointmentCardProps) {
               )}
             </>
           )}
+        </div>
+      )}
+
+      {/* Bouton régénération Calendar / Meet (vidéo uniquement, si event ou lien manquant) */}
+      {appointment.appointment_mode === 'video' && (!meetLink || !calendarEventId) && (
+        <div className="flex flex-wrap gap-2 mb-4">
+          <button
+            onClick={handleRegenerateCalendar}
+            disabled={isRegenerating}
+            className="flex items-center gap-1.5 px-3 py-2 text-xs font-medium font-sans rounded-xl border border-sage-300 text-sage-700 hover:bg-sage-50 transition-colors disabled:opacity-60 min-h-[36px]"
+            title="Régénérer l'événement Google Calendar et le lien Meet"
+          >
+            {isRegenerating ? (
+              <span className="inline-block w-3.5 h-3.5 border-2 border-sage-400 border-t-transparent rounded-full animate-spin" aria-hidden="true" />
+            ) : (
+              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+              </svg>
+            )}
+            {isRegenerating ? 'Régénération…' : 'Régénérer Meet'}
+          </button>
         </div>
       )}
 

--- a/src/pages/api/admin/appointments/[id]/regenerate-calendar.ts
+++ b/src/pages/api/admin/appointments/[id]/regenerate-calendar.ts
@@ -4,7 +4,7 @@ import type { APIRoute } from 'astro';
 import { auth } from '../../../../../lib/auth';
 import { isAdminSession } from '../../../../../lib/authz';
 import { supabaseAdmin } from '../../../../../lib/supabase';
-import { createCalendarEvent, CalendarAuthError } from '../../../../../lib/google-calendar';
+import { createCalendarEvent, CalendarAuthError, CalendarPermissionError, CalendarQuotaError } from '../../../../../lib/google-calendar';
 
 // ---------------------------------------------------------------------------
 // POST — régénère l'événement Google Calendar et le lien Meet pour un RDV existant
@@ -22,6 +22,12 @@ export const POST: APIRoute = async ({ params, request }) => {
 
   // 2. Fetch appointment
   const { id } = params;
+  if (!id) {
+    return new Response(JSON.stringify({ error: 'ID manquant' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
   const { data: appointment, error } = await supabaseAdmin
     .from('appointments')
     .select('id, patient_name, patient_email, appointment_mode, scheduled_at, duration, google_calendar_event_id, video_link')
@@ -61,18 +67,26 @@ export const POST: APIRoute = async ({ params, request }) => {
       location: 'Téléconsultation',
       attendeeEmail: appointment.patient_email,
       withMeet: true,
-      appointmentId: `${appointment.id}-regen`,
+      appointmentId: `${appointment.id}-regen-${Date.now()}`,
       colorId: '11',
     });
 
     // 5. Update DB
-    await supabaseAdmin
+    const { error: updateError } = await supabaseAdmin
       .from('appointments')
       .update({
         google_calendar_event_id: calResult.eventId,
         ...(calResult.meetLink ? { video_link: calResult.meetLink } : {}),
       })
       .eq('id', id);
+
+    if (updateError) {
+      console.error('[regenerate-calendar] DB update failed:', updateError.message);
+      return new Response(
+        JSON.stringify({ error: 'Événement créé mais sauvegarde échouée' }),
+        { status: 500, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
 
     // 6. Return updated calendar info
     return new Response(
@@ -93,7 +107,20 @@ export const POST: APIRoute = async ({ params, request }) => {
       );
     }
 
-    console.error('[admin/appointments/regenerate-calendar] Erreur régénération événement:', err);
+    if (err instanceof CalendarPermissionError) {
+      return new Response(
+        JSON.stringify({ error: 'permission_denied', message: 'Permissions insuffisantes sur Google Calendar' }),
+        { status: 403, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+    if (err instanceof CalendarQuotaError) {
+      return new Response(
+        JSON.stringify({ error: 'quota_exceeded', message: 'Quota Google Calendar dépassé, réessayez plus tard' }),
+        { status: 429, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+
+    console.error('[admin/appointments/regenerate-calendar] Erreur régénération événement:', err instanceof Error ? { name: err.name, message: err.message } : String(err));
     return new Response(
       JSON.stringify({ error: 'Erreur lors de la régénération de l\'événement agenda' }),
       { status: 500, headers: { 'Content-Type': 'application/json' } },

--- a/src/pages/api/admin/appointments/[id]/regenerate-calendar.ts
+++ b/src/pages/api/admin/appointments/[id]/regenerate-calendar.ts
@@ -1,0 +1,102 @@
+export const prerender = false;
+
+import type { APIRoute } from 'astro';
+import { auth } from '../../../../../lib/auth';
+import { isAdminSession } from '../../../../../lib/authz';
+import { supabaseAdmin } from '../../../../../lib/supabase';
+import { createCalendarEvent, CalendarAuthError } from '../../../../../lib/google-calendar';
+
+// ---------------------------------------------------------------------------
+// POST — régénère l'événement Google Calendar et le lien Meet pour un RDV existant
+// ---------------------------------------------------------------------------
+
+export const POST: APIRoute = async ({ params, request }) => {
+  // 1. Auth guard — admin seulement
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!isAdminSession(session)) {
+    return new Response(JSON.stringify({ error: 'Non autorisé' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // 2. Fetch appointment
+  const { id } = params;
+  const { data: appointment, error } = await supabaseAdmin
+    .from('appointments')
+    .select('id, patient_name, patient_email, appointment_mode, scheduled_at, duration, google_calendar_event_id, video_link')
+    .eq('id', id)
+    .single();
+
+  if (error || !appointment) {
+    return new Response(JSON.stringify({ error: 'Rendez-vous introuvable' }), {
+      status: 404,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // 3. Guard: téléconsultation uniquement
+  if (appointment.appointment_mode !== 'video') {
+    return new Response(
+      JSON.stringify({ error: 'Ce rendez-vous n\'est pas en téléconsultation' }),
+      { status: 400, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+
+  try {
+    // 4. Call createCalendarEvent
+    const start = new Date(appointment.scheduled_at);
+    const end = new Date(start.getTime() + appointment.duration * 60 * 1000);
+
+    const calResult = await createCalendarEvent({
+      title: `🎥 ${appointment.patient_name} — séance téléconsultation (${appointment.duration} min)`,
+      start: start.toISOString(),
+      end: end.toISOString(),
+      description: [
+        `Patient: ${appointment.patient_name}`,
+        `Email: ${appointment.patient_email}`,
+        'Mode: Téléconsultation',
+        `Durée: ${appointment.duration} min`,
+      ].join('\n'),
+      location: 'Téléconsultation',
+      attendeeEmail: appointment.patient_email,
+      withMeet: true,
+      appointmentId: `${appointment.id}-regen`,
+      colorId: '11',
+    });
+
+    // 5. Update DB
+    await supabaseAdmin
+      .from('appointments')
+      .update({
+        google_calendar_event_id: calResult.eventId,
+        ...(calResult.meetLink ? { video_link: calResult.meetLink } : {}),
+      })
+      .eq('id', id);
+
+    // 6. Return updated calendar info
+    return new Response(
+      JSON.stringify({
+        google_calendar_event_id: calResult.eventId,
+        video_link: calResult.meetLink ?? null,
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    );
+  } catch (err) {
+    if (err instanceof CalendarAuthError) {
+      return new Response(
+        JSON.stringify({
+          error: 'oauth_required',
+          message: 'Reconnectez Google Calendar via le tableau de bord admin',
+        }),
+        { status: 503, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+
+    console.error('[admin/appointments/regenerate-calendar] Erreur régénération événement:', err);
+    return new Response(
+      JSON.stringify({ error: 'Erreur lors de la régénération de l\'événement agenda' }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+};


### PR DESCRIPTION
## Summary

Certains RDV en téléconsultation peuvent se retrouver sans `google_calendar_event_id` et/ou `video_link` en base (échec lors de la confirmation, expiration OAuth, etc.). Cette PR ajoute un bouton d'action dans le dashboard admin pour régénérer ces données sans intervention technique.

## Changes

- **`POST /api/admin/appointments/[id]/regenerate-calendar`** — nouvel endpoint admin protégé (BetterAuth) qui recrée l'event Google Calendar + lien Meet pour un RDV `video` existant
- **`AppointmentCard.tsx`** — bouton « Régénérer Meet » conditionnel (visible si `appointment_mode === 'video'` ET `video_link` ou `google_calendar_event_id` manquant), spinner, toasts succès/erreur, masquage automatique après succès

## Behavior

- Patient reçoit une invitation Google Calendar (`attendeeEmail` passé à `createCalendarEvent`, `sendUpdates: 'all'`)
- Erreur 503 si OAuth non configuré → message explicite invitant à reconnecter via le badge GoogleCalendarStatus
- Bouton disparaît dès que les deux champs sont présents (mise à jour état local sans reload)

## Related

Closes #53

## Artifacts

- Spec: `artifacts/specs/53-regenerate-calendar-event-meet-spec.md`
- Plan: `artifacts/plans/53-regenerate-calendar-event-meet-plan.md`

## Testing

- [ ] Unit tests passing
- [ ] Testé manuellement : RDV téléconsultation avec `video_link` null → bouton visible → clic → lien généré → bouton disparaît
- [ ] Testé : RDV in-person → bouton absent
- [ ] Testé : OAuth non configuré → toast erreur avec message reconnexion

## Quality Gate

- [ ] `npm run lint` ✅ (0 erreurs sur les fichiers modifiés)