### PR TITLE
fix(#61): branche les plages manuelles sur la prise de rendez-vous

### DIFF
--- a/src/lib/appointment-eligibility.ts
+++ b/src/lib/appointment-eligibility.ts
@@ -1,0 +1,107 @@
+/**
+ * Règle d'éligibilité cabinet — source unique de vérité partagée entre :
+ *   - le moteur de génération des créneaux (`google-calendar.ts`),
+ *   - les portes de validation de prise de rendez-vous (API create / admin / report).
+ *
+ * Centraliser la règle ici évite la dérive : la validation ne peut plus durcir
+ * « mercredi uniquement » en ignorant les `manual_time_slots`.
+ */
+import type { Period } from '@/types/manual-slots';
+import { fetchManualSlots } from './manual-slots.js';
+import { getParisISOWeekday, toParisDateString } from '../utils/date.js';
+
+// ---------------------------------------------------------------------------
+// Demi-journées ouvrées (heure locale Paris)
+// ---------------------------------------------------------------------------
+
+export type DayHalf = 'morning' | 'afternoon';
+
+/**
+ * Bornes horaires par demi-journée (heure Paris).
+ * - morning   = 08:00–12:00
+ * - afternoon = 14:00–19:00
+ */
+export const DAY_HALF_PERIODS: Record<DayHalf, { startHour: number; endHour: number }> = {
+  morning: { startHour: 8, endHour: 12 },
+  afternoon: { startHour: 14, endHour: 19 },
+};
+
+export const DAY_HALVES: readonly DayHalf[] = ['morning', 'afternoon'];
+
+// ---------------------------------------------------------------------------
+// Règle d'éligibilité (additive, manuel par-dessus mercredi)
+// ---------------------------------------------------------------------------
+
+/**
+ * Éligibilité cabinet par demi-journée :
+ *
+ *   cabinet-eligible(period) = mercredi OU manual_slot couvre la période
+ *
+ * Le modèle est **additif** : un manual_slot ajoute des demi-journées cabinet
+ * par-dessus le mercredi par défaut, sans jamais le retirer.
+ *
+ * @param isWednesday    true si le jour est mercredi (cabinet par défaut)
+ * @param manualPeriods  périodes couvertes par au moins un manual_slot ce jour
+ */
+export function cabinetEligibility(
+  isWednesday: boolean,
+  manualPeriods: Set<Period>,
+): Record<DayHalf, boolean> {
+  const allDay = manualPeriods.has('all_day');
+  return {
+    morning: isWednesday || allDay || manualPeriods.has('morning'),
+    afternoon: isWednesday || allDay || manualPeriods.has('afternoon'),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers orientés « créneau unique » (validation à la prise de rendez-vous)
+// ---------------------------------------------------------------------------
+
+/**
+ * Indique la demi-journée (morning/afternoon) d'un créneau d'après son heure
+ * de début Paris. Fiable car `isWithinBusinessHours` rejette déjà les créneaux
+ * à cheval sur la pause midi (12h–14h).
+ */
+export function dayHalfFor(isoDate: string): DayHalf {
+  const hour = new Intl.DateTimeFormat('fr-FR', {
+    timeZone: 'Europe/Paris',
+    hour: 'numeric',
+    hour12: false,
+  }).format(new Date(isoDate));
+  return parseInt(hour, 10) < 12 ? 'morning' : 'afternoon';
+}
+
+/**
+ * Périodes manuelles couvrant le jour Paris d'un créneau, sous forme de Set.
+ * Récupère une fenêtre large puis filtre sur la date Paris exacte afin d'éviter
+ * tout décalage UTC/Paris (le filtre `fetchManualSlots` s'appuie sur la date UTC).
+ */
+export async function fetchManualPeriodsForDate(isoDate: string): Promise<Set<Period>> {
+  const slotDate = new Date(isoDate);
+  const dateKey = toParisDateString(slotDate);
+  // Fenêtre de 3 jours centrée pour rester robuste au décalage de filtre UTC.
+  const dayMs = 24 * 60 * 60 * 1000;
+  const records = await fetchManualSlots(
+    new Date(slotDate.getTime() - dayMs),
+    new Date(slotDate.getTime() + dayMs),
+  );
+  const periods = new Set<Period>();
+  for (const record of records) {
+    if (record.slot_date === dateKey) periods.add(record.period);
+  }
+  return periods;
+}
+
+/**
+ * Un créneau présentiel est-il cabinet-éligible pour son jour ?
+ *
+ * Réutilise `cabinetEligibility` (moteur de génération) + consulte les plages
+ * manuelles du jour : la validation ne peut ainsi jamais diverger de la liste
+ * des créneaux proposés au patient.
+ */
+export async function isCabinetEligibleSlot(isoDate: string): Promise<boolean> {
+  const isWednesday = getParisISOWeekday(new Date(isoDate)) === 3;
+  const manualPeriods = await fetchManualPeriodsForDate(isoDate);
+  return cabinetEligibility(isWednesday, manualPeriods)[dayHalfFor(isoDate)];
+}

--- a/src/lib/google-calendar.ts
+++ b/src/lib/google-calendar.ts
@@ -10,6 +10,12 @@ import { supabaseAdmin } from './supabase.js';
 import { sendEmail } from './resend.js';
 import { fetchManualSlots } from './manual-slots.js';
 import type { Period } from '@/types/manual-slots';
+import {
+  DAY_HALF_PERIODS,
+  DAY_HALVES,
+  cabinetEligibility,
+  type DayHalf,
+} from './appointment-eligibility.js';
 
 // ---------------------------------------------------------------------------
 // Erreur typée
@@ -330,47 +336,11 @@ function formatDate(date: Date): string {
 // Génération des créneaux candidats
 // ---------------------------------------------------------------------------
 
-/**
- * Periods of a working day (Paris local time).
- * - morning   = 08:00–12:00
- * - afternoon = 14:00–19:00
- */
-type DayHalf = 'morning' | 'afternoon';
-
-const DAY_HALF_PERIODS: Record<DayHalf, { startHour: number; endHour: number }> = {
-  morning: { startHour: 8, endHour: 12 },
-  afternoon: { startHour: 14, endHour: 19 },
-};
-
-const DAY_HALVES: readonly DayHalf[] = ['morning', 'afternoon'];
+// La règle d'éligibilité cabinet (DayHalf, DAY_HALF_PERIODS, DAY_HALVES,
+// cabinetEligibility) vit dans `appointment-eligibility.ts` et est réutilisée
+// par les portes de validation de prise de rendez-vous.
 
 const DAY_MS = 24 * 60 * 60 * 1000;
-
-/**
- * Éligibilité cabinet par demi-journée, selon la règle métier :
- *
- *   cabinet-eligible(period) = mercredi OU manual_slot couvre la période
- *
- * Le modèle est **additif** : un manual_slot ajoute des demi-journées cabinet
- * par-dessus le mercredi par défaut, sans jamais le retirer.
- *
- * La téléconsultation (visio) est l'**inverse strict** du cabinet :
- *
- *   video-eligible(period) = jour ouvré ET NON cabinet-eligible(period)
- *
- * @param isWednesday   true si le jour est mercredi (cabinet par défaut)
- * @param manualPeriods  périodes couvertes par au moins un manual_slot ce jour
- */
-function cabinetEligibility(
-  isWednesday: boolean,
-  manualPeriods: Set<Period>,
-): Record<DayHalf, boolean> {
-  const allDay = manualPeriods.has('all_day');
-  return {
-    morning: isWednesday || allDay || manualPeriods.has('morning'),
-    afternoon: isWednesday || allDay || manualPeriods.has('afternoon'),
-  };
-}
 
 export interface GenerateSlotsInput {
   startDate: Date;

--- a/src/pages/api/admin/appointments/index.ts
+++ b/src/pages/api/admin/appointments/index.ts
@@ -16,7 +16,7 @@ import AppointmentConfirmed from '../../../../emails/AppointmentConfirmed';
 import PaymentRequest from '../../../../emails/PaymentRequest';
 import type { AppointmentType } from '../../../../types/appointment';
 import { invalidateAvailabilityCache } from '../../../../lib/calendar-cache.js';
-import { isWednesdayParis } from '../../../../utils/date';
+import { isCabinetEligibleSlot } from '../../../../lib/appointment-eligibility';
 
 // ---------------------------------------------------------------------------
 // Validation helpers
@@ -121,8 +121,8 @@ export const POST: APIRoute = async ({ request }) => {
   if (scheduledDate.getTime() < Date.now())
     return errorResponse(400, 'La date de séance doit être dans le futur', 'scheduled_at');
 
-  if (appointment_mode === 'in-person' && !isWednesdayParis(scheduled_at))
-    return errorResponse(400, 'Les rendez-vous en présentiel ont lieu le mercredi uniquement.', 'scheduled_at');
+  if (appointment_mode === 'in-person' && !(await isCabinetEligibleSlot(scheduled_at)))
+    return errorResponse(400, 'Les rendez-vous en présentiel ne sont pas disponibles sur ce créneau.', 'scheduled_at');
 
   try {
     const slotEnd = new Date(scheduledDate.getTime() + Number(duration) * 60 * 1000);

--- a/src/pages/api/appointments/[id].ts
+++ b/src/pages/api/appointments/[id].ts
@@ -12,7 +12,8 @@ import { getTypeLabel, getModeLabel, calculatePrice } from '../../../lib/pricing
 import { stripe, createAppointmentPaymentLink } from '../../../lib/stripe';
 import { createCalendarEvent, updateCalendarEvent, deleteCalendarEvent } from '../../../lib/google-calendar';
 import { hasAppointmentConflict } from '../../../lib/appointment-conflicts';
-import { isWednesdayParis, isWithinBusinessHours } from '../../../utils/date';
+import { isWithinBusinessHours } from '../../../utils/date';
+import { isCabinetEligibleSlot } from '../../../lib/appointment-eligibility';
 import { invalidateAvailabilityCache } from '../../../lib/calendar-cache.js';
 import AppointmentConfirmed from '../../../emails/AppointmentConfirmed';
 import AppointmentDeclined from '../../../emails/AppointmentDeclined';
@@ -418,8 +419,8 @@ export const PATCH: APIRoute = async ({ request, params }) => {
     if (newDate.getTime() < Date.now())
       return errorResponse(422, 'Le nouveau créneau doit être dans le futur');
 
-    if (appointment.appointment_mode === 'in-person' && !isWednesdayParis(rescheduled_to as string))
-      return errorResponse(422, 'Les rendez-vous en présentiel ont lieu le mercredi uniquement.');
+    if (appointment.appointment_mode === 'in-person' && !(await isCabinetEligibleSlot(rescheduled_to as string)))
+      return errorResponse(422, 'Les rendez-vous en présentiel ne sont pas disponibles sur ce créneau.');
 
     if (!isWithinBusinessHours(rescheduled_to as string, appointment.duration))
       return errorResponse(422, 'Le créneau doit être dans les plages horaires (8h-12h ou 14h-19h).');

--- a/src/pages/api/appointments/index.ts
+++ b/src/pages/api/appointments/index.ts
@@ -9,8 +9,9 @@ import AppointmentRequestReceived from '../../../emails/AppointmentRequestReceiv
 import AppointmentRequestNotification from '../../../emails/AppointmentRequestNotification';
 import type { AppointmentType, AppointmentDuration, AppointmentMode } from '../../../types/appointment';
 import { checkRateLimit, rateLimitResponse } from '../../../lib/rate-limit';
-import { isWednesdayParis, isWithinBusinessHours } from '../../../utils/date';
+import { isWithinBusinessHours } from '../../../utils/date';
 import { hasAppointmentConflict } from '../../../lib/appointment-conflicts';
+import { isCabinetEligibleSlot } from '../../../lib/appointment-eligibility';
 
 // ---------------------------------------------------------------------------
 // Validation helpers
@@ -114,8 +115,10 @@ export const POST: APIRoute = async ({ request }) => {
     return errorResponse(422, 'Le rendez-vous doit être pris au moins 1 heure à l\'avance', 'scheduled_at');
 
   // 3. Règles métier
-  if (appointment_mode === 'in-person' && !isWednesdayParis(scheduled_at as string))
-    return errorResponse(422, 'Les rendez-vous en présentiel ont lieu le mercredi uniquement.');
+  // Éligibilité cabinet réutilisée avec le moteur de génération des créneaux :
+  // mercredi par défaut OU plages manuelles (manual_time_slots).
+  if (appointment_mode === 'in-person' && !(await isCabinetEligibleSlot(scheduled_at as string)))
+    return errorResponse(422, 'Les rendez-vous en présentiel ne sont pas disponibles sur ce créneau.');
 
   if (!isWithinBusinessHours(scheduled_at as string, duration as number))
     return errorResponse(422, 'Le créneau est en dehors des horaires d\'ouverture (8h-12h et 14h-19h).');

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,14 +1,26 @@
-/**
- * Vérifie qu'une date ISO tombe un mercredi en heure de Paris.
- * Utilisé pour valider les créneaux en présentiel (mercredi uniquement).
- */
-export function isWednesdayParis(isoDate: string): boolean {
-  const date = new Date(isoDate);
-  const parisDay = new Intl.DateTimeFormat('fr-FR', {
+/** ISO weekday in Paris time (1 = lundi, …, 7 = dimanche). */
+export function getParisISOWeekday(date: Date): number {
+  // en-US short abbreviations are stable across runtimes, unlike fr-FR ones.
+  const abbr = new Intl.DateTimeFormat('en-US', {
     timeZone: 'Europe/Paris',
-    weekday: 'long',
+    weekday: 'short',
   }).format(date);
-  return parisDay === 'mercredi';
+  const map: Record<string, number> = {
+    Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6, Sun: 7,
+  };
+  return map[abbr] ?? 7;
+}
+
+/** Date au format YYYY-MM-DD en heure locale Paris. */
+export function toParisDateString(date: Date): string {
+  const parts = new Intl.DateTimeFormat('fr-FR', {
+    timeZone: 'Europe/Paris',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(date);
+  const get = (t: string) => parts.find((p) => p.type === t)?.value ?? '';
+  return `${get('year')}-${get('month')}-${get('day')}`;
 }
 
 /**

--- a/tests/unit/appointment-eligibility.test.ts
+++ b/tests/unit/appointment-eligibility.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { ManualTimeSlot } from '@/types/manual-slots';
+
+// Mock fetchManualSlots so isCabinetEligibleSlot stays a pure logic test
+// (no Supabase I/O). The records injected per-case are filtered by Paris date
+// inside fetchManualPeriodsForDate, mirroring production.
+vi.mock('@/lib/manual-slots', () => ({
+  fetchManualSlots: vi.fn(),
+}));
+
+import { fetchManualSlots } from '@/lib/manual-slots';
+import {
+  cabinetEligibility,
+  isCabinetEligibleSlot,
+  dayHalfFor,
+} from '@/lib/appointment-eligibility';
+import type { Period } from '@/types/manual-slots';
+
+// Deterministic Paris dates (UTC+2 in June 2026):
+//   Mon 2026-06-15 · Tue 2026-06-16 · Wed 2026-06-17
+// Morning 09:00 Paris = 07:00Z ; Afternoon 15:00 Paris = 13:00Z.
+const MON_MORNING = '2026-06-15T07:00:00.000Z';
+const MON_AFTERNOON = '2026-06-15T13:00:00.000Z';
+const TUE_MORNING = '2026-06-16T07:00:00.000Z';
+const WED_MORNING = '2026-06-17T07:00:00.000Z';
+
+function record(date: string, period: Period): ManualTimeSlot {
+  return {
+    id: `${date}-${period}`,
+    slot_date: date,
+    period,
+    created_at: '',
+    updated_at: '',
+    deleted_at: null,
+  };
+}
+
+function mockSlots(records: ManualTimeSlot[]): void {
+  (fetchManualSlots as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(records);
+}
+
+beforeEach(() => {
+  mockSlots([]);
+});
+
+describe('cabinetEligibility — additive rule', () => {
+  const empty = new Set<Period>();
+
+  it('treats Wednesday as cabinet-eligible both halves by default', () => {
+    expect(cabinetEligibility(true, empty)).toEqual({ morning: true, afternoon: true });
+  });
+
+  it('is not eligible on a non-Wednesday day without manual slots', () => {
+    expect(cabinetEligibility(false, empty)).toEqual({ morning: false, afternoon: false });
+  });
+
+  it('adds a manual half on top of the default', () => {
+    expect(cabinetEligibility(false, new Set(['morning'])))
+      .toEqual({ morning: true, afternoon: false });
+  });
+
+  it('covers both halves with an all_day manual slot', () => {
+    expect(cabinetEligibility(false, new Set(['all_day'])))
+      .toEqual({ morning: true, afternoon: true });
+  });
+});
+
+describe('dayHalfFor', () => {
+  it('classifies a morning slot', () => {
+    expect(dayHalfFor(MON_MORNING)).toBe('morning');
+  });
+
+  it('classifies an afternoon slot', () => {
+    expect(dayHalfFor(MON_AFTERNOON)).toBe('afternoon');
+  });
+});
+
+describe('isCabinetEligibleSlot — booking validation gate', () => {
+  it('allows in-person on Wednesday without manual slots', async () => {
+    expect(await isCabinetEligibleSlot(WED_MORNING)).toBe(true);
+  });
+
+  it('rejects in-person on Monday without manual slots', async () => {
+    expect(await isCabinetEligibleSlot(MON_MORNING)).toBe(false);
+  });
+
+  it('allows in-person on Monday when a morning manual slot exists', async () => {
+    mockSlots([record('2026-06-15', 'morning')]);
+    expect(await isCabinetEligibleSlot(MON_MORNING)).toBe(true);
+  });
+
+  it('rejects the afternoon half when only the morning manual slot exists', async () => {
+    mockSlots([record('2026-06-15', 'morning')]);
+    expect(await isCabinetEligibleSlot(MON_AFTERNOON)).toBe(false);
+  });
+
+  it('allows the afternoon half when an afternoon manual slot exists', async () => {
+    mockSlots([record('2026-06-15', 'afternoon')]);
+    expect(await isCabinetEligibleSlot(MON_AFTERNOON)).toBe(true);
+  });
+
+  it('covers both halves with an all_day manual slot', async () => {
+    mockSlots([record('2026-06-16', 'all_day')]);
+    expect(await isCabinetEligibleSlot(TUE_MORNING)).toBe(true);
+  });
+
+  it('does not leak an adjacent day manual slot into the checked day', async () => {
+    mockSlots([record('2026-06-16', 'all_day')]); // Tuesday, not Monday
+    expect(await isCabinetEligibleSlot(MON_MORNING)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Contexte

Closes #61 — suite à la fusion de #59 (gestion manuelle des plages horaires), les créneaux manuels n'étaient **pas pris en compte lors de la validation** d'un rendez-vous.

## Problème

Le moteur partagé de génération (`generateSlotsForRange` → `cabinetEligibility`) intègre correctement les `manual_time_slots`. Mais **trois portes de validation** dupliquaient la règle d'éligibilité en durcodant « mercredi uniquement » via `isWednesdayParis()` et rejetaient les créneaux présentiel valides créés sur des jours à plage manuelle :

| Endpoint | Flux | Code |
|---|---|---|
| `api/appointments/index.ts` | création client | 422 |
| `api/admin/appointments/index.ts` | création admin | 400 |
| `api/appointments/[id].ts` | report | 422 |

Conséquence : les rendez-vous présentiel sur les nouvelles plages manuelles échouaient côté client **et** admin.

## Solution

Centralise la règle d'éligibilité cabinet dans un module partagé `src/lib/appointment-eligibility.ts`, réutilisé par le moteur de génération **et** les portes de validation — élimine la logique dupliquée qui avait dérivé.

- `appointment-eligibility.ts` (nouveau) : `DayHalf`, `DAY_HALF_PERIODS`, `DAY_HALVES`, `cabinetEligibility`, `dayHalfFor`, `fetchManualPeriodsForDate`, `isCabinetEligibleSlot`
- `google-calendar.ts` : importe les symboles déplacés (plus de copie locale, comportement identique)
- 3 endpoints : `isWednesdayParis(...)` → `await isCabinetEligibleSlot(...)` (consulte les plages manuelles du jour)
- `utils/date.ts` : ajoute `getParisISOWeekday` + `toParisDateString`, supprime `isWednesdayParis`

## Tests

- 13 nouveaux tests unitaires : règle additive (mercredi + manuel), classification demi-journée, porte de validation (jour manuel autorisé / jour non-éligible rejeté / non-fuite d'un jour adjacent)
- 25/25 tests passent (`npm test`)
- Lint propre sur les fichiers modifiés

🤖 Generated with [Claude Code](https://claude.com/claude-code)