### PR TITLE
feat(admin): refonte /mes-rdvs — liste compacte, recherche et groupes par date

### DIFF
--- a/src/components/admin/AppointmentCard.tsx
+++ b/src/components/admin/AppointmentCard.tsx
@@ -29,7 +29,7 @@ type ModalType = 'confirm' | 'decline' | 'reschedule' | null;
 // Constantes statut
 // ---------------------------------------------------------------------------
 
-const STATUS_LABELS: Record<AppointmentStatus, string> = {
+export const STATUS_LABELS: Record<AppointmentStatus, string> = {
   pending: 'En attente',
   confirmed: 'Confirmé',
   declined: 'Refusé',
@@ -39,7 +39,7 @@ const STATUS_LABELS: Record<AppointmentStatus, string> = {
   cancelled: 'Annulé',
 };
 
-const STATUS_BADGE: Record<AppointmentStatus, string> = {
+export const STATUS_BADGE: Record<AppointmentStatus, string> = {
   pending: 'bg-amber-100 text-amber-800',
   confirmed: 'bg-green-100 text-green-800',
   declined: 'bg-red-100 text-red-800',

--- a/src/components/admin/AppointmentsManager.tsx
+++ b/src/components/admin/AppointmentsManager.tsx
@@ -1,0 +1,448 @@
+/**
+ * AppointmentsManager — React island pour la liste des rendez-vous (back-office)
+ *
+ * Refonte de la vue /mes-rdvs : remplace la pile de ~89 AppointmentCard denses
+ * par une liste compacte repliable, avec :
+ *   - recherche instantanée (nom / email / téléphone / motif / cp / ville)
+ *   - filtres par statut (compteurs dynamiques reflétant la recherche)
+ *   - partition À venir (tri ascendant) / Passés (tri descendant, replié)
+ *   - regroupement par jour avec libellé relatif (Aujourd'hui / Demain / …)
+ *   - dépliage d'une ligne → <AppointmentCard/> réutilisé tel quel
+ *
+ * L'état "filtre par statut" persiste en sessionStorage (clé `mes-rdvs-filter`),
+ * identique au comportement vanilla précédent.
+ */
+
+import { useDeferredValue, useMemo, useState } from 'react';
+import type { Appointment, AppointmentStatus } from '../../types/appointment';
+import {
+  AppointmentCard,
+  STATUS_BADGE,
+  STATUS_LABELS,
+} from './AppointmentCard';
+import {
+  formatDayHeader,
+  formatTimeParis,
+  getRelativeDayLabel,
+  isUpcoming,
+  toParisDateString,
+} from '../../utils/date';
+import { getModeLabel } from '../../lib/pricing';
+
+// ---------------------------------------------------------------------------
+// Types & constantes
+// ---------------------------------------------------------------------------
+
+interface AppointmentsManagerProps {
+  appointments: Appointment[];
+}
+
+type FilterKey = 'all' | AppointmentStatus;
+
+interface DayGroup {
+  dayKey: string; // YYYY-MM-DD (Paris)
+  label: string; // « Aujourd'hui » ou format long
+  appointments: Appointment[];
+}
+
+const FILTERS: { key: FilterKey; label: string }[] = [
+  { key: 'all', label: 'Tous' },
+  { key: 'pending', label: 'En attente' },
+  { key: 'rescheduled', label: 'Reportés' },
+  { key: 'payment_pending', label: 'Paiement en attente' },
+  { key: 'payment_received', label: 'Paiement reçu' },
+  { key: 'confirmed', label: 'Confirmés' },
+  { key: 'declined', label: 'Refusés' },
+  { key: 'cancelled', label: 'Annulés' },
+];
+
+const FILTER_STORAGE_KEY = 'mes-rdvs-filter';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Construit une chaîne searchable normalisée pour un rendez-vous. */
+function searchableText(a: Appointment): string {
+  return [
+    a.patient_name,
+    a.patient_email,
+    a.patient_phone,
+    a.patient_postal_code,
+    a.patient_city,
+    a.patient_reason,
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase()
+    .trim();
+}
+
+/**
+ * Regroupe une liste d'appointments (déjà triée) par jour calendaire Paris.
+ * Conserve l'ordre d'entrée : un tri ascendant produit des groupes ascendants.
+ */
+function groupByDay(items: Appointment[]): DayGroup[] {
+  const groups: DayGroup[] = [];
+  for (const appt of items) {
+    const dayKey = toParisDateString(new Date(appt.scheduled_at));
+    const last = groups[groups.length - 1];
+    if (last && last.dayKey === dayKey) {
+      last.appointments.push(appt);
+    } else {
+      groups.push({
+        dayKey,
+        label:
+          getRelativeDayLabel(appt.scheduled_at) ??
+          formatDayHeader(appt.scheduled_at),
+        appointments: [appt],
+      });
+    }
+  }
+  return groups;
+}
+
+function panelId(apptId: string): string {
+  return `appt-panel-${apptId}`;
+}
+
+function readInitialFilter(): FilterKey {
+  if (typeof window === 'undefined') return 'all';
+  const saved = window.sessionStorage.getItem(FILTER_STORAGE_KEY);
+  return saved && FILTERS.some((f) => f.key === saved) ? (saved as FilterKey) : 'all';
+}
+
+// ---------------------------------------------------------------------------
+// Composant principal
+// ---------------------------------------------------------------------------
+
+export function AppointmentsManager({ appointments }: AppointmentsManagerProps) {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [statusFilter, setStatusFilter] = useState<FilterKey>(readInitialFilter);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [showPast, setShowPast] = useState(false);
+
+  const deferredQuery = useDeferredValue(searchQuery);
+
+  // ── 1. Filtrage (recherche + statut) ──────────────────────────────────────
+  const filtered = useMemo(() => {
+    const q = deferredQuery.toLowerCase().trim();
+    return appointments.filter((a) => {
+      if (statusFilter !== 'all' && a.status !== statusFilter) return false;
+      if (q && !searchableText(a).includes(q)) return false;
+      return true;
+    });
+  }, [appointments, deferredQuery, statusFilter]);
+
+  // Compteurs dynamiques des filtres (reflètent la recherche en cours).
+  const statusCounts = useMemo(() => {
+    const counts: Record<string, number> = { all: appointments.length };
+    const q = deferredQuery.toLowerCase().trim();
+    const base = q
+      ? appointments.filter((a) => searchableText(a).includes(q))
+      : appointments;
+    counts.all = base.length;
+    for (const a of base) {
+      counts[a.status] = (counts[a.status] ?? 0) + 1;
+    }
+    return counts;
+  }, [appointments, deferredQuery]);
+
+  // ── 2. Partition À venir / Passés ─────────────────────────────────────────
+  const { upcomingGroups, pastGroups, upcomingCount, pastCount } = useMemo(() => {
+    const now = Date.now();
+    const upcoming = filtered
+      .filter((a) => isUpcoming(a.scheduled_at, now))
+      .sort((a, b) => a.scheduled_at.localeCompare(b.scheduled_at)); // ascendant
+    const past = filtered
+      .filter((a) => !isUpcoming(a.scheduled_at, now))
+      .sort((a, b) => b.scheduled_at.localeCompare(a.scheduled_at)); // descendant
+    return {
+      upcomingGroups: groupByDay(upcoming),
+      pastGroups: groupByDay(past),
+      upcomingCount: upcoming.length,
+      pastCount: past.length,
+    };
+  }, [filtered]);
+
+  function handleFilterChange(key: FilterKey) {
+    setStatusFilter(key);
+    if (key === 'all') {
+      window.sessionStorage.removeItem(FILTER_STORAGE_KEY);
+    } else {
+      window.sessionStorage.setItem(FILTER_STORAGE_KEY, key);
+    }
+  }
+
+  const hasNoResult = filtered.length === 0;
+  const isSearching = deferredQuery.trim().length > 0 || statusFilter !== 'all';
+
+  // ── Rendu ─────────────────────────────────────────────────────────────────
+  return (
+    <div className="space-y-5">
+      {/* Barre de recherche */}
+      <div className="relative">
+        <label htmlFor="appt-search" className="sr-only">
+          Rechercher un rendez-vous
+        </label>
+        <svg
+          className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-sage-400 pointer-events-none"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M21 21l-4.35-4.35M11 19a8 8 0 100-16 8 8 0 000 16z"
+          />
+        </svg>
+        <input
+          id="appt-search"
+          type="search"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          placeholder="Rechercher nom, email, téléphone…"
+          className="
+            w-full pl-10 pr-9 py-2.5 text-sm text-sage-900 placeholder-sage-400 font-sans
+            border border-sage-200 rounded-xl bg-white
+            focus:outline-none focus:ring-2 focus:ring-mint-400 focus:border-transparent
+            transition-colors min-h-[44px]
+          "
+        />
+        {searchQuery && (
+          <button
+            type="button"
+            onClick={() => setSearchQuery('')}
+            className="
+              absolute right-2.5 top-1/2 -translate-y-1/2 w-6 h-6 inline-flex items-center justify-center
+              rounded-full text-sage-400 hover:text-sage-700 hover:bg-sage-100
+              focus:outline-none focus:ring-2 focus:ring-mint-400 transition-colors
+            "
+            aria-label="Effacer la recherche"
+          >
+            <svg className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z" />
+            </svg>
+          </button>
+        )}
+      </div>
+
+      {/* Filtres par statut */}
+      <div
+        className="flex flex-wrap gap-2"
+        role="group"
+        aria-label="Filtrer par statut"
+      >
+        {FILTERS.map(({ key, label }) => {
+          const count = statusCounts[key] ?? 0;
+          if (key !== 'all' && count === 0) return null;
+          const isActive = statusFilter === key;
+          return (
+            <button
+              key={key}
+              type="button"
+              onClick={() => handleFilterChange(key)}
+              aria-pressed={isActive}
+              className={`
+                inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium font-sans
+                rounded-full border transition-colors focus:outline-none focus:ring-2 focus:ring-mint-400
+                ${isActive
+                  ? 'bg-mint-600 text-white border-mint-600'
+                  : 'bg-white text-sage-600 border-sage-200 hover:border-mint-400 hover:text-mint-700'}
+              `}
+            >
+              {label}
+              <span
+                className={`
+                  inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1 text-xs rounded-full
+                  ${isActive ? 'bg-mint-500 text-white' : 'bg-sage-100 text-sage-600'}
+                `}
+              >
+                {count}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* État vide */}
+      {hasNoResult && (
+        <div className="text-center py-12">
+          <div className="w-14 h-14 mx-auto mb-4 bg-sage-100 rounded-full flex items-center justify-center">
+            <svg className="w-7 h-7 text-sage-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M21 21l-4.35-4.35M11 19a8 8 0 100-16 8 8 0 000 16z" />
+            </svg>
+          </div>
+          <p className="font-serif text-lg text-sage-600">
+            {isSearching ? 'Aucun résultat' : 'Aucun rendez-vous'}
+          </p>
+          <p className="text-sage-400 text-sm mt-1 font-sans">
+            {isSearching
+              ? 'Essayez un autre terme ou changez de filtre.'
+              : 'Les nouvelles demandes apparaîtront ici.'}
+          </p>
+        </div>
+      )}
+
+      {/* Section À venir */}
+      {upcomingCount > 0 && (
+        <section aria-label="Rendez-vous à venir">
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="font-serif text-base font-semibold text-sage-800">
+              À venir
+              <span className="ml-2 text-sm font-sans font-normal text-sage-500">
+                {upcomingCount} rendez-vous{upcomingCount > 1 ? 's' : ''}
+              </span>
+            </h2>
+          </div>
+          <div className="space-y-6">
+            {upcomingGroups.map((group) => (
+              <DayGroupBlock
+                key={group.dayKey}
+                group={group}
+                expandedId={expandedId}
+                onToggle={setExpandedId}
+              />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Section Passés (repliée par défaut) */}
+      {pastCount > 0 && (
+        <section aria-label="Rendez-vous passés" className="pt-2">
+          <button
+            type="button"
+            onClick={() => setShowPast((v) => !v)}
+            aria-expanded={showPast}
+            className="
+              w-full flex items-center justify-between gap-3 px-4 py-3
+              bg-white rounded-xl border border-sage-200 shadow-sm
+              hover:bg-sage-50 focus:outline-none focus:ring-2 focus:ring-mint-400
+              transition-colors text-left
+            "
+          >
+            <span className="flex items-center gap-2.5 font-serif text-base font-semibold text-sage-700">
+              <svg
+                className={`w-4 h-4 text-sage-400 transition-transform ${showPast ? 'rotate-90' : ''}`}
+                viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"
+              >
+                <path fillRule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clipRule="evenodd" />
+              </svg>
+              Passés
+              <span className="text-sm font-sans font-normal text-sage-500">
+                {pastCount} rendez-vous{pastCount > 1 ? 's' : ''}
+              </span>
+            </span>
+            <span className="text-xs font-sans text-sage-400">
+              {showPast ? 'Masquer' : 'Afficher'}
+            </span>
+          </button>
+          {showPast && (
+            <div className="space-y-6 mt-4">
+              {pastGroups.map((group) => (
+                <DayGroupBlock
+                  key={group.dayKey}
+                  group={group}
+                  expandedId={expandedId}
+                  onToggle={setExpandedId}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sous-composant : un groupe par jour (en-tête + lignes compactes)
+// ---------------------------------------------------------------------------
+
+interface DayGroupBlockProps {
+  group: DayGroup;
+  expandedId: string | null;
+  onToggle: (id: string | null) => void;
+}
+
+function DayGroupBlock({ group, expandedId, onToggle }: DayGroupBlockProps) {
+  return (
+    <div>
+      {/* En-tête de jour (non sticky : sticky dans un conteneur scrollable
+          interne serait plus complexe ; on garde un en-tête simple et lisible) */}
+      <div className="flex items-center gap-2 mb-2 px-1">
+        <h3 className="font-serif text-sm font-semibold text-sage-700 capitalize">
+          {group.label}
+        </h3>
+        <span className="text-xs font-sans text-sage-400">
+          {group.appointments.length}
+        </span>
+        <span className="flex-1 h-px bg-sage-100" aria-hidden="true" />
+      </div>
+
+      <ul className="space-y-2">
+        {group.appointments.map((appt) => {
+          const isOpen = expandedId === appt.id;
+          const pid = panelId(appt.id);
+          return (
+            <li
+              key={appt.id}
+              className="rounded-xl border border-sage-200 bg-white overflow-hidden"
+            >
+              {/* Ligne compacte — bouton toggler */}
+              <button
+                type="button"
+                onClick={() => onToggle(isOpen ? null : appt.id)}
+                aria-expanded={isOpen}
+                aria-controls={pid}
+                className="
+                  w-full flex items-center gap-3 px-4 py-3 text-left
+                  hover:bg-sage-50 focus:outline-none focus:ring-2 focus:ring-mint-400
+                  transition-colors min-h-[56px]
+                "
+              >
+                <span className="font-sans text-sm font-medium text-sage-900 w-16 shrink-0 tabular-nums">
+                  {formatTimeParis(appt.scheduled_at)}
+                </span>
+                <span className="flex-1 min-w-0">
+                  <span className="block text-sm font-medium text-sage-900 font-sans truncate">
+                    {appt.patient_name}
+                  </span>
+                  <span className="block text-xs text-sage-500 font-sans truncate">
+                    {getModeLabel(appt.appointment_mode)}
+                    {appt.is_first_session ? ' · 1ère séance' : ''}
+                  </span>
+                </span>
+                <span
+                  className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium font-sans shrink-0 ${STATUS_BADGE[appt.status]}`}
+                >
+                  {STATUS_LABELS[appt.status]}
+                </span>
+                <svg
+                  className={`w-4 h-4 text-sage-400 transition-transform shrink-0 ${isOpen ? 'rotate-90' : ''}`}
+                  viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"
+                >
+                  <path fillRule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clipRule="evenodd" />
+                </svg>
+              </button>
+
+              {/* Panneau déplié — AppointmentCard réutilisé tel quel */}
+              {isOpen && (
+                <div
+                  id={pid}
+                  className="border-t border-sage-100 p-4 bg-sage-50/50"
+                >
+                  <AppointmentCard appointment={appt} />
+                </div>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/src/pages/mes-rdvs.astro
+++ b/src/pages/mes-rdvs.astro
@@ -11,7 +11,7 @@ export const prerender = false;
 
 import Layout from '../layouts/Layout.astro';
 import Navbar from '../components/islands/Navbar';
-import { AppointmentCard } from '../components/admin/AppointmentCard';
+import { AppointmentsManager } from '../components/admin/AppointmentsManager';
 import { AdminCreateButton } from '../components/admin/AdminCreateButton';
 import GoogleCalendarStatus from '../components/admin/GoogleCalendarStatus';
 import { PatientList } from '../components/admin/PatientList';
@@ -19,7 +19,7 @@ import { TimeSlotManager } from '../components/admin/TimeSlotManager';
 import { auth } from '../lib/auth';
 import { isAdminSession } from '../lib/authz';
 import { supabaseAdmin } from '../lib/supabase';
-import type { Appointment, AppointmentStatus } from '../types/appointment';
+import type { Appointment } from '../types/appointment';
 
 // ── Auth guard ───────────────────────────────────────────────────────────────
 const session = await auth.api.getSession({ headers: Astro.request.headers });
@@ -31,15 +31,17 @@ if (!isAdminSession(session)) {
 }
 
 // ── Fetch appointments ───────────────────────────────────────────────────────
-// Colonnes explicites : exclut les champs sensibles non nécessaires à AppointmentCard
-// (évite la sérialisation de données PII/cliniques dans les props Astro island).
+// Colonnes explicites : exclut les champs sensibles non nécessaires à l'island
+// AppointmentsManager (et à AppointmentCard en vue dépliée). Évite la sérialisation
+// de données PII/cliniques dans les props Astro.
 const APPOINTMENT_COLUMNS = [
   'id', 'status', 'scheduled_at', 'rescheduled_to',
   'appointment_type', 'appointment_mode', 'duration',
   'base_price', 'discount', 'final_price', 'is_first_session',
   'patient_name', 'patient_email', 'patient_phone', 'patient_postal_code',
-  'patient_reason', 'therapist_notes',
-  'video_link', 'stripe_payment_link_url', 'stripe_payment_link_id',
+  'patient_city', 'patient_reason', 'therapist_notes',
+  'video_link', 'google_calendar_event_id',
+  'stripe_payment_link_url', 'stripe_payment_link_id',
   'created_at', 'updated_at',
 ].join(',');
 
@@ -55,20 +57,7 @@ if (error) {
   console.error('[mes-rdvs] Erreur Supabase :', error);
 }
 
-// ── Comptages par statut ─────────────────────────────────────────────────────
-type FilterKey = 'all' | AppointmentStatus;
-
-const FILTERS: { key: FilterKey; label: string }[] = [
-  { key: 'all',              label: 'Tous'               },
-  { key: 'pending',          label: 'En attente'         },
-  { key: 'rescheduled',      label: 'Reportés'           },
-  { key: 'payment_pending',  label: 'Paiement en attente'},
-  { key: 'payment_received', label: 'Paiement reçu'      },
-  { key: 'confirmed',        label: 'Confirmés'          },
-  { key: 'declined',         label: 'Refusés'            },
-  { key: 'cancelled',        label: 'Annulés'            },
-];
-
+// ── Comptages par statut (pour l'en-tête de page : « N · X en attente ») ───────
 const counts: Record<string, number> = { all: appointments.length };
 for (const appt of appointments) {
   counts[appt.status] = (counts[appt.status] ?? 0) + 1;
@@ -178,76 +167,13 @@ for (const appt of appointments) {
       </div>
 
       <section id="appointments-tab-panel" role="tabpanel" aria-labelledby="appointments-tab">
-        <!-- Filtres par statut -->
-        <div
-          class="flex flex-wrap gap-2 mb-6"
-          role="group"
-          aria-label="Filtrer par statut"
-        >
-          {FILTERS.map(({ key, label }) => {
-            const count = counts[key] ?? 0;
-            if (key !== 'all' && count === 0) return null;
-            return (
-              <button
-                type="button"
-                data-filter={key}
-                class={`
-                  filter-btn inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium font-sans
-                  rounded-full border transition-colors focus:outline-none focus:ring-2 focus:ring-mint-400
-                  ${key === 'all'
-                    ? 'bg-mint-600 text-white border-mint-600'
-                    : 'bg-white text-sage-600 border-sage-200 hover:border-mint-400 hover:text-mint-700'}
-                `}
-                aria-pressed={key === 'all' ? 'true' : 'false'}
-              >
-                {label}
-                <span class={`
-                  inline-flex items-center justify-center w-5 h-5 text-xs rounded-full
-                  ${key === 'all' ? 'bg-mint-500 text-white' : 'bg-sage-100 text-sage-600'}
-                `}>
-                  {count}
-                </span>
-              </button>
-            );
-          })}
-        </div>
-
-        <!-- Message vide -->
-        {appointments.length === 0 && (
-          <div class="text-center py-16">
-            <div class="w-16 h-16 mx-auto mb-4 bg-sage-100 rounded-full flex items-center justify-center">
-              <svg class="w-8 h-8 text-sage-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-              </svg>
-            </div>
-            <p class="font-serif text-xl text-sage-600">Aucun rendez-vous</p>
-            <p class="text-sage-400 text-sm mt-1 font-sans">
-              Les nouvelles demandes apparaîtront ici.
-            </p>
-          </div>
-        )}
-
-        <!-- Liste des rendez-vous -->
-        <div id="appointments-list" class="space-y-4">
-          {appointments.map((appt) => (
-            <div
-              class="appointment-wrapper"
-              data-status={appt.status}
-            >
-              <AppointmentCard client:load appointment={appt} />
-            </div>
-          ))}
-        </div>
-
-        <!-- Message "aucun résultat pour ce filtre" (caché par défaut) -->
-        <p
-          id="no-filter-result"
-          class="hidden text-center py-12 text-sage-400 font-sans text-sm"
-          role="status"
-          aria-live="polite"
-        >
-          Aucun rendez-vous pour ce filtre.
-        </p>
+        <!--
+          Island unique : reçoit tous les rendez-vous (déjà chargés côté serveur)
+          et gère en interne la recherche, les filtres par statut, le partition
+          À venir / Passés et le regroupement par jour. La vue dépliée d'un RDV
+          réutilise <AppointmentCard /> tel quel.
+        -->
+        <AppointmentsManager client:load appointments={appointments} />
       </section>
 
       <section
@@ -288,51 +214,9 @@ for (const appt of appointments) {
     }
   });
 
-  // ── Filtres par statut ─────────────────────────────────────────────────────
-  const filterBtns = document.querySelectorAll<HTMLButtonElement>('.filter-btn');
-  const wrappers = document.querySelectorAll<HTMLElement>('.appointment-wrapper');
-  const noResult = document.getElementById('no-filter-result');
-
-  function applyFilter(filter: string) {
-    filterBtns.forEach((b) => {
-      const isActive = b.dataset['filter'] === filter;
-      b.setAttribute('aria-pressed', String(isActive));
-      if (isActive) {
-        b.classList.add('bg-mint-600', 'text-white', 'border-mint-600');
-        b.classList.remove('bg-white', 'text-sage-600', 'border-sage-200', 'hover:border-mint-400', 'hover:text-mint-700');
-      } else {
-        b.classList.remove('bg-mint-600', 'text-white', 'border-mint-600');
-        b.classList.add('bg-white', 'text-sage-600', 'border-sage-200', 'hover:border-mint-400', 'hover:text-mint-700');
-      }
-    });
-
-    let visible = 0;
-    wrappers.forEach((wrapper) => {
-      const show = filter === 'all' || wrapper.dataset['status'] === filter;
-      wrapper.style.display = show ? '' : 'none';
-      if (show) visible++;
-    });
-
-    if (noResult) {
-      noResult.classList.toggle('hidden', visible > 0);
-    }
-  }
-
-  // Restore persisted filter on page load (M5)
-  const saved = sessionStorage.getItem('mes-rdvs-filter');
-  if (saved && saved !== 'all') {
-    applyFilter(saved);
-  }
-
-  filterBtns.forEach((btn) => {
-    btn.addEventListener('click', () => {
-      const filter = btn.dataset['filter'] ?? 'all';
-      sessionStorage.setItem('mes-rdvs-filter', filter);
-      applyFilter(filter);
-    });
-  });
-
   // ── Onglets Rendez-vous / Patients / Plages horaires ─────────────────────────────
+  // (Le filtrage par statut des rendez-vous est désormais géré par l'island
+  //  React <AppointmentsManager />, y compris la persistance en sessionStorage.)
   const tabButtons = document.querySelectorAll<HTMLButtonElement>('.tab-btn');
   const appointmentsTabPanel = document.getElementById('appointments-tab-panel');
   const patientsTabPanel = document.getElementById('patients-tab-panel');

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -52,3 +52,66 @@ export function isWithinBusinessHours(isoDate: string, durationMin: number): boo
 
   return inMorning || inAfternoon;
 }
+
+/**
+ * Un rendez-vous est « à venir » tant que son heure de début n'est pas passée.
+ * On se base sur l'heure de début (et non de fin) — suffisant pour un tri d'agenda.
+ */
+export function isUpcoming(iso: string, nowMs: number = Date.now()): boolean {
+  return new Date(iso).getTime() >= nowMs;
+}
+
+/** Compare deux instants au jour calendaire près (fuseau Paris). */
+export function isSameParisDay(isoA: string, isoB: string): boolean {
+  return toParisDateString(new Date(isoA)) === toParisDateString(new Date(isoB));
+}
+
+/**
+ * Décalage arithmétique d'un jour calendaire `YYYY-MM-DD`.
+ * L'arithmétique se fait sur la date UTC (zéro heure) pour rester insensible
+ * aux transitions DST : on manipule une date « pure », pas une heure.
+ */
+function shiftParisDay(dayKey: string, deltaDays: number): string {
+  const [y, m, d] = dayKey.split('-').map(Number);
+  const shifted = new Date(Date.UTC(y, m - 1, d) + deltaDays * 86_400_000);
+  const sy = shifted.getUTCFullYear();
+  const sm = String(shifted.getUTCMonth() + 1).padStart(2, '0');
+  const sd = String(shifted.getUTCDate()).padStart(2, '0');
+  return `${sy}-${sm}-${sd}`;
+}
+
+/**
+ * Libellé relatif au jour courant (fuseau Paris).
+ * Renvoie "Aujourd'hui" / "Demain" / "Hier", ou `null` si le jour est plus éloigné.
+ */
+export function getRelativeDayLabel(
+  iso: string,
+  nowMs: number = Date.now(),
+): string | null {
+  const todayKey = toParisDateString(new Date(nowMs));
+  const targetKey = toParisDateString(new Date(iso));
+  if (targetKey === todayKey) return "Aujourd'hui";
+  if (targetKey === shiftParisDay(todayKey, 1)) return 'Demain';
+  if (targetKey === shiftParisDay(todayKey, -1)) return 'Hier';
+  return null;
+}
+
+/** Format court pour en-tête de groupe : ex. « ven. 3 juillet 2026 ». */
+export function formatDayHeader(iso: string): string {
+  return new Intl.DateTimeFormat('fr-FR', {
+    weekday: 'short',
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'Europe/Paris',
+  }).format(new Date(iso));
+}
+
+/** Heure courte HH:mm en fuseau Paris. */
+export function formatTimeParis(iso: string): string {
+  return new Intl.DateTimeFormat('fr-FR', {
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: 'Europe/Paris',
+  }).format(new Date(iso));
+}


### PR DESCRIPTION
## Summary
- Remplace la pile de ~89 `AppointmentCard` denses (~35 000 px de scroll) par un îlot React unique `AppointmentsManager` avec liste compacte repliable (~56 px/ligne)
- Ajoute une recherche instantanée (nom, email, téléphone, motif, code postal, ville) via `useDeferredValue`
- Partition **À venir** (tri ascendant, prochain RDV en premier) / **Passés** (tri descendant, replié par défaut) avec regroupement par jour et libellés relatifs
- Filtres par statut conservés avec compteurs dynamiques (reflètent la recherche en cours), persistence `sessionStorage['mes-rdvs-filter']`
- Corrige un bug latent : `google_calendar_event_id` et `patient_city` absents de la projection SQL → `undefined` en runtime

**Gain attendu** : scroll d'ouverture ~35 000 px → ~3 500 px (×10)

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #64: feat: refonte /mes-rdvs — liste compacte, recherche et groupes par date | open |
| Implementation | 1 commit on `feat/64-mes-rdvs-liste-compacte` | Complete |
| Verification | Lint ✅ Typecheck ✅ (0 erreur dans les fichiers modifiés) Tests ✅ (25/25) Build ✅ | Passed |

## Changements détaillés

| Fichier | Nature |
|---|---|
| `src/components/admin/AppointmentsManager.tsx` | **Nouvel îlot** — recherche, filtres, partition, grouping, lignes compactes, dépliage vers `AppointmentCard` |
| `src/components/admin/AppointmentCard.tsx` | Export `STATUS_LABELS`/`STATUS_BADGE` (réutilisés par l'îlot) |
| `src/utils/date.ts` | +5 helpers : `isUpcoming`, `isSameParisDay`, `getRelativeDayLabel`, `formatDayHeader`, `formatTimeParis` |
| `src/pages/mes-rdvs.astro` | `APPOINTMENT_COLUMNS` corrigé (+`google_calendar_event_id`, `patient_city`), bloc liste → îlot, script filtre vanilla supprimé |

## Fonctionnalités conservées

- Filtre par statut (8 statuts, même clé `sessionStorage['mes-rdvs-filter']`)
- Actions par RDV via `AppointmentCard` réutilisé tel quel (confirmer/refuser/reporter/notes/rappel/calendar)
- Tabs Rendez-vous / Patients / Plages (sélecteurs e2e intacts)

## Hors périmètre

- Vue master-detail / tableau paginé (options écartées)
- Déplacement des tabs en React (refactor orthogonal)
- Consolidation des `formatDate` dupliqués (nettoyage orthogonal)

## Test Plan

- [ ] Vérifier que la page `/mes-rdvs/` compile et se charge sans erreur (auth guard → redirect login, puis page liste)
- [ ] Créer des RDV de test via le wizard public ou l'admin → vérifier l'affichage compact
- [ ] Tester la recherche : taper un nom/email/téléphone dans la barre → résultats filtrés instantanément
- [ ] Tester les filtres par statut : cliquer sur "En attente" → seuls les pending apparaissent, compteurs dynamiques
- [ ] Vérifier la partition À venir / Passés : Passés replié par défaut, clic pour déplier
- [ ] Vérifier le regroupement par jour : en-têtes "Aujourd'hui", "Demain", etc.
- [ ] Cliquer sur une ligne compacte → `AppointmentCard` se déplie avec toutes les actions
- [ ] Vérifier la persistence du filtre : rafraîchir la page → filtre actif restauré

Fixes #64