### PR TITLE
feat(#63): annulation/report RDV + système d'avoir interne

### DIFF
--- a/artifacts/analyses/63-admin-annulation-avoir-credit-rdv-analysis.mdx
+++ b/artifacts/analyses/63-admin-annulation-avoir-credit-rdv-analysis.mdx
@@ -1,0 +1,383 @@
+---
+title: "Admin : annulation/report RDV + avoir — Analyse"
+description: "Analyse technique du système d'annulation, report et avoir sur rendez-vous payés"
+issue: 63
+type: analysis
+created: 2026-07-03
+---
+
+## Source
+
+Demande produit (Tavian, issue #63) : *« The therapist need a better appointment workflow
+from her rendez-vous page. Right now, she can refuse a remote meeting before it get payed.
+Now, she needs to be able to cancel or reschedule every kind of further appointments in
+every step of the workflow. Cette règle s'applique à tous les rendez vous à partir de la
+veille du jour actuel. […] if it's cancelled, admin should have the information of "credit"
+already payed but not consume. On next appointments, a checkbox should be available when
+credit is available to deduce it from actual pricing. If price is zero, no need for stripe
+payment. »*
+
+Décisions de produit validées en framing (issue #63, frame approuvé) :
+
+- Annuler (`cancelled`) ≠ Refuser (`declined`).
+- Avoir interne uniquement — **pas de `stripe.refunds.create`**.
+- Avoirs **admin-only** (le patient n'a pas d'UI ; il contacte la thérapeute).
+- Montant de l'avoir = `final_price` réellement payé.
+- Report d'un RDV vidéo déjà payé = move direct admin (corrige le bug double-facturation).
+- Restitution d'avoir si le nouveau RDV est annulé.
+- Reliquat d'avoir conservé si session moins chère (FIFO).
+
+## Problem
+
+Trois lacunes concrètes dans le back-office `/mes-rdvs/` :
+
+1. **Pas d'annulation.** Le statut `cancelled` est défini (`src/types/appointment.ts:30`,
+   `supabase/migrations/001_init.sql:47-55`) mais **aucun handler ni bouton ne le produit**.
+   Une fois un RDV confirmé/payé, la thérapeute est bloquée. Seul `decline` existe
+   (`src/pages/api/appointments/[id].ts:342-381`), limité aux demandes non payées.
+
+2. **Bug de double-facturation sur report vidéo payé.** L'action `reschedule`
+   (`[id].ts:408-503`) expire systématiquement le Payment Link Stripe (ligne 446) puis
+   `accept_reschedule` (`[id].ts:583-592`) **régénère un nouveau lien Stripe pour toute
+   vidéo**, même si le statut était `payment_received`. Un RDV vidéo déjà payé, reporté,
+   est donc re-facturé au patient.
+
+3. **Aucun mécanisme d'avoir.** Recherche exhaustive : zéro `stripe.refunds.create`,
+   aucune colonne/table de crédit, aucun concept d'avoir dans le code. Seul texte
+   informatif dans `src/pages/cgv.astro` et `src/components/pricing/PaymentInfo.tsx`.
+   Une téléconsultation payée annulée = argent « perdu » côté app.
+
+## Outcome
+
+La thérapeute peut, depuis `/mes-rdvs/`, **annuler ou reporter n'importe quel RDV** dans
+la fenêtre d'éligibilité (veille du jour actuel inclus), tous modes/statuts confondus.
+L'annulation d'une téléconsultation payée génère un **avoir traçable**, réutilisable sur
+une création manuelle ultérieure (case « Utiliser l'avoir »). Si le prix final tombe à 0,
+aucun paiement Stripe n'est demandé. Le report d'un RDV payé ne re-facture plus. Les
+avoirs consommés sont restitués si le RDV bénéficiaire est lui-même annulé.
+
+## Appetite
+
+Cycle F-full (~2-3 jours). Multi-domaine : migration DB (2 tables + 1 colonne), state
+machine RDV, 2 nouveaux handlers, UI admin (2 composants), template email, logique de
+ledger (FIFO + restitution).
+
+## Décisions de modélisation résolues
+
+Les 3 questions ouvertes du frame sont tranchées par l'analyse du code existant :
+
+### D1 — Statut d'un RDV vidéo payé après report direct
+
+**Décision : conserver `payment_received`.**
+
+Raisons :
+- Le handler `cancel` doit savoir qu'un RDV **a été payé** pour émettre un avoir. Le test
+  naturel est `status === 'payment_received'` (sémantique « paiement Stripe reçu »,
+  utilisée aussi par le webhook `stripe-webhook.ts:199`).
+- Passer en `confirmed` ferait perdre cette information — il faudrait alors tester
+  `stripe_payment_intent_id IS NOT NULL`, plus fragile (peut être null en mode mock).
+- Le report direct devient : `scheduled_at` mis à jour, statut inchangé, Meet/Calendar
+  mis à jour via `updateCalendarEvent`. Aucun email de demande de paiement.
+
+### D2 — Afficher le solde d'avoir côté admin
+
+**Décision : oui, sur la page Patients (`PatientList.tsx`) ET dans le formulaire de
+création (`AdminCreateButton.tsx`).**
+
+Raisons :
+- Admin-only et faible coût (un endpoint `GET /api/admin/credits?email=` + un indicateur).
+- La thérapeute doit voir qu'un patient a un avoir pour décider de l'appliquer — sinon la
+  case à cocher est invisible jusqu'à saisir l'email, et le suivi est impossible.
+- La page Patients est déjà le lieu naturel d'agrégation par email (`/api/admin/patients`).
+
+### D3 — Granularité de `credit_usages`
+
+**Décision : une ligne par tranche FIFO consommée** (standard ledger).
+
+Une consommation peut toucher plusieurs lignes `credits` (quand le crédit disponible est
+étalé sur plusieurs avoirs). Chaque tranche = une ligne `credit_usages`. La restitution se
+fait par `SELECT … WHERE appointment_id = X` puis restauration `remaining` + `DELETE`.
+Aucune colonne dénormalisée nécessaire côté appointments — sauf `credit_applied` pour
+l'affichage et le calcul du montant Stripe (voir D4).
+
+### D4 — Modèle de prix avec avoir (décision émergente de l'analyse)
+
+**Décision : `credit_applied` est une colonne séparée sur `appointments` ; le montant
+Stripe = `final_price − credit_applied`.**
+
+La sémantique actuelle de `final_price` est « ce que Stripe facture » (`[id].ts:180`,
+`[id].ts:587`, webhook). Si on réduisait `final_price` par l'avoir, on perdrait le prix
+catalogue et casserait l'affichage (`AppointmentCard.tsx:319`). On garde donc :
+
+| Colonne | Sémantique | Exemple (65€ grid, 40€ avoir) |
+|---|---|---|
+| `base_price` | prix grille | 6500 |
+| `discount` | remise 1ère/solidaire | 0 |
+| `final_price` | prix après remise (= dû catalogue) | 6500 |
+| `credit_applied` (NEW) | avoir consommé | 4000 |
+| — montant Stripe — | `final_price − credit_applied` | 2500 |
+
+Si `credit_applied ≥ final_price` → montant Stripe = 0 → **aucun lien Stripe généré**
+(règle produit « if price is zero, no need for stripe payment »).
+
+**Statut cible quand montant = 0 — aligné sur D1 (correction de cohérence).** Puisque
+(D1) un RDV vidéo payé conserve `payment_received`, un RDV vidéo **entièrement couvert
+par avoir** doit aussi aboutir à `payment_received` (et non `confirmed`). Uniformité :
+**`payment_received` = « la séance est réglée »**, peu importe le moyen (Stripe cash ou
+avoir). Cas par mode :
+
+| Mode | Montant Stripe | Statut cible |
+|---|---|---|
+| `in-person` | (jamais de Stripe) | `confirmed` |
+| `video`, montant > 0 | `final_price − credit_applied` | `payment_pending` (lien Stripe) → `payment_received` (webhook) |
+| `video`, montant = 0 (avoir couvre tout) | — | **`payment_received` direct**, aucun lien Stripe, Meet/Calendar générés |
+
+Ainsi la règle consolidée d'annulation (`status === 'payment_received'` → émettre un avoir
+de `final_price − credit_applied`) reste juste : pour un RDV vidéo financé à 100% par
+avoir, `final_price − credit_applied = 0` → **aucun nouvel avoir** (aucun cash encaissé),
+et `credit_applied > 0` → **restitution** de l'avoir source. Cohérent avec le tableau de
+sémantique ci-dessous.
+
+## Shapes — Modèle d'avoir
+
+### Shape 1 : Ledger avec `credit_usages` (recommandé)
+
+Deux tables :
+
+```sql
+CREATE TABLE credits (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  patient_email TEXT NOT NULL,
+  source_appointment_id UUID REFERENCES appointments(id),
+  amount INTEGER NOT NULL CHECK (amount > 0),      -- cents, montant d'origine
+  remaining INTEGER NOT NULL CHECK (remaining >= 0 AND remaining <= amount),
+  reason TEXT NOT NULL DEFAULT 'cancellation',     -- extensible ('manual' future)
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE credit_usages (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  credit_id UUID NOT NULL REFERENCES credits(id),
+  appointment_id UUID NOT NULL REFERENCES appointments(id),  -- RDV consommateur
+  amount INTEGER NOT NULL CHECK (amount > 0),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE appointments ADD COLUMN credit_applied INTEGER NOT NULL DEFAULT 0;
+```
+
+**Flux :**
+- **Création d'avoir** (annulation payée) : `INSERT credits (amount=remaining=final_price−credit_applied, source_appointment_id, patient_email)`.
+- **Consommation** (création manuelle avec avoir) : requête FIFO
+  `SELECT … WHERE patient_email AND remaining > 0 ORDER BY created_at`, boucle de
+  consommation, `INSERT credit_usages` par tranche, `UPDATE credits.remaining`.
+- **Restitution** (annulation d'un RDV consommateur) :
+  `SELECT credit_usages WHERE appointment_id`, `UPDATE credits.remaining += amount`,
+  `DELETE credit_usages`.
+
+**Trade-offs :**
+- ✅ Provenance complète (quel RDV a généré/consumé quoi).
+- ✅ Restitution triviale et exacte.
+- ✅ FIFO naturel (ORDER BY created_at).
+- ✅ Extensible (« création manuelle d'avoir » future = INSERT avec reason='manual').
+- ⚠️ 2 tables + 1 colonne ; logique de consommation ~40 lignes.
+
+**Rough scope : L** (migration + lib `credits.ts` + intégrations).
+
+### Shape 2 : Solde unique par patient
+
+```sql
+CREATE TABLE patient_credits (
+  patient_email TEXT PRIMARY KEY,
+  balance INTEGER NOT NULL DEFAULT 0
+);
+ALTER TABLE appointments ADD COLUMN credit_applied INTEGER NOT NULL DEFAULT 0;
+```
+
+**Flux :** `balance += final_price` à l'annulation payée ; `balance -= credit_applied` à
+l'utilisation ; restitution `balance += credit_applied`.
+
+**Trade-offs :**
+- ✅ Minimal (1 table).
+- ❌ Aucune provenance (impossible d'auditer quel RDV a créé l'avoir).
+- ❌ La « création manuelle d'avoir depuis la page Patients » (soupape future) serait
+  inauditable.
+- ❌ Pas de FIFO (un seul pot).
+
+**Rough scope : M.**
+
+### Shape 3 : Event-sourcing (append-only `credit_events`)
+
+Une table d'événements (`issued`/`consumed`/`restored`), solde calculé par agrégation.
+
+**Trade-offs :**
+- ✅ Audit maximal.
+- ❌ Overkill pour 1 thérapeute — complexité de requête, pas de besoin en scala.
+- ❌ Reconstruction du solde à chaque lecture.
+
+**Éliminé** — ne sert pas l'appétit.
+
+## Fit Check
+
+**Shape 1 (Ledger) retenue.**
+
+| Contrainte (frame) | Shape 1 | Shape 2 | Shape 3 |
+|---|:---:|:---:|:---:|
+| Restitution exacte sur re-annulation | ✅ | ⚠️ (via colonne) | ✅ |
+| Provenance / audit | ✅ | ❌ | ✅ |
+| FIFO explicite | ✅ | ❌ | ✅ |
+| Extensible (avoir manuel futur) | ✅ | ⚠️ | ✅ |
+| Appétit F-full maîtrisé | ✅ | ✅ | ❌ |
+
+Shape 1 est le meilleur compromis auditabilité/complexité. Shape 2 est éliminée (perte de
+provenance, restitution fragile). Shape 3 est éliminée (overkill).
+
+```mermaid
+flowchart LR
+  subgraph "Annulation RDV payé"
+    A1[RDV payment_received<br/>final_price=6500, credit_applied=0] -->|cancel| A2[status=cancelled]
+    A2 --> A3["INSERT credits<br/>amount=6500, remaining=6500<br/>source=RDV annulé"]
+  end
+  subgraph "Création manuelle avec avoir"
+    B1[RDV nouveau<br/>final_price=6500] -->|use_credit| B2["Consume FIFO<br/>credit_applied=4000"]
+    B2 --> B3["INSERT credit_usages<br/>credits.remaining -= 4000"]
+    B2 --> B4["Stripe amount = 2500<br/>ou 0 → confirmed direct"]
+  end
+  subgraph "Annulation du RDV bénéficiaire"
+    C1[RDV credit_applied=4000] -->|cancel| C2["Restitution:<br/>SELECT credit_usages<br/>remaining += 4000<br/>DELETE usages"]
+    C2 -.->|"pas de nouvel avoir<br/>(sauf si Stripe payé)"| C3["Si payment_received:<br/>nouvel avoir = 2500"]
+  end
+```
+
+## Décisions produit complémentaires (post-revue produit)
+
+Ces points clarifient des scénarios soulevés en revue et sont **verrouillés** pour le spec :
+
+1. **Cycle de vie de l'avoir — pas d'expiration.** Un avoir est ouvert indéfiniment,
+   géré manuellement par la thérapeute (qui voit le solde sur la page Patients, D2).
+   Aucun job de purge, aucune TTL. La thérapeute décide quand l'appliquer.
+
+2. **Email d'annulation — wording « avoir interne, pas remboursement cash ».** Le template
+   `AppointmentCancelled` doit expliciter que le patient dispose d'un **avoir réutilisable**
+   (montant, validité permanente) et qu'il doit **contacter la thérapeute** pour l'utiliser
+   — jamais parler de « remboursement ». C'est l'unique surface patient de l'avoir. Pour les
+   annulations **sans** avoir (présentiel, impayé), l'email reste une notification simple.
+
+3. **Éligibilité à l'avoir = statut `payment_received`, pas le mode.** En l'état, seul le
+   mode `video` atteint `payment_received` (le présentiel est payé sur place, jamais prépayé
+   en ligne). La règle reste gated sur **le paiement reçu**, pas sur le mode — ainsi, si un
+   futur mode de paiement en ligne couvrait le présentiel, la règle tiendrait sans modification.
+
+4. **Report d'un RDV financé par avoir (prix→0) vers un créneau de prix différent.**
+   Le report direct (statut `confirmed` ou `payment_received`) conserve l'affectation :
+   `credit_applied` et `final_price` inchangés. **Pas de re-facturation** de la différence,
+   pas de restitution. Cohérent avec la règle « payment kept » du RDV vidéo payé cash.
+   (La thérapeute peut, si besoin, annuler puis recréer manuellement pour réajuster.)
+
+5. **Fenêtre d'éligibilité inclut des RDV déjà passés — par conception.** `>= début de la
+   veille` permet d'annuler un RDV qui s'est déjà déroulé (ex. séance de la veille matin).
+   La **jugement de la thérapeute est le garde-fou intentionnel** (citation produit :
+   *« Pertinent pour annulation de dernière minute si le thérapeute n'a pas eu le temps de
+   l'annuler le jour même »*). On n'ajoute pas de garde-fou automatique sur « RDV déjà
+   écoulé » — ce serait contredire le besoin. Documenté pour mémoire.
+
+6. **Bug (F) justifié dans cet incrément.** Le report et l'annulation partagent le même
+   handler PATCH et la même zone UI ; traiter l'un sans l'autre laisserait un RDV vidéo
+   payé impossible à déplacer sans re-facturation. Couplage fort → même epic.
+
+## Sémantique d'annulation complète (cas figurés)
+
+| RDV annulé | credit_applied | statut avant | Avoir créé ? | Restitution ? |
+|---|---|---|---|---|
+| vidéo, 65€ payés | 0 | `payment_received` | **oui** : 6500 | — |
+| présentiel confirmé | 0 | `confirmed` | non (pas payé) | — |
+| vidéo en attente paiement | 0 | `payment_pending` | non | — |
+| vidéo créé avec 40€ avoir, 25€ Stripe payés | 4000 | `payment_received` | **oui** : 2500 (cash) | **oui** : 4000 |
+| vidéo créé avec 65€ avoir (prix→0, non Stripe) | 6500 | `payment_received` | non (`final_price − credit_applied = 0`, aucun cash) | **oui** : 6500 |
+
+**Règle consolidée à l'annulation :**
+1. Si `credit_applied > 0` → **restituer** `credit_applied` aux avoirs sources (toujours).
+2. Si `status === 'payment_received'` → **créer** un nouvel avoir de
+   `final_price − credit_applied` (le cash réellement encaissé via Stripe) — si ce montant
+   est 0, aucun avoir n'est créé (cas du RDV 100% financé par avoir).
+
+## State machine cible (extraits)
+
+```mermaid
+stateDiagram-v2
+  [*] --> pending: wizard public
+  [*] --> confirmed: admin présentiel
+  [*] --> payment_pending: admin vidéo
+
+  pending --> confirmed: confirm (présentiel)
+  pending --> payment_pending: confirm (vidéo)
+  payment_pending --> payment_received: webhook Stripe
+  payment_received --> confirmed: (alias sémantique)
+
+  pending --> declined: refuse
+  payment_pending --> declined: refuse
+
+  confirmed --> cancelled: ANNULER (nouveau)
+  payment_received --> cancelled: ANNULER (nouveau) + avoir
+  payment_pending --> cancelled: ANNULER (nouveau)
+  pending --> cancelled: ANNULER (nouveau)
+  rescheduled --> cancelled: ANNULER (nouveau)
+
+  payment_received --> payment_received: REPORT direct (nouveau, move admin)
+  confirmed --> confirmed: REPORT direct (move admin)
+  pending --> rescheduled: REPORT (proposition patient)
+  payment_pending --> rescheduled: REPORT (proposition patient)
+```
+
+## Fichiers impactés
+
+| Fichier | Changement | Shape |
+|---|---|:---:|
+| `supabase/migrations/008_credits.sql` (NEW) | tables `credits`, `credit_usages`, colonne `credit_applied`, RLS, trigger `updated_at` | 1 |
+| `src/lib/credits.ts` (NEW) | `getAvailableCredit`, `consumeCredit` (FIFO), `restoreCredit`, `issueCreditForCancellation` | 1 |
+| `src/lib/appointment-eligibility.ts` | `isCancellableByTherapist` (fenêtre veille) | — |
+| `src/utils/date.ts` | `startOfYesterdayParis` (helper TZ) | — |
+| `src/pages/api/appointments/[id].ts` | actions `cancel` + `reschedule_paid` (branche payment_received) | — |
+| `src/pages/api/admin/appointments/index.ts` | appliquer `use_credit`, calcul montant Stripe | — |
+| `src/pages/api/admin/credits.ts` (NEW) | `GET ?email=` solde + historique | — |
+| `src/components/admin/AppointmentCard.tsx` | bouton Annuler + éligibilité + cas report payé | — |
+| `src/components/admin/AdminCreateButton.tsx` | case « Utiliser l'avoir » + affichage solde | — |
+| `src/components/admin/PatientList.tsx` | badge « avoir disponible » | — |
+| `src/emails/AppointmentCancelled.tsx` (NEW) | template email d'annulation | — |
+| `src/types/appointment.ts` | `credit_applied` sur `Appointment` | — |
+
+## Risques & idempotence
+
+- **Idempotence de l'avoir à l'annulation** : protéger par `source_appointment_id UNIQUE`
+  sur `credits` → impossible de créer 2 avoirs pour la même annulation (re-clic bouton).
+- **Atomicité consommation** : la consommation FIFO doit être transactionnelle (SELECT
+  FOR UPDATE ou lecture-then-write dans une RPC Postgres). Supabase JS n'expose pas
+  `FOR UPDATE` ; utiliser une `pg` transaction (`src/lib/db.ts` existe ?) ou une RPC
+  `consume_credits(p_email, p_amount, p_appointment_id)` SECURITY DEFINER. **Point pour
+  spec/plan.**
+- **Stripe mock** : en mode mock, `payment_received` est atteint sans vrai paiement
+  (`stripe.ts:17`). L'avoir serait créé « à vide » — acceptable en dev, documenter.
+- **Email non bloquant** : comme `decline`, l'échec d'envoi email ne doit pas faire échouer
+  l'annulation (dégradation gracieuse).
+
+## Atomicité du ledger — décision
+
+**Investigation effectuée :**
+- Aucun pool `pg` utilisable dans `src/` (seul `src/lib/auth.server.ts` importe `pg`, pour
+  l'adaptateur interne better-auth — non réutilisable).
+- Aucun usage de `.rpc()` dans tout `src/` — le codebase écrit via `supabaseAdmin` JS.
+- `CREATE FUNCTION` Postgres est en revanche un pattern établi
+  (`001_init.sql:94` `update_updated_at`, `001_init.sql:111` `compute_scheduled_end`) pour
+  les triggers.
+
+**Décision : RPC Postgres `SECURITY DEFINER` invoquée via `supabaseAdmin.rpc()`.**
+
+La consommation FIFO concurrente (2 créations manuelles simultanées pour le même patient)
+ne peut pas être rendue atomique avec `supabaseAdmin` JS seul (pas de `SELECT FOR UPDATE`,
+pas de transaction multi-requêtes). Une fonction Postgres `consume_credits(p_email,
+p_amount, p_appointment_id) RETURNS TABLE(credit_id, amount)` gère le verrouillage et
+l'écriture en une transaction. De même `restore_credits(p_appointment_id)` pour la
+restitution. C'est un nouveau pattern d'appel (`.rpc()`) mais conforme aux conventions SQL
+existantes. `getAvailableCredit` et `issueCreditForCancellation` restent en JS pur (pas de
+concurrency).

--- a/artifacts/frames/63-admin-annulation-avoir-credit-rdv-frame.mdx
+++ b/artifacts/frames/63-admin-annulation-avoir-credit-rdv-frame.mdx
@@ -1,0 +1,160 @@
+---
+issue: 63
+title: "Admin : annuler/reporter tout RDV + système d'avoir (crédit) sur annulation payée"
+status: approved
+tier: F-full
+created: 2026-07-03
+---
+
+## Problem Statement
+
+La thérapeute gère ses rendez-vous depuis `/mes-rdvs/` (`src/pages/mes-rdvs.astro`), mais le
+workflow d'action est incomplet :
+
+1. **Aucune action « Annuler » n'existe.** Le statut `cancelled` est défini dans le type
+   `AppointmentStatus` (`src/types/appointment.ts:30`) et la contrainte DB CHECK
+   (`supabase/migrations/001_init.sql:47-55`), mais **aucun handler ni bouton ne le produit**.
+   Seul `decline` (« Refuser ») existe — et il ne s'applique qu'aux nouvelles demandes non
+   payées (`pending`, `rescheduled`, `payment_pending`). Une fois un RDV confirmé ou payé,
+   la thérapeute n'a aucun moyen de l'annuler.
+
+2. **Le « Reporter » actuel re-facture les RDV vidéo déjà payés.** L'action `reschedule`
+   (`src/pages/api/appointments/[id].ts:408-503`) expire l'ancien Payment Link Stripe
+   (ligne 446) et, côté `accept_reschedule`, **régénère un nouveau lien Stripe pour la vidéo**
+   (lignes 583-592) — même si la séance était déjà en `payment_received`. C'est un bug latent
+   de double-facturation.
+
+3. **Aucun mécanisme d'avoir / crédit.** Le code ne contient aucun `stripe.refunds.create`,
+   aucune colonne/table de crédit, aucun concept d'avoir (recherche exhaustive : seulement
+   du texte informatif dans `src/pages/cgv.astro` et `src/components/pricing/PaymentInfo.tsx`).
+   Quand une téléconsultation payée doit être annulée, l'argent payé est « perdu » côté app
+   — pas de trace, pas de déduction possible sur une séance ultérieure.
+
+## Why This Matters
+
+- La thérapeute reçoit des appels et doit pouvoir annuler ou reporter **n'importe quel** RDV
+  confirmé/payé, pas seulement refuser les nouvelles demandes.
+- La fenêtre d'éligibilité inclut **la veille du jour actuel** (annulation de dernière
+  minute si pas eu le temps le jour même).
+- Quand une séance vidéo déjà payée est annulée, l'argent doit rester chez la thérapeute
+  (pas de remboursement Stripe réel) mais être tracé comme **avoir réutilisable** sur une
+  séance future — sinon le patient paie deux fois.
+- L'avoir est **admin-only** : le patient n'a pas d'UI pour le consulter ; il contacte la
+  thérapeute qui crée manuellement le nouveau RDV en appliquant l'avoir.
+
+## Success Criteria
+
+### A. Annulation (nouvelle action `cancel`)
+
+- [ ] Bouton **« Annuler »** visible sur `AppointmentCard` pour les RDV dans la fenêtre
+      d'éligibilité (voir critère E), tous statuts sauf `declined`/`cancelled`.
+- [ ] Action `cancel` dans le PATCH `src/pages/api/appointments/[id].ts` :
+      transition vers `cancelled`, message optionnel au patient, email de notification.
+- [ ] *Annuler* reste distinct de *Refuser* : Refuser = demande non payée (`→ declined`),
+      Annuler = RDV confirmé/payé (`→ cancelled`).
+- [ ] L'événement Google Calendar lié est supprimé (comme pour `decline`, `[id].ts:374-378`).
+
+### B. Avoir automatique sur annulation payée
+
+- [ ] Si le RDV annulé est en `payment_received` (vidéo payée) → une ligne **avoir** est
+      créée, montant = `final_price` (ce qui a été effectivement payé).
+- [ ] L'avoir est rattaché au `patient_email` (clé d'identité patient, normalisée lowercase).
+- [ ] **Aucun appel `stripe.refunds.create`** — l'argent reste.
+- [ ] Aucun avoir pour les annulations de RDV non payés (`confirmed` présentiel,
+      `payment_pending`, `pending`).
+
+### C. Réutilisation de l'avoir (admin-only)
+
+- [ ] Dans `AdminCreateButton.tsx` (création manuelle), une case **« Utiliser l'avoir
+      disponible »** apparaît quand le `patient_email` saisi a un avoir disponible.
+- [ ] Cocher la case déduit l'avoir du `final_price` (FIFO sur `remaining`).
+- [ ] Si le reliquat d'avoir est supérieur au prix, le **reliquat reste disponible** pour
+      une séance future.
+- [ ] Si le prix final après déduction = 0 → **aucun lien Stripe généré**, statut `confirmed`
+      directement (pas `payment_pending`).
+- [ ] Si le prix final > 0 et mode vidéo → un lien Stripe est généré pour le **solde restant**.
+- [ ] Le patient n'a **aucune UI** pour les avoirs (aucun changement à `BookingWizard.tsx`).
+
+### D. Restitution de l'avoir si le nouveau RDV est annulé
+
+- [ ] Si un RDV créé avec un avoir est lui-même annulé → l'avoir **revient** (restauration
+      des `remaining` sur les lignes consommées, via table `credit_usages`).
+- [ ] Aucun **nouvel** avoir n'est créé dans ce cas (aucun nouvel argent n'a été payé).
+
+### E. Fenêtre d'éligibilité
+
+- [ ] Les actions **Annuler** et **Reporter** ne sont proposées que pour les RDV avec
+      `scheduled_at ≥ début de la veille` (`startOfYesterday` en timezone Europe/Paris).
+- [ ] Les RDV antérieurs sont en lecture seule (historique).
+- [ ] La logique d'éligibilité est partagée (helper `isCancellableByTherapist` ou équivalent)
+      pour éviter la divergence client/serveur.
+
+### F. Report d'un RDV vidéo déjà payé (correction du bug double-facturation)
+
+- [ ] Pour un RDV en `payment_received` (vidéo payée), le **report** effectue un move
+      direct admin : `scheduled_at` mis à jour, statut reste `confirmed` (ou équivalent
+      payé), paiement conservé, Meet/Calendar mis à jour.
+- [ ] Aucune régénération de lien Stripe, aucun re-accept patient, aucun email de demande
+      de paiement — seulement un email de notification du nouveau créneau.
+- [ ] Pour les RDV non payés, le flow actuel de proposition au patient est conservé.
+
+## Constraints
+
+- **Pas de remboursement Stripe réel** (règle produit dure).
+- **Patient identifié par `patient_email`** (lowercase, normalisé à l'insertion) — pas de
+  table `patients` ni de FK. L'avoir est rattaché à l'email.
+- **Avoirs admin-only** : aucune exposition côté patient.
+- Toutes les mutations passent par `supabaseAdmin` (service_role), RLS active
+  (`001_init.sql:127-135`).
+- Réutiliser `calculatePrice` (`src/lib/pricing.ts`), `sendEmail`/`buildAppointmentConversationSubject`
+  (`src/lib/resend.ts`), les helpers `ics`, `deleteCalendarEvent`/`updateCalendarEvent`
+  (`src/lib/google-calendar.ts`).
+- Emails via templates Resend (`src/emails/*.tsx`) — nouveau template `AppointmentCancelled`.
+- Conformité aux conventions de code existantes (TypeScript strict, centimes pour les prix,
+  ISO 8601 pour les dates, français pour l'UI).
+
+## Out of Scope
+
+- Remboursement Stripe réel automatisé.
+- UI patient pour consulter / utiliser un avoir (le patient appelle la thérapeute).
+- Création manuelle d'avoir depuis la page Patients (soupape future, hors périmètre).
+- Annulation par le patient lui-même (self-service).
+- Migration rétroactive des RDV historiques.
+- Notifications SMS pour l'annulation (le rappel SMS est un autre epic, #40).
+
+## Stakeholders
+
+- **Oriane Montabonnet** (thérapeute) — utilisatrice finale du back-office.
+
+## Appetite
+
+Tier: **F-full**
+Reasoning :
+- **Multi-domaine** : nouvelle table DB (`credits`) + table de jointure (`credit_usages`),
+  modifications du state machine RDV (`[id].ts`), 2 nouveaux handlers d'action (`cancel`,
+  `reschedule_paid`), UI admin (boutons + cas Avoir dans `AppointmentCard` et
+  `AdminCreateButton`), nouveau template email, logique de ledger (FIFO + restitution).
+- **Migration DB** nécessaire → pas de F-lite.
+- **Décisions d'architecture** sur le modèle de crédit (ledger vs solde, restitution,
+  idempotence) → justifie analyze + architecture sketch.
+
+## Open Questions
+
+_Résolues par alignement produit (cette section documente les décisions pour mémoire) :_
+
+1. **Annuler vs Refuser** → distincts. Refuser = demande non payée (`declined`) ;
+   Annuler = RDV confirmé/payé (`cancelled`).
+2. **Avoir réel vs interne** → interne uniquement (pas de `stripe.refunds.create`).
+3. **Portée de la case Avoir** → admin-only (création manuelle).
+4. **Montant de l'avoir** → `final_price` réellement payé.
+5. **Report d'un RDV payé** → move direct admin (corrige le bug de double-facturation).
+6. **Restitution d'avoir sur re-annulation** → via `credit_usages` (pas de nouvel avoir).
+
+_Ouvertes pour analyze :_
+
+- Sémantique exacte du statut final d'un RDV vidéo payé après report direct (garder
+  `payment_received` vs `confirmed` ?) — voir analyze.
+- Doit-on exposer le solde d'avoir sur la carte RDV / page Patients pour information admin,
+  ou seulement dans le formulaire de création ? — voir analyze.
+- Granularité de la table `credit_usages` (une ligne par tranche FIFO consommée, ou une
+  ligne par RDV consommateur avec snapshot) ? — voir analyze.

--- a/artifacts/plans/63-admin-annulation-avoir-credit-rdv-plan.mdx
+++ b/artifacts/plans/63-admin-annulation-avoir-credit-rdv-plan.mdx
@@ -1,0 +1,538 @@
+---
+title: "Plan: Annulation/Report RDV + système d'avoir interne"
+issue: 63
+spec: artifacts/specs/63-admin-annulation-avoir-credit-rdv-spec.mdx
+complexity: 7/10
+tier: F-full
+generated: 2026-07-03
+---
+
+## Summary
+
+Implémente l'annulation (`cancel`) et le report direct des RDV vidéo payés (`reschedule_paid`),
+plus un ledger d'avoir interne (`credits`/`credit_usages`) consommable en création manuelle
+admin. 7 slices → ~17 micro-tasks sur 5 waves. Aucun `stripe.refunds.create` ; atomicité
+FIFO via RPC Postgres.
+
+## Architecture
+
+```mermaid
+flowchart TD
+  subgraph "Slice 1 — Foundation"
+    MIG["008_credits.sql<br/>tables + RPC + RLS"] --> LIB["credits.ts<br/>getAvailable/issue/consume/restore"]
+    ELIG["appointment-eligibility.ts<br/>isCancellableByTherapist"]
+    DATE["date.ts<br/>startOfYesterdayParis"]
+    TYPES["appointment.ts<br/>+ credit_applied"]
+  end
+  subgraph "Slices 2-4 — Cancel"
+    PATCH["[id].ts PATCH<br/>cancel action"]
+    LIB --> PATCH
+    EMAIL["AppointmentCancelled.tsx"]
+    CARD["AppointmentCard.tsx<br/>bouton Annuler"]
+  end
+  subgraph "Slice 5 — Reschedule paid"
+    PATCH2["[id].ts PATCH<br/>reschedule_paid action"]
+    CARD2["AppointmentCard.tsx<br/>branche Reporter payé"]
+  end
+  subgraph "Slice 6 — Create with credit"
+    POST["admin/appointments POST<br/>use_credit + amount=0"]
+    ACB["AdminCreateButton.tsx<br/>case Utiliser l'avoir"]
+    LIB --> POST
+  end
+  subgraph "Slice 7 — Endpoint"
+    GET["admin/credits.ts GET<br/>balance + history"]
+  end
+  PATCH --> CARD
+  PATCH2 --> CARD2
+  POST --> ACB
+```
+
+```mermaid
+flowchart LR
+  subgraph credits.ts
+    gAC[getAvailableCredit]
+    iAC[issueCreditForCancellation]
+    cC[consumeCredits]
+    rC[restoreCredits]
+  end
+  subgraph "[id].ts"
+    cancel[cancel handler]
+    rp[reschedule_paid handler]
+  end
+  subgraph admin/index.ts
+    create[POST create]
+  end
+  subgraph admin/credits.ts
+    getbal[GET balance]
+  end
+  cC -.->|RPC consume_credits| postgres[(Postgres)]
+  rC -.->|RPC restore_credits| postgres
+  cancel --> rC
+  cancel --> iAC
+  create --> cC
+  create --> gAC
+  getbal --> gAC
+  tests[tests/credits.test.ts] -.->|mocks supabase| credits.ts
+```
+
+## Bootstrap Context
+
+Conventions vérifiées dans le code :
+- **Tests** : `tests/unit/*.test.ts`, vitest, env `node`, `@/` alias → `./src/`, mock supabase
+  via `setup.ts` (`vi.stubEnv`). Pattern : `vi.mock('@/lib/...')` pour isoler la logique pure.
+- **Prix** : centimes (integer). `calculatePrice` retourne des euros → `* 100` au stockage.
+- **Emails** : `src/emails/*.tsx` (React), rendus via `@react-email/render`, envoyés par
+  `sendEmail` (`src/lib/resend.ts`), `threadKey: appointment:{id}:patient`.
+- **State machine** : actions dispatch dans `PATCH [id].ts` via `body.action`.
+- **Migration** : fichiers `supabase/migrations/00N_*.sql` numérotés ; `CREATE FUNCTION`
+  établi (`001_init.sql:94,111`) ; RLS service_role-only.
+- **GCal** : `deleteCalendarEvent`/`updateCalendarEvent` (`src/lib/google-calendar.ts`),
+  appels non-bloquants (`.catch(console.error)`).
+
+## Agents
+
+| Agent | Tasks | Fichiers |
+|---|---|---|
+| backend-dev-A | T1 (migration+RPC), T4 (credits.ts), T9 (cancel handler), T13 (reschedule_paid), T16 (admin POST use_credit) | `008_credits.sql`, `credits.ts`, `[id].ts`, `admin/appointments/index.ts` |
+| backend-dev-B | T18 (GET endpoint), T19 (types) | `admin/credits.ts`, `appointment.ts` |
+| frontend-dev-A | T10 (email), T11 (cancel UI), T14 (reschedule UI), T17 (credit checkbox) | `AppointmentCancelled.tsx`, `AppointmentCard.tsx`, `AdminCreateButton.tsx` |
+| backend-dev-C | T6 (date helper), T7 (eligibility) | `date.ts`, `appointment-eligibility.ts` |
+| tester-A | T5 (credits tests), T8 (eligibility tests) | `tests/unit/credits.test.ts`, `tests/unit/cancel-eligibility.test.ts` |
+
+## Wave Structure
+
+5 waves, max 3 agents parallèles. ~3 jours vs ~5 séquentiel.
+
+| Wave | Trigger | Agents | Tasks |
+|------|---------|--------|-------|
+| 1 | start | 3 ∥ | backend-dev-A: T1→T4 · backend-dev-C: T6→T7 · backend-dev-B: T19 · tester-A: T5→T8 |
+| 2 | Wave 1 done | 2 ∥ | backend-dev-A: T9 · frontend-dev-A: T10→T11 |
+| 3 | Wave 2 done | 2 ∥ | backend-dev-A: T13 · frontend-dev-A: T14 |
+| 4 | Wave 3 done | 2 ∥ | backend-dev-A: T16 · frontend-dev-A: T17 |
+| 5 | Wave 4 done | 1 | backend-dev-B: T18 |
+
+### Budget — per task
+
+| Task | Items | Class | Est. ops | Split? |
+|------|-------|-------|----------|--------|
+| T1 migration+RPC | 4 (tables, column, 2 RPC, RLS, triggers) | judgmental | 6 | — |
+| T4 credits.ts | 4 fonctions | judgmental | 5 | — |
+| T9 cancel handler | 1 (logique restore+issue+email+gcal) | judgmental | 6 | — |
+| T13 reschedule_paid | 1 | bounded | 3 | — |
+| T16 admin POST use_credit | 1 (branch amount=0) | judgmental | 5 | — |
+| autres (T6,7,10,11,14,17,18,19) | 1 chacun | bounded | 2-3 | — |
+
+**Total estimé : ~50 ops.** Aucune tâche > 50, aucune instance > 4 tasks ni > 2 subjects.
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|----------|-------|-------|----------|--------|
+| backend-dev-A | T1, T4, T9, T13, T16 | 22 | credits, appointments, rpc | — (séquentiel par waves) |
+| backend-dev-B | T18, T19 | 5 | credits, types | — |
+| frontend-dev-A | T10, T11, T14, T17 | 10 | email, ui | — |
+| backend-dev-C | T6, T7 | 4 | date, eligibility | — |
+| tester-A | T5, T8 | 6 | credits, eligibility | — |
+
+Aucun split requis (max 5 tasks sur backend-dev-A mais étalés sur 5 waves, jamais > 1 par wave simultanée).
+
+## Consistency Report
+
+- **Covered** : 24/24 critères de succès (chacun tracé à ≥1 micro-task).
+- **Uncovered** : 0.
+- **Untraced tasks** : 0 (toutes les tasks mappent vers un critère).
+- **Exemptions** : les RPC PL/pgSQL (`consume_credits`, `restore_credits`) ne sont pas
+  unit-testables sans DB ; vérifiées par revue manuelle + tests d'intégration via le flow
+  applicatif (T5 teste `credits.ts` qui les invoque, en mockant le retour RPC).
+
+## Micro-Tasks
+
+### Slice 1 — Foundation (Wave 1)
+
+#### T1 — Migration 008 : tables credits + RPC — `[P]` Wave 1
+- **File**: `supabase/migrations/008_credits.sql` (NEW)
+- **Agent**: backend-dev-A
+- **Subject**: rpc
+- **Spec trace**: SC migration + RPC
+- **Slice**: V1
+- **Phase**: GREEN
+- **Difficulty**: 4
+- **Shape**:
+  ```sql
+  -- tables
+  CREATE TABLE credits (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    patient_email TEXT NOT NULL,
+    source_appointment_id UUID REFERENCES appointments(id) ON DELETE SET NULL,
+    amount INTEGER NOT NULL CHECK (amount > 0),
+    remaining INTEGER NOT NULL CHECK (remaining >= 0 AND remaining <= amount),
+    reason TEXT NOT NULL DEFAULT 'cancellation',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+  );
+  CREATE UNIQUE INDEX credits_source_appointment_uniq ON credits(source_appointment_id) WHERE source_appointment_id IS NOT NULL;
+  CREATE INDEX credits_patient_email_idx ON credits(patient_email) WHERE remaining > 0;
+
+  CREATE TABLE credit_usages (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    credit_id UUID NOT NULL REFERENCES credits(id) ON DELETE CASCADE,
+    appointment_id UUID NOT NULL REFERENCES appointments(id) ON DELETE CASCADE,
+    amount INTEGER NOT NULL CHECK (amount > 0),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+  );
+  CREATE UNIQUE INDEX credit_usages_once_per_appt_credit ON credit_usages(credit_id, appointment_id);
+  CREATE INDEX credit_usages_appointment_idx ON credit_usages(appointment_id);
+
+  ALTER TABLE appointments ADD COLUMN credit_applied INTEGER NOT NULL DEFAULT 0;
+  ALTER TABLE appointments ADD CONSTRAINT credit_applied_chk CHECK (credit_applied >= 0);
+
+  -- triggers updated_at (réutiliser update_updated_at() de 001)
+  CREATE TRIGGER credits_updated_at BEFORE UPDATE ON credits
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+  -- RLS service_role-only (comme appointments)
+  ALTER TABLE credits ENABLE ROW LEVEL SECURITY;
+  ALTER TABLE credit_usages ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY credits_service_role_all ON credits USING (auth.role() = 'service_role');
+  CREATE POLICY credit_usages_service_role_all ON credit_usages USING (auth.role() = 'service_role');
+
+  -- RPC consume_credits : FIFO atomique, SECURITY DEFINER durci
+  CREATE OR REPLACE FUNCTION consume_credits(p_email TEXT, p_amount INTEGER, p_appointment_id UUID)
+  RETURNS TABLE(credit_id UUID, amount INTEGER)
+  LANGUAGE plpgsql SECURITY DEFINER AS $$
+  DECLARE total_available INTEGER;
+  BEGIN
+    SELECT COALESCE(SUM(remaining),0) INTO total_available
+      FROM credits WHERE patient_email = LOWER(p_email) AND remaining > 0 FOR UPDATE;
+    IF total_available < p_amount THEN
+      RAISE EXCEPTION 'CREDIT_INSUFFICIENT: dispo %, demandé %', total_available, p_amount;
+    END IF;
+    -- FIFO : boucle sur les avoirs les plus anciens
+    RETURN QUERY
+      WITH picked AS (
+        SELECT id, remaining,
+               LEAST(remaining, p_amount - COALESCE(SUM(p_amount) OVER (ORDER BY created_at, id ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING),0)) AS take
+        FROM credits WHERE patient_email = LOWER(p_email) AND remaining > 0
+        ORDER BY created_at, id
+      )
+      UPDATE credits c SET remaining = c.remaining - p.take
+        FROM picked p WHERE c.id = p.id AND p.take > 0
+        RETURNING c.id, p.take;
+    -- enregistrer les usages
+    INSERT INTO credit_usages(credit_id, appointment_id, amount)
+      SELECT c.id, p_appointment_id, ... ; -- (voir implémentation détaillée)
+  END;
+  $$;
+  REVOKE ALL ON FUNCTION consume_credits(TEXT,INTEGER,UUID) FROM PUBLIC;
+  GRANT EXECUTE ON FUNCTION consume_credits(TEXT,INTEGER,UUID) TO service_role;
+
+  -- RPC restore_credits : idem pattern
+  CREATE OR REPLACE FUNCTION restore_credits(p_appointment_id UUID) RETURNS void ...;
+  REVOKE ALL ON FUNCTION restore_credits(UUID) FROM PUBLIC;
+  GRANT EXECUTE ON FUNCTION restore_credits(UUID) TO service_role;
+  ```
+- **Verify**: `docker compose exec postgres psql -U postgres -d omf_therapie -f /docker-entrypoint-initdb.d/008_credits.sql` (ou apply locale) ; `\df consume_credits` liste la fonction.
+- **Expected**: 0 erreurs, 2 tables + 1 colonne + 2 fonctions créées.
+- **Time**: 8 min
+
+#### T4 — credits.ts lib — Wave 1 (après T1)
+- **File**: `src/lib/credits.ts` (NEW)
+- **Agent**: backend-dev-A
+- **Subject**: credits
+- **Spec trace**: S1–S4
+- **Slice**: V1
+- **Phase**: GREEN
+- **Difficulty**: 3
+- **Shape**: exporte `getAvailableCredit(email): Promise<number>` (SUM remaining),
+  `issueCreditForCancellation(appt): Promise<CreditRow>` (INSERT, gère UNIQUE conflict),
+  `consumeCredits(email, amount, apptId): Promise<Usage[]>` (`supabaseAdmin.rpc('consume_credits', ...)`),
+  `restoreCredits(apptId): Promise<void>` (`supabaseAdmin.rpc('restore_credits', ...)`).
+- **Verify**: `npx tsc --noEmit` ; `npm run lint`.
+- **Expected**: 0 erreurs de type.
+- **Time**: 5 min
+
+#### T5 — Tests credits.ts — `[P]` Wave 1
+- **File**: `tests/unit/credits.test.ts` (NEW)
+- **Agent**: tester-A
+- **Subject**: credits
+- **Spec trace**: SC tests credits
+- **Slice**: V1
+- **Phase**: RED-GATE
+- **Difficulty**: 3
+- **Shape**: mock `@/lib/supabase` (supabaseAdmin) ; cas — consume exact, consume partiel
+  (reliquat > 0), consume > dispo (échec via RPC RAISE), restore, double-issue bloqué
+  (UNIQUE), plusieurs NULL source_appointment_id autorisés.
+- **Verify**: `npm test -- credits`.
+- **Expected**: tous verts.
+- **Time**: 6 min
+
+#### T6 — startOfYesterdayParis — `[P]` Wave 1
+- **File**: `src/utils/date.ts`
+- **Agent**: backend-dev-C
+- **Subject**: date
+- **Spec trace**: SC éligibilité
+- **Slice**: V1
+- **Phase**: GREEN
+- **Difficulty**: 2
+- **Shape**: `export function startOfYesterdayParis(now = new Date()): Date` — calcule
+  minuit de la veille en Europe/Paris via `Intl.DateTimeFormat` (pattern `toParisDateString`).
+- **Verify**: `npm test` (après T8).
+- **Time**: 3 min
+
+#### T7 — isCancellableByTherapist — Wave 1 (après T6)
+- **File**: `src/lib/appointment-eligibility.ts`
+- **Agent**: backend-dev-C
+- **Subject**: eligibility
+- **Spec trace**: SC éligibilité
+- **Slice**: V1
+- **Phase**: GREEN
+- **Difficulty**: 2
+- **Shape**: `export function isCancellableByTherapist(appt: {scheduled_at: string; status: AppointmentStatus}): boolean`
+  → `appt.status ∉ {'declined','cancelled'} && new Date(appt.scheduled_at) >= startOfYesterdayParis()`.
+- **Verify**: `npm test -- cancel-eligibility`.
+- **Time**: 3 min
+
+#### T8 — Tests éligibilité — `[P]` Wave 1
+- **File**: `tests/unit/cancel-eligibility.test.ts` (NEW)
+- **Agent**: tester-A
+- **Subject**: eligibility
+- **Spec trace**: SC éligibilité
+- **Slice**: V1
+- **Phase**: RED-GATE
+- **Difficulty**: 2
+- **Shape**: cas — RDV veille (éligible), RDV avant-hier (non), status declined/cancelled
+  (non), RDV hier soir tard (éligible). Pattern du `appointment-eligibility.test.ts` existant.
+- **Verify**: `npm test -- cancel-eligibility`.
+- **Expected**: tous verts.
+- **Time**: 4 min
+
+#### T19 — Type credit_applied — `[P]` Wave 1
+- **File**: `src/types/appointment.ts`
+- **Agent**: backend-dev-B
+- **Subject**: types
+- **Spec trace**: D4
+- **Slice**: V1
+- **Phase**: GREEN
+- **Difficulty**: 1
+- **Shape**: ajouter `credit_applied: number;` à l'interface `Appointment`.
+- **Verify**: `npx tsc --noEmit`.
+- **Time**: 2 min
+
+### Slice 2-4 — Annulation (Wave 2)
+
+#### T9 — Handler cancel — Wave 2
+- **File**: `src/pages/api/appointments/[id].ts`
+- **Agent**: backend-dev-A
+- **Subject**: appointments
+- **Spec trace**: N1, SC annulation + avoir + restitution
+- **Slice**: V2/V3/V4
+- **Phase**: GREEN
+- **Difficulty**: 4
+- **Shape**: ajouter `if (action === 'cancel') { ... }` après `decline` :
+  1. guard `isCancellableByTherapist(appointment)` (sinon 422).
+  2. `if (appointment.credit_applied > 0) await restoreCredits(id)` — non-bloquant si échec ? NON, bloquant (cohérence ledger) → 500 si échec.
+  3. `if (appointment.status === 'payment_received') { const cash = appointment.final_price - appointment.credit_applied; if (cash > 0) await issueCreditForCancellation(appointment, cash); }`
+  4. UPDATE status='cancelled'.
+  5. `deleteCalendarEvent` si google_calendar_event_id (non-bloquant).
+  6. `sendEmail(AppointmentCancelled, { hasCredit: cash>0, creditAmount: cash, ... })` (non-bloquant).
+  Ajouter 'cancel' à la liste d'actions valides (ligne 103).
+- **Verify**: `npx tsc --noEmit` ; test manuel via curl sur un RDV de test.
+- **Time**: 7 min
+
+#### T10 — Email AppointmentCancelled — `[P]` Wave 2
+- **File**: `src/emails/AppointmentCancelled.tsx` (NEW)
+- **Agent**: frontend-dev-A
+- **Subject**: email
+- **Spec trace**: SC email wording
+- **Slice**: V2
+- **Phase**: GREEN
+- **Difficulty**: 2
+- **Shape**: props `{ patientName, scheduledAt, hasCredit, creditAmount? }`. Deux variantes :
+  sans avoir (notification simple) / avec avoir (mention « Vous disposez d'un avoir de X€,
+  valide en permanence. Contactez votre thérapeute pour l'utiliser »). **Jamais** le mot
+  « remboursement ». Pattern de `AppointmentDeclined.tsx`/`BaseLayout.tsx`.
+- **Verify**: `npx tsc --noEmit`.
+- **Time**: 4 min
+
+#### T11 — UI bouton Annuler — Wave 2 (après T10)
+- **File**: `src/components/admin/AppointmentCard.tsx`
+- **Agent**: frontend-dev-A
+- **Subject**: ui
+- **Spec trace**: U1, U2
+- **Slice**: V2
+- **Phase**: GREEN
+- **Difficulty**: 3
+- **Shape**: ajouter `isCancellableByTherapist` import ; bouton « Annuler » (rouge) visible
+  quand éligible ET non read-only ; modal type 'cancel' (message optionnel) ; `handleCancel`
+  → `callPatch({ action: 'cancel', ...(msg ? {therapist_notes: msg} : {}) })`.
+- **Verify**: build `npm run build` (island compile).
+- **Time**: 5 min
+
+### Slice 5 — Report vidéo payé (Wave 3)
+
+#### T13 — Handler reschedule_paid — Wave 3
+- **File**: `src/pages/api/appointments/[id].ts`
+- **Agent**: backend-dev-A
+- **Subject**: appointments
+- **Spec trace**: N2, SC reschedule_paid
+- **Slice**: V5
+- **Phase**: GREEN
+- **Difficulty**: 3
+- **Shape**: `if (action === 'reschedule_paid') { ... }` :
+  - guard `status === 'payment_received' && appointment_mode === 'video' && isCancellableByTherapist`.
+  - valider `rescheduled_to` (futur, business hours, conflict).
+  - UPDATE scheduled_at uniquement (status/prix/stripe inchangés).
+  - `updateCalendarEvent(google_calendar_event_id, {start, end})` (non-bloquant).
+  - `sendEmail(AppointmentRescheduled, { ... SANS acceptUrl })` (non-bloquant).
+  - **Aucun** `createAppointmentPaymentLink`, **aucun** `stripe.paymentLinks.update`.
+  Ajouter 'reschedule_paid' à la liste d'actions (ligne 103).
+- **Verify**: `npx tsc --noEmit`.
+- **Time**: 5 min
+
+#### T14 — UI branche Reporter payé — Wave 3
+- **File**: `src/components/admin/AppointmentCard.tsx`
+- **Agent**: frontend-dev-A
+- **Subject**: ui
+- **Spec trace**: U3
+- **Slice**: V5
+- **Phase**: GREEN
+- **Difficulty**: 2
+- **Shape**: pour `status === 'payment_received' && mode video && éligible`, le bouton
+  « Reporter » appelle `reschedule_paid` (move direct) au lieu du flow proposition. Badge
+  « payé » visible. Pour les autres statuts, flow existant inchangé.
+- **Verify**: `npm run build`.
+- **Time**: 4 min
+
+### Slice 6 — Création avec avoir (Wave 4)
+
+#### T16 — Admin POST use_credit — Wave 4
+- **File**: `src/pages/api/admin/appointments/index.ts`
+- **Agent**: backend-dev-A
+- **Subject**: appointments
+- **Spec trace**: N3, SC création avec avoir
+- **Slice**: V6
+- **Phase**: GREEN
+- **Difficulty**: 4
+- **Shape**: lire `use_credit` du body ; après `calculatePrice` :
+  - si `use_credit` : `balance = await getAvailableCredit(email)` ; `credit_applied = min(balance, final_price)`.
+  - si `credit_applied > 0` : `await consumeCredits(email, credit_applied, appointment.id)` (après insert, donc après avoir l'id).
+  - montant dû = `final_price − credit_applied`.
+  - **status initial** : `video` → (`montant == 0 ? 'payment_received' : 'payment_pending'`) ; `in-person` → `confirmed` (inchangé).
+  - Stripe link **seulement si** video ET montant > 0 (`amount: montantDû`).
+  - Meet/Calendar **si** montant==0 (équivalent d'une séance confirmée payée).
+  Inclure `credit_applied` dans l'INSERT.
+- **Verify**: `npx tsc --noEmit`.
+- **Time**: 7 min
+
+#### T17 — UI case Utiliser l'avoir — Wave 4
+- **File**: `src/components/admin/AdminCreateButton.tsx`
+- **Agent**: frontend-dev-A
+- **Subject**: ui
+- **Spec trace**: U5
+- **Slice**: V6
+- **Phase**: GREEN
+- **Difficulty**: 3
+- **Shape**: quand `patient_email` change et est valide, fetch `GET /api/admin/credits?email=`
+  → si `balance > 0`, afficher case « Utiliser l'avoir (X€ disponibles) ». Si cochée,
+  `livePrice` affiche le montant dû après déduction. Payload inclut `use_credit: true`.
+- **Verify**: `npm run build`.
+- **Time**: 5 min
+
+### Slice 7 — Endpoint GET (Wave 5)
+
+#### T18 — GET /api/admin/credits — Wave 5
+- **File**: `src/pages/api/admin/credits.ts` (NEW)
+- **Agent**: backend-dev-B
+- **Subject**: credits
+- **Spec trace**: N4, SC endpoint
+- **Slice**: V7
+- **Phase**: GREEN
+- **Difficulty**: 2
+- **Shape**: `export const GET` — auth admin ; query `email` ; retourne `{ balance, history: CreditRow[] }`
+  via `getAvailableCredit` + SELECT credits/credit_usages WHERE patient_email = LOWER(email).
+  Validation email (EMAIL_RE). Pattern de `admin/appointments/index.ts`.
+- **Verify**: `npx tsc --noEmit` ; `curl` test local.
+- **Time**: 4 min
+
+## Task Seeding Blueprint
+
+<!-- Used by /implement to seed TaskCreate calls on session start.
+     Format: T{n} | agent-instance | blockedBy | subject
+     blockedBy refs T-numbers within this list (not session task IDs).
+     Agent instances are named (tester-A/B, backend-dev-A/B/C, devops-A/B)
+     so parallel tasks map to distinct spawned agents.
+     Seed in wave order; within a wave all rows are parallel (∥). -->
+
+### Wave 1 — no deps, 4 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T1 | backend-dev-A | — | rpc |
+| T6 | backend-dev-C | — | date |
+| T19 | backend-dev-B | — | types |
+
+### Wave 1b — after T1/T6, parallel
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T4 | backend-dev-A | T1 | credits |
+| T7 | backend-dev-C | T6 | eligibility |
+| T5 | tester-A | T4 | credits |
+| T8 | tester-A | T7 | eligibility |
+
+### Wave 2 — after Wave 1, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T9 | backend-dev-A | T4, T7 | appointments |
+| T10 | frontend-dev-A | T19 | email |
+| T11 | frontend-dev-A | T9, T10 | ui |
+
+### Wave 3 — after Wave 2, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T13 | backend-dev-A | T7 | appointments |
+| T14 | frontend-dev-A | T13 | ui |
+
+### Wave 4 — after Wave 3, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T16 | backend-dev-A | T4 | appointments |
+| T17 | frontend-dev-A | T16 | ui |
+
+### Wave 5 — after Wave 4
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T18 | backend-dev-B | T4 | credits |
+
+## RED-GATE Sentinels
+
+- **Gate V1** (après T5+T8) : `npm test` vert (credits + eligibility). Si rouge, ne pas
+  passer à Wave 2.
+- **Gate V2** (après T9) : `npx tsc --noEmit` vert + handler cancel compile (restore+issue
+  câblés). Si rouge, bloquer.
+- **Gate V6** (après T16+T17) : build complet `npm run build` vert (island checkbox compile
+  + POST gère amount=0).
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart.
+     Single-session execution: agent runs all waves sequentially. -->
+- T1 — rpc (migration 008: tables credits/credit_usages + RPC consume/restore)
+- T4 — credits (src/lib/credits.ts: getAvailable/issue/consume/restore)
+- T5 — credits (tests/unit/credits.test.ts)
+- T6 — date (src/utils/date.ts: startOfYesterdayParis)
+- T7 — eligibility (src/lib/appointment-eligibility.ts: isCancellableByTherapist)
+- T8 — eligibility (tests/unit/cancel-eligibility.test.ts)
+- T9 — appointments ([id].ts: cancel handler)
+- T10 — email (src/emails/AppointmentCancelled.tsx)
+- T11 — ui (AppointmentCard.tsx: bouton Annuler)
+- T13 — appointments ([id].ts: reschedule_paid handler)
+- T14 — ui (AppointmentCard.tsx: branche Reporter payé)
+- T16 — appointments (admin/appointments/index.ts: use_credit)
+- T17 — ui (AdminCreateButton.tsx: case Utiliser l'avoir)
+- T18 — credits (src/pages/api/admin/credits.ts: GET balance)
+- T19 — types (src/types/appointment.ts: credit_applied)

--- a/artifacts/specs/63-admin-annulation-avoir-credit-rdv-spec.mdx
+++ b/artifacts/specs/63-admin-annulation-avoir-credit-rdv-spec.mdx
@@ -1,0 +1,251 @@
+---
+issue: 63
+title: "Annulation/Report RDV + système d'avoir interne"
+status: approved
+tier: F-full
+created: 2026-07-03
+promoted_from: artifacts/analyses/63-admin-annulation-avoir-credit-rdv-analysis.mdx
+---
+
+## Context
+
+Promu depuis `artifacts/analyses/63-admin-annulation-avoir-credit-rdv-analysis.mdx`
+(shape retenue : **Ledger** `credits` + `credit_usages`). Frame approuvé :
+`artifacts/frames/63-admin-annulation-avoir-credit-rdv-frame.mdx`.
+
+Décisions verrouillées en analyse : D1 (statut payé = `payment_received`), D2 (solde d'avoir
+visible admin sur Patients + création), D3 (`credit_usages` = 1 ligne/tranche FIFO),
+D4 (`credit_applied` colonne séparée ; montant Stripe = `final_price − credit_applied` ;
+video montant=0 → `payment_received` direct). Atomicité FIFO via RPC `SECURITY DEFINER`.
+
+## Goal
+
+Permettre à la thérapeute d'**annuler ou reporter tout RDV** dans la fenêtre d'éligibilité,
+d'émettre un **avoir interne** sur annulation d'un RDV payé, et de **réutiliser** cet avoir
+lors d'une création manuelle — sans jamais appeler `stripe.refunds.create`.
+
+## Users
+
+- **Thérapeute (admin)** — utilisatrice finale de `/mes-rdvs/` et `/api/admin/*`. Voit les
+  avoirs, les applique en création manuelle, annule/reporte les RDV.
+- **Patient** — reçoit uniquement un email d'annulation (mention de l'avoir éventuel). N'a
+  **aucune UI** pour consulter/utiliser un avoir.
+
+## Expected Behavior
+
+### Annulation
+
+1. Sur la carte d'un RDV éligible (`scheduled_at ≥ début de la veille`, statut ≠
+   `declined`/`cancelled`), un bouton **« Annuler »** (rouge) s'affiche à côté des actions
+   existantes.
+2. Un modal demande un message optionnel au patient, puis confirme.
+3. Le statut passe à `cancelled`. L'événement Google Calendar lié est supprimé.
+4. **Si le RDV a consommé un avoir** (`credit_applied > 0`) → l'avoir est **restitué**
+   (restauration des `remaining` sources, suppression des `credit_usages`).
+5. **Si le RDV est `payment_received`** → un **nouvel avoir** de `final_price − credit_applied`
+   est créé (montant = cash réellement encaissé). Si ce montant est 0 (RDV 100% financé par
+   avoir), aucun avoir n'est créé.
+6. Le patient reçoit un email `AppointmentCancelled` : notification simple (pas d'avoir) OU
+   mention d'avoir (montant, « valide en permanence », « contactez la thérapeute pour
+   l'utiliser ») — jamais le mot « remboursement ».
+
+### Report d'un RDV vidéo déjà payé (`payment_received`)
+
+1. Le bouton **« Reporter »** déclenche un **move direct admin** : l'admin choisit un nouveau
+   créneau, la date est mise à jour immédiatement, le paiement est **conservé**
+   (`credit_applied` et `final_price` inchangés).
+2. Meet/Calendar sont mis à jour via `updateCalendarEvent`.
+3. **Aucun lien Stripe régénéré, aucun email de demande de paiement, aucune re-accept patient.**
+4. Le patient reçoit un email de notification du nouveau créneau.
+
+### Report d'un RDV non payé (`pending`/`payment_pending`)
+
+Comportement inchangé : proposition au patient via `accept_reschedule` + lien signé.
+
+### Création manuelle avec avoir
+
+1. Dans `AdminCreateButton`, après saisie d'un `patient_email` disposant d'un avoir, une case
+   **« Utiliser l'avoir (XX€ disponibles) »** apparaît.
+2. Si cochée, `credit_applied` = min(avoir disponible, `final_price`). Le montant dû =
+   `final_price − credit_applied`.
+3. **Si montant dû = 0** → statut `payment_received` direct (pour `video`) / `confirmed`
+   (pour `in-person`), aucun lien Stripe, Meet/Calendar générés.
+4. **Si montant dû > 0 et mode `video`** → lien Stripe pour le solde restant.
+5. Consommation FIFO atomique via RPC, reliquat conservé sur les avoirs sources.
+
+## Data Model & Consumers
+
+```mermaid
+classDiagram
+  class appointments {
+    UUID id PK
+    TEXT patient_email
+    TEXT appointment_mode
+    INTEGER base_price
+    INTEGER discount
+    INTEGER final_price
+    INTEGER credit_applied
+    TEXT status
+    TIMESTAMPTZ scheduled_at
+    TEXT google_calendar_event_id
+  }
+  class credits {
+    UUID id PK
+    TEXT patient_email
+    UUID source_appointment_id FK
+    INTEGER amount
+    INTEGER remaining
+    TEXT reason
+    TIMESTAMPTZ created_at
+    TIMESTAMPTZ updated_at
+  }
+  class credit_usages {
+    UUID id PK
+    UUID credit_id FK
+    UUID appointment_id FK
+    INTEGER amount
+    TIMESTAMPTZ created_at
+  }
+  credits ||--o{ credit_usages : "consumed by"
+  appointments ||--o| credits : "source of"
+  appointments ||--o{ credit_usages : "consumer"
+```
+
+```mermaid
+flowchart LR
+  subgraph "Cette issue"
+    AC[AppointmentCard.tsx<br/>boutons Annuler/Reporter + éligibilité] --> PATCH
+    AB[AdminCreateButton.tsx<br/>case Utiliser l'avoir] --> POST
+    PATCH[/api/appointments/id PATCH<br/>cancel, reschedule_paid/] --> LIB
+    POST[/api/admin/appointments POST<br/>applique use_credit/] --> LIB
+    LIB[credits.ts<br/>consume/restore/issue] --> RPC
+    RPC[(RPC Postgres<br/>consume_credits, restore_credits)]
+    CA[credits + credit_usages<br/>migration 008]
+    EM[emails/AppointmentCancelled.tsx]
+    PATCH --> EM
+    CA --> LIB
+  end
+  subgraph "Future (out of scope)"
+    PM[Patients page<br/>badge avoir] -.-> API
+    API[/api/admin/credits GET/] -.-> CA
+  end
+```
+
+| Consommateur | Champs consommés | Quand | Statut |
+|---|---|---|:---:|
+| `AppointmentCard` (admin) | `scheduled_at`, `status`, `credit_applied` | rendu boutons + affichage | cette issue |
+| `AdminCreateButton` (admin) | solde avoir par `patient_email` | création manuelle | cette issue |
+| `PatientList` (admin) | solde avoir par email | badge info patient | future* |
+| `[id].ts` PATCH `cancel` | `status`, `credit_applied`, `final_price`, `payment_received` | annulation | cette issue |
+| `admin/appointments/index.ts` POST | solde avoir, `credit_applied` | création avec avoir | cette issue |
+
+*Note : D2 du frame stipulait un badge Patients. En raffinant, le **minimum viable** est la
+case dans `AdminCreateButton` (requis pour le critère C). Le badge Patients est reporté en
+future pour limiter le scope ; l'endpoint `GET /api/admin/credits` est inclus pour le servir
+ultérieurement et pour permettre à la case d'afficher le montant.
+
+## Breadboard
+
+### UI Affordances (admin)
+
+| ID | Élément | Handler | Endpoint | Condition |
+|---|---|---|---|---|
+| U1 | Bouton « Annuler » | `handleCancel` | PATCH `cancel` | éligible (E) ∧ status ∉ {declined, cancelled} |
+| U2 | Modal « Annuler » (msg optionnel) | `handleCancel` | PATCH `cancel` | U1 cliqué |
+| U3 | Bouton « Reporter » (branche payée) | `handleReschedulePaid` | PATCH `reschedule_paid` | éligible ∧ status = `payment_received` ∧ mode `video` |
+| U4 | Bouton « Reporter » (branche impayée) | `handleReschedule` (existant) | PATCH `reschedule` | éligible ∧ status ∈ {pending, payment_pending} |
+| U5 | Case « Utiliser l'avoir (XX€) » | `handleSubmit` | POST admin | avoir dispo > 0 pour l'email saisi |
+
+### API Affordances
+
+| ID | Endpoint | Action | Effet |
+|---|---|---|---|
+| N1 | PATCH `/api/appointments/[id]` | `cancel` | status→cancelled, delete GCal, restore+issue credit, email |
+| N2 | PATCH `/api/appointments/[id]` | `reschedule_paid` | move direct (video payé), update Meet/Calendar, email notif |
+| N3 | POST `/api/admin/appointments` | (existante) + `use_credit` | consomme FIFO, ajuste montant Stripe/statut |
+| N4 | GET `/api/admin/credits?email=` | — | solde + historique (sert U5 montant + future badge) |
+
+### Data Affordances (lib `credits.ts`)
+
+| ID | Fonction | Effet | Atomicité |
+|---|---|---|---|
+| S1 | `getAvailableCredit(email)` | SELECT SUM(remaining) WHERE email | lecture pure |
+| S2 | `issueCreditForCancellation(appt)` | INSERT credits (UNIQUE source_appointment_id) | JS pur |
+| S3 | `consumeCredits(email, amount, apptId)` | RPC `consume_credits` | RPC atomique |
+| S4 | `restoreCredits(apptId)` | RPC `restore_credits` | RPC atomique |
+
+## Slices
+
+| # | Slice | Demo | Dépend |
+|---|---|---|:---:|
+| 1 | **Migration + lib credits + éligibilité** | `008_credits.sql` appliquée ; `credits.ts` + RPC durcis ; `isCancellableByTherapist` + helper TZ ; tests unitaires consume/restore/issue | — |
+| 2 | **Annulation (cancel)** | Bouton U1+U2 sur RDV éligible → status `cancelled`, email, GCal supprimé | 1 |
+| 3 | **Avoir auto sur annulation payée** | Annuler un `payment_received` → ligne `credits` créée ; idempotent | 1, 2 |
+| 4 | **Restitution sur re-annulation** | Annuler un RDV avec `credit_applied > 0` → avoir restauré | 1, 2 |
+| 5 | **Report vidéo payé (direct move)** | Reporter un `payment_received` → move direct, paiement conservé, pas de re-facturation | 1 |
+| 6 | **Création manuelle avec avoir** | Case U5 → déduction, montant=0 skip Stripe, reliquat conservé | 1 |
+| 7 | **Endpoint GET solde avoir** | `GET /api/admin/credits` (sert U5 montant + future badge Patients) | 1 |
+
+## Success Criteria
+
+### Migration & lib (slice 1)
+- [ ] `supabase/migrations/008_credits.sql` crée `credits` + `credit_usages` + colonne `appointments.credit_applied` + RLS service_role-only + trigger `updated_at` + contrainte `UNIQUE(credits.source_appointment_id)`.
+- [ ] RPC `consume_credits(p_email TEXT, p_amount INT, p_appointment_id UUID) RETURNS TABLE(credit_id UUID, amount INT)` — atomique, FIFO, `SECURITY DEFINER`, **`REVOKE EXECUTE FROM PUBLIC; GRANT EXECUTE TO service_role;`**, owner = rôle minimal dédié (pas `postgres`).
+- [ ] RPC `restore_credits(p_appointment_id UUID) RETURNS void` — même durcissement (SECURITY DEFINER + REVOKE/GRANT).
+- [ ] `src/lib/credits.ts` exporte `getAvailableCredit`, `issueCreditForCancellation`, `consumeCredits`, `restoreCredits`.
+- [ ] Helper `isCancellableByTherapist(appt)` (`src/lib/appointment-eligibility.ts`) : `scheduled_at ≥ startOfYesterdayParis`, partagé client/serveur ; + `startOfYesterdayParis` (`src/utils/date.ts`).
+- [ ] Tests unitaires `tests/credits.test.ts` couvrent : consume exact, consume partiel (reliquat), consume > disponible (échec), restore, double-issue bloqué par UNIQUE, plusieurs NULL `source_appointment_id` autorisés (Postgres).
+
+### Annulation (slice 2)
+- [ ] Bouton « Annuler » visible sur RDV éligible (E), caché si status ∈ {declined, cancelled} ou hors fenêtre.
+- [ ] Action `cancel` dans PATCH `[id].ts` : status → `cancelled`, supprime l'événement GCal si présent, envoie email `AppointmentCancelled`.
+- [ ] L'email d'annulation n'utilise **jamais** le mot « remboursement » (assertion de contenu testée).
+- [ ] L'échec d'envoi email ne fait pas échouer l'annulation (non-blocking, loggué).
+
+### Avoir auto (slice 3)
+- [ ] Annuler un RDV `payment_received` crée une ligne `credits` (`amount = remaining = final_price − credit_applied`).
+- [ ] Annuler un RDV non-`payment_received` ne crée **aucune** ligne `credits`.
+- [ ] Un 2e `cancel` sur le même RDV (re-clic) ne crée **pas** de 2e avoir (UNIQUE source_appointment_id).
+
+### Restitution (slice 4)
+- [ ] Annuler un RDV avec `credit_applied > 0` restaure les `remaining` sources et supprime les `credit_usages`.
+- [ ] La restitution s'exécute **avant** la création d'un éventuel nouvel avoir (ordre : restore puis issue).
+
+### Report vidéo payé (slice 5)
+- [ ] `reschedule_paid` met à jour `scheduled_at` sans changer status/prix/stripe, appelle `updateCalendarEvent`, envoie un email de notification (pas `PaymentRequest`, **pas de lien d'acceptation** — email simple type `AppointmentRescheduledNotify` ou réutilise `AppointmentRescheduled` sans acceptUrl).
+- [ ] Aucun appel à `createAppointmentPaymentLink` ni `stripe.paymentLinks.update` sur `reschedule_paid`.
+
+### Création avec avoir (slice 6)
+- [ ] Case « Utiliser l'avoir » visible uniquement si `getAvailableCredit(email) > 0`, affiche le montant disponible.
+- [ ] `credit_applied` = min(avoir, final_price) consommé via RPC FIFO.
+- [ ] Si montant dû (`final_price − credit_applied`) = 0 → statut `payment_received` (video) / `confirmed` (in-person), aucun lien Stripe généré.
+- [ ] Si montant dû > 0 et video → lien Stripe pour le solde.
+- [ ] Reliquat d'avoir conservé sur les lignes `credits` sources (remaining > 0 possible).
+
+### Éligibilité & endpoint (slice 7)
+- [ ] `GET /api/admin/credits?email=` retourne `{ balance, history[] }` (auth admin).
+
+## Edge Cases
+
+| Cas | Stratégie |
+|---|---|
+| Re-clic bouton Annuler (concurrence) | UNIQUE(source_appointment_id) bloque le double-avoir ; status déjà `cancelled` → 409 |
+| Consommation concurrente (2 créations même email) | RPC `consume_credits` transactionnel (verrou par ligne) |
+| Avoir > prix (reliquat) | `consumeCredits` consomme partiellement, `remaining` mis à jour |
+| Avoir insuffisant (demande > disponible) | RPC échoue (RAISE) → 409 ; pas de consommation partielle forcée par l'API |
+| RDV vidéo 100% avoir (montant=0) annulé | restore (credit_applied > 0) ; pas de nouvel avoir (final_price − credit_applied = 0) |
+| Stripe mock en dev | `payment_received` atteint sans cash ; avoir créé « à vide » — acceptable, documenté dans README/CLAUDE.md |
+| Annulation d'un RDV déjà écoulé (veille) | Autorisé par conception (jugement thérapeute) — pas de garde-fou automatique |
+| Email patient échoue | Non-bloquant (comme `decline`), loggué |
+| Suppression GCal échoue | Non-bloquant (comme `decline`), loggué |
+| Patient introuvable en BDD à l'annulation | N/A — l'email est sur le RDV, pas de lookup patient |
+| Report d'un RDV avoir-only vers prix différent | Prix/avoir conservés inchangés (pas de re-facturation) |
+
+## Out of Scope
+
+- `stripe.refunds.create` (jamais).
+- UI patient pour les avoirs.
+- Création manuelle d'avoir depuis la page Patients (badge Patients aussi reporté).
+- Annulation self-service patient.
+- Migration rétroactive des RDV historiques.
+- Notifications SMS d'annulation (epic #40).

--- a/package-lock.json
+++ b/package-lock.json
@@ -565,6 +565,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1219,6 +1220,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -1405,6 +1407,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1645,6 +1648,7 @@
       "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.4.0.tgz",
       "integrity": "sha512-RpMtLUIQAEWMgdPLNVbIF5ON2mm+CH0U3rCdUCU1VyeAUui4m38DyK7/aXMLZov2YDjG684pS1D0MBllrmgjQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "^2.0.1"
       }
@@ -1652,7 +1656,8 @@
     "node_modules/@better-fetch/fetch": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.21.tgz",
-      "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="
+      "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==",
+      "peer": true
     },
     "node_modules/@capsizecss/unpack": {
       "version": "4.0.0",
@@ -1714,31 +1719,11 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1770,7 +1755,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1787,7 +1771,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1804,7 +1787,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1821,7 +1803,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1838,7 +1819,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1855,7 +1835,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1872,7 +1851,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1889,7 +1867,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1906,7 +1883,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1923,7 +1899,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1940,7 +1915,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1957,7 +1931,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1974,7 +1947,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1991,7 +1963,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2008,7 +1979,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2025,7 +1995,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2042,7 +2011,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2075,7 +2043,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2108,7 +2075,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2141,7 +2107,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2158,7 +2123,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2175,7 +2139,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2192,7 +2155,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2605,9 +2567,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2623,9 +2582,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -2643,9 +2599,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2661,9 +2614,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -2681,9 +2631,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2699,9 +2646,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -2719,9 +2663,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2738,9 +2679,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2756,9 +2694,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2782,9 +2717,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2806,9 +2738,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2832,9 +2761,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2856,9 +2782,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2882,9 +2805,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2907,9 +2827,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2931,9 +2848,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3178,6 +3092,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
       "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3989,6 +3904,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -5269,6 +5185,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -5291,6 +5208,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
       "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -5303,6 +5221,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
       "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "1.28.0"
       },
@@ -5825,6 +5744,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
       "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/semantic-conventions": "1.28.0"
@@ -5850,6 +5770,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
       "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/resources": "1.30.1",
@@ -5908,6 +5829,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
       "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -6076,9 +5998,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6098,9 +6017,6 @@
       "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6122,9 +6038,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6144,9 +6057,6 @@
       "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6168,9 +6078,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6190,9 +6097,6 @@
       "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6423,6 +6327,7 @@
       "integrity": "sha512-uGo0BOOzjbMUo3lu+BIDWayvn5o6Xyfmnlla5VGf05n8gHMvO1ll7U4FtzWe3hxMLwt53pmc4iE0M+B5slG+Ug==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -6436,6 +6341,7 @@
       "integrity": "sha512-qXyj7RZLE7POy9BMKSoqQ00tOXThjOZSUnI2Yu9i29IHngPlmrNayIWBoVKtElES7OWwypUcpiajwi1mUWx6/A==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -6449,6 +6355,7 @@
       "integrity": "sha512-M3B7JpVH4ytgn83/ujRR1k1DQHvTeABiDM61OvAbjLRPhC/5KLHU5KkzIbbuGIrjWwxAbL1kSQzU8MhLEtSxyw==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prismjs": "^1.30.0"
       },
@@ -6465,6 +6372,7 @@
       "integrity": "sha512-jfhebvv3dVsp3OdPgKXnk8+e2pBiDVZejDOBFzBa/IblrAJ9cQDkN6rBD5IyEg8hTOxwbw3iaI/yZFmDmIguIA==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -6543,6 +6451,7 @@
       "integrity": "sha512-QWBB56RkkU0AJ9h+qy33gfT5iuZknPC7Un/IjZv9B0QmMIK+WWacc0cH6y2SV5Cv/b99hU94fjEMOOO4enpkbQ==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -6582,6 +6491,7 @@
       "integrity": "sha512-jmsKnQm1ykpBzw4hCYHwBkt5pW2jScXffPeEH5ZRF5tZeF5b1pvlFTO9han7C0pCkZYo1kEvWiRtx69yfCIwuw==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -6595,6 +6505,7 @@
       "integrity": "sha512-TwmOmBDibavUQpXBxpmZYi2Iks/yeZOzFYh+di9EltMSnEabH8dMZXrl+pxNXzCgZ2XE8HY7VmUL65Lenfu5PA==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -6621,6 +6532,7 @@
       "integrity": "sha512-sRCpEARNVTf3FQhZOC+JTvu5r6ubiYWkT0ucYXg8ctkyi4G8QG+jgYPiNUqVeTLA2STOfmPM/nrk1nb84y6CPQ==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -6634,6 +6546,7 @@
       "integrity": "sha512-lkWc/NjOcefRZMkQoSDDbuKBEBDES9aXnFEOuPH845wD3TxPwh+QTf0fStuzjoRLUZWpHnio4z7qGGRYusn/sw==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -6663,6 +6576,7 @@
       "integrity": "sha512-aYK8q0IPkBXyMsbpMXgxazwHxYJxTrXrV95GFuu2HbEiIToMwSyUgb8HDFYwPqqfV03/jbwqlsXmFxsOd+VNaw==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -6675,6 +6589,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/render/-/render-2.0.8.tgz",
       "integrity": "sha512-5udvVr3U/WuGJZfLdLBOhkzrqRWd2Q5ZYmF7ppcy7FzWcwgshdqLMNqJOXcVzAXJXg/2bm7D+WGJzTtZOZMQnQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "html-to-text": "^9.0.5",
         "prettier": "^3.5.3"
@@ -6784,6 +6699,7 @@
       "integrity": "sha512-TYqkioRS45wTR5il3dYk/SbUjjEdhSwh9BtRNB99qNH1pXAwA45H7rAuxehiu8iJQJH0IyIr+6n62gBz9ezmsw==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -6798,6 +6714,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6814,6 +6731,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6830,6 +6748,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6846,6 +6765,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6862,6 +6782,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6878,9 +6799,7 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6897,9 +6816,7 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6916,9 +6833,7 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6935,9 +6850,7 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6954,9 +6867,7 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6973,9 +6884,7 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6992,6 +6901,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7008,6 +6918,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -7026,6 +6937,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7042,6 +6954,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7176,9 +7089,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7191,9 +7101,6 @@
       "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -7208,9 +7115,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7223,9 +7127,6 @@
       "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -7240,9 +7141,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7255,9 +7153,6 @@
       "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -7272,9 +7167,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7287,9 +7179,6 @@
       "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -7304,9 +7193,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7319,9 +7205,6 @@
       "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -7336,9 +7219,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7352,9 +7232,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7367,9 +7244,6 @@
       "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -7824,6 +7698,7 @@
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
       "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -7969,6 +7844,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -8021,6 +7897,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -8031,6 +7908,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -8134,6 +8012,7 @@
       "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.0",
         "@typescript-eslint/types": "8.59.0",
@@ -8680,6 +8559,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8720,6 +8600,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -9036,6 +8917,7 @@
       "resolved": "https://registry.npmjs.org/astro/-/astro-5.18.1.tgz",
       "integrity": "sha512-m4VWilWZ+Xt6NPoYzC4CgGZim/zQUO7WFL0RHCH0AiEavF1153iC3+me2atDvXpf/yX4PyGUeD8wZLq1cirT3g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^2.13.0",
         "@astrojs/internal-helpers": "0.7.6",
@@ -9672,6 +9554,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10750,6 +10633,7 @@
       "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.11.tgz",
       "integrity": "sha512-LrwidLCV8azdMGjvtwp30nj9tIv1BwI3VhtC0UaGSjQkAVWw4bN42I8qwbxRziPeSQoj+zUVkOpxZzAWBDARtQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.39.0",
         "@standard-schema/spec": "^1.1.0",
@@ -10868,6 +10752,7 @@
       "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.5.tgz",
       "integrity": "sha512-kOFJkBP7utAQLEYrobZm3vkTH8mXq5GNgvjc5/XEST1ilVHaxXUXfeDeFlqoETMtyqS4+3/h4ONX2i++ebZrvA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@better-auth/utils": "^0.4.0",
         "@better-fetch/fetch": "^1.1.21",
@@ -11071,6 +10956,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -12111,7 +11997,8 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/data-uri-to-buffer": {
       "version": "6.0.2",
@@ -12537,7 +12424,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1507524.tgz",
       "integrity": "sha512-OjaNE7qpk6GRTXtqQjAE5bGx6+c4F1zZH0YXtpZQLM92HNXx4zMAaqlKhP4T52DosG6hDW8gPMNhGOF8xbwk/w==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -12978,7 +12866,6 @@
       "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -13073,6 +12960,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -15707,6 +15595,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -15716,6 +15605,7 @@
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
       "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -15939,6 +15829,7 @@
       "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.17.tgz",
       "integrity": "sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       }
@@ -16146,6 +16037,7 @@
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "devOptional": true,
       "license": "MPL-2.0",
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -16177,6 +16069,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -16197,6 +16090,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -16217,6 +16111,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -16237,6 +16132,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -16257,6 +16153,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -16277,9 +16174,7 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -16300,9 +16195,7 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -16323,9 +16216,7 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -16346,9 +16237,7 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -16369,6 +16258,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -16389,6 +16279,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -17775,6 +17666,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
       }
@@ -18797,6 +18689,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -19050,6 +18943,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -19980,6 +19874,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -19992,6 +19887,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -21623,6 +21519,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -21726,6 +21623,7 @@
       "integrity": "sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==",
       "devOptional": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -21872,6 +21770,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -22145,6 +22044,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -22701,6 +22601,7 @@
       "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.9",
         "@vitest/mocker": "4.1.9",
@@ -22785,6 +22686,448 @@
         }
       }
     },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/vitest/node_modules/@vitest/mocker": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
@@ -22848,6 +23191,7 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -23594,6 +23938,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/components/admin/AdminCreateButton.tsx
+++ b/src/components/admin/AdminCreateButton.tsx
@@ -36,6 +36,7 @@ interface FormState {
   is_solidarity: boolean;
   send_email: boolean;
   video_link: string;
+  use_credit: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -75,6 +76,7 @@ const INITIAL_STATE: FormState = {
   is_solidarity: false,
   send_email: true,
   video_link: "",
+  use_credit: false,
 };
 
 // ---------------------------------------------------------------------------
@@ -170,6 +172,22 @@ function AdminCreateModal({ onClose, prefillData }: { onClose: () => void; prefi
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Solde d'avoir disponible pour le patient_email saisi (admin-only).
+  const [availableCredit, setAvailableCredit] = useState<number | null>(null);
+  useEffect(() => {
+    const email = form.patient_email.trim();
+    setAvailableCredit(null);
+    if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) return;
+    const controller = new AbortController();
+    fetch(`/api/admin/credits?email=${encodeURIComponent(email)}`, { credentials: "same-origin", signal: controller.signal })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (data && typeof data.balance === "number") setAvailableCredit(data.balance);
+      })
+      .catch(() => { /* silencieux : pas d'avoir connu */ });
+    return () => controller.abort();
+  }, [form.patient_email]);
+
   const containerRef = useRef<HTMLDivElement>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
   const onCloseRef = useRef(onClose);
@@ -247,6 +265,14 @@ function AdminCreateModal({ onClose, prefillData }: { onClose: () => void; prefi
     [form.appointment_type, form.duration, form.override_first_session, form.is_solidarity, form.useOverridePrice, form.overridePrice],
   );
 
+  // Avoir déductible (centimes → euros). Plafonné au prix final si l'avoir est plus grand.
+  const creditEuros = useMemo(() => {
+    if (!form.use_credit || availableCredit == null || availableCredit <= 0) return 0;
+    return Math.min(availableCredit / 100, livePrice.finalPrice);
+  }, [form.use_credit, availableCredit, livePrice.finalPrice]);
+
+  const amountDueEuros = Math.max(0, livePrice.finalPrice - creditEuros);
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setLoading(true);
@@ -267,6 +293,9 @@ function AdminCreateModal({ onClose, prefillData }: { onClose: () => void; prefi
         is_solidarity: form.is_solidarity,
         send_email: form.send_email,
         ...(form.useOverridePrice ? { override_price: form.overridePrice } : {}),
+        ...(form.use_credit && availableCredit != null && availableCredit > 0
+          ? { use_credit: true }
+          : {}),
       };
 
       if (form.appointment_mode === "video" && form.video_link.trim()) {
@@ -529,11 +558,37 @@ function AdminCreateModal({ onClose, prefillData }: { onClose: () => void; prefi
                 {livePrice.discount > 0 && (
                   <span className="text-mint-700"> · remise −{livePrice.discount}€</span>
                 )}
+                {creditEuros > 0 && (
+                  <span className="text-mint-700"> · avoir −{creditEuros.toFixed(2)}€</span>
+                )}
               </span>
               <span className="text-base font-semibold text-sage-900 font-sans">
-                À régler : {livePrice.finalPrice}€
+                À régler : {amountDueEuros.toFixed(2)}€
               </span>
             </div>
+
+            {/* Case « Utiliser l'avoir » — admin-only, visible si le patient a un avoir */}
+            {availableCredit != null && availableCredit > 0 && (
+              <label className="mt-3 flex items-center gap-3 cursor-pointer group border-t border-sage-200 pt-3">
+                <input
+                  type="checkbox"
+                  checked={form.use_credit}
+                  onChange={e => update("use_credit", e.target.checked)}
+                  className="h-4 w-4 rounded border-sage-300 text-mint-600 focus:ring-mint-400"
+                />
+                <span className="text-sm text-sage-700 font-sans group-hover:text-sage-900">
+                  Utiliser l'avoir disponible{" "}
+                  <span className="text-mint-700 font-medium">
+                    ({(availableCredit / 100).toFixed(2)}€)
+                  </span>
+                  {form.use_credit && amountDueEuros === 0 && (
+                    <span className="block text-xs text-mint-700 mt-0.5">
+                      Avoir suffisant : aucun paiement en ligne ne sera demandé.
+                    </span>
+                  )}
+                </span>
+              </label>
+            )}
           </div>
 
           {/* ── Options ── */}

--- a/src/components/admin/AppointmentCard.tsx
+++ b/src/components/admin/AppointmentCard.tsx
@@ -107,9 +107,11 @@ export function AppointmentCard({ appointment }: AppointmentCardProps) {
   const isReadOnly = status === 'declined' || status === 'cancelled';
   // Éligibilité à l'annulation / report (fenêtre veille incluse, Europe/Paris).
   const isCancellable = isCancellableByTherapist(appointment);
-  // Un RDV vidéo déjà payé se reporte par move direct admin (pas de re-facturation).
-  const isPaidVideoReschedule =
-    status === 'payment_received' && appointment.appointment_mode === 'video';
+  // Un RDV déjà arrimé (confirmed ∨ payment_received, tous modes) se reporte par
+  // move direct admin : la thérapeute déplace le créneau, paiement/avoir conservé,
+  // patient notifié. Pas de re-validation, pas de proposition.
+  const isDirectReschedule =
+    status === 'confirmed' || status === 'payment_received';
 
   // ── PATCH helper ─────────────────────────────────────────────────────────
 
@@ -162,9 +164,9 @@ export function AppointmentCard({ appointment }: AppointmentCardProps) {
       setActionError('Veuillez sélectionner un nouveau créneau.');
       return;
     }
-    // Pour un RDV vidéo déjà payé : move direct admin (paiement conservé).
-    // Pour les autres : flow de proposition au patient.
-    const action = isPaidVideoReschedule ? 'reschedule_paid' : 'reschedule';
+    // RDV déjà arrimé (confirmed/payment_received) : move direct admin.
+    // Sinon (pending/payment_pending) : flow de proposition au patient.
+    const action = isDirectReschedule ? 'reschedule_paid' : 'reschedule';
     await callPatch({
       action,
       rescheduled_to: new Date(rescheduleDate).toISOString(),
@@ -847,8 +849,8 @@ export function AppointmentCard({ appointment }: AppointmentCardProps) {
           }}
         >
           <p className="text-sm text-sage-600 font-sans mb-4">
-            {isPaidVideoReschedule
-              ? 'Le rendez-vous sera déplacé vers le nouveau créneau. Le paiement déjà effectué est conservé — aucun nouveau paiement ne sera demandé. Le patient sera notifié.'
+            {isDirectReschedule
+              ? 'Le rendez-vous sera déplacé vers le nouveau créneau. Le paiement déjà effectué (ou l\'avoir) est conservé — aucun nouveau paiement ne sera demandé. Le patient sera notifié.'
               : 'Le patient recevra un email avec le nouveau créneau proposé.'}
           </p>
           <div className="mb-4">

--- a/src/components/admin/AppointmentCard.tsx
+++ b/src/components/admin/AppointmentCard.tsx
@@ -1,13 +1,15 @@
 /**
  * AppointmentCard — React island pour la gestion d'un rendez-vous (back-office)
  *
- * Actions disponibles selon le statut :
- *   pending / rescheduled → Confirmer | Refuser | Reporter | Annuler
- *   payment_pending       → Voir lien paiement | Refuser | Annuler
- *   payment_received (vidéo payé) → Reporter (move direct) | Envoyer rappel avis | Annuler
- *   confirmed             → Envoyer rappel avis | Annuler
- *   declined / cancelled  → lecture seule
+ * Actions disponibles selon le statut (un seul conteneur, hiérarchie principale→dangereux) :
+ *   pending          → Confirmer · Reporter · Refuser
+ *   payment_pending  → Voir lien paiement · Refuser
+ *   confirmed/payé   → Envoyer rappel avis · Reporter · Annuler (+ avertissement avoir si payé)
+ *   rescheduled      → Annuler la proposition
+ *   declined / cancelled → lecture seule
  *
+ * Refuser (demande non payée) et Annuler (RDV confirmé/payé) sont mutuellement
+ * exclusifs par statut : ils n'apparaissent jamais simultanément.
  * Annuler / Reporter ne s'affichent que dans la fenêtre d'éligibilité (veille incluse).
  */
 
@@ -411,7 +413,10 @@ export function AppointmentCard({ appointment }: AppointmentCardProps) {
         </details>
       )}
 
-      {/* Boutons d'action */}
+      {/* Boutons d'action — un seul conteneur cohérent par statut.
+          Hiérarchie : action principale (plein) → secondaires (contour sage) →
+          destructive (contour rouge, à droite). Refuser et Annuler sont
+          mutuellement exclusifs par statut (jamais simultanés). */}
       {!isReadOnly && (
         <div className="flex flex-wrap gap-2 mb-4">
           {status === 'pending' && (
@@ -428,16 +433,6 @@ export function AppointmentCard({ appointment }: AppointmentCardProps) {
               </button>
               <button
                 onClick={() => {
-                  setModal('decline');
-                  setActionError(null);
-                }}
-                disabled={actionLoading}
-                className="inline-flex items-center px-4 py-2 text-sm font-medium font-sans rounded-xl border border-red-300 text-red-700 hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-300 focus:ring-offset-1 transition-colors disabled:opacity-60 disabled:cursor-not-allowed min-h-[40px]"
-              >
-                Refuser
-              </button>
-              <button
-                onClick={() => {
                   setModal('reschedule');
                   setActionError(null);
                 }}
@@ -445,6 +440,16 @@ export function AppointmentCard({ appointment }: AppointmentCardProps) {
                 className="inline-flex items-center px-4 py-2 text-sm font-medium font-sans rounded-xl border border-sage-300 text-sage-700 hover:bg-sage-50 focus:outline-none focus:ring-2 focus:ring-sage-300 focus:ring-offset-1 transition-colors disabled:opacity-60 disabled:cursor-not-allowed min-h-[40px]"
               >
                 Reporter
+              </button>
+              <button
+                onClick={() => {
+                  setModal('decline');
+                  setActionError(null);
+                }}
+                disabled={actionLoading}
+                className="inline-flex items-center px-4 py-2 text-sm font-medium font-sans rounded-xl border border-red-300 text-red-700 hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-300 focus:ring-offset-1 transition-colors disabled:opacity-60 disabled:cursor-not-allowed min-h-[40px]"
+              >
+                Refuser
               </button>
             </>
           )}
@@ -520,44 +525,47 @@ export function AppointmentCard({ appointment }: AppointmentCardProps) {
                   Email envoyé
                 </span>
               )}
+              {/* Reporter un RDV confirmé/payé : move direct admin (paiement conservé pour vidéo payé). */}
+              {isCancellable && (
+                <button
+                  onClick={() => {
+                    setModal('reschedule');
+                    setActionError(null);
+                  }}
+                  disabled={actionLoading}
+                  className="inline-flex items-center px-4 py-2 text-sm font-medium font-sans rounded-xl border border-sage-300 text-sage-700 hover:bg-sage-50 focus:outline-none focus:ring-2 focus:ring-sage-300 focus:ring-offset-1 transition-colors disabled:opacity-60 disabled:cursor-not-allowed min-h-[40px]"
+                >
+                  Reporter
+                </button>
+              )}
+              {/* Annuler un RDV confirmé/payé (exclusif avec Refuser qui n'apparaît qu'en pending/payment_pending). */}
+              {isCancellable && (
+                <button
+                  onClick={() => {
+                    setModal('cancel');
+                    setActionError(null);
+                  }}
+                  disabled={actionLoading}
+                  className="inline-flex items-center px-4 py-2 text-sm font-medium font-sans rounded-xl border border-red-300 text-red-700 hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-300 focus:ring-offset-1 transition-colors disabled:opacity-60 disabled:cursor-not-allowed min-h-[40px]"
+                >
+                  Annuler
+                </button>
+              )}
             </>
           )}
         </div>
       )}
 
-      {/* Action Annuler — visible pour tout RDV non-read-only dans la fenêtre d'éligibilité */}
-      {!isReadOnly && isCancellable && (
-        <div className="flex flex-wrap gap-2 mb-4">
-          {/* Reporter : pour un RDV payé/confirmé éligible (move direct admin pour vidéo payé). */}
-          {(status === 'confirmed' || status === 'payment_received') && (
-            <button
-              onClick={() => {
-                setModal('reschedule');
-                setActionError(null);
-              }}
-              disabled={actionLoading}
-              className="inline-flex items-center px-4 py-2 text-sm font-medium font-sans rounded-xl border border-sage-300 text-sage-700 hover:bg-sage-50 focus:outline-none focus:ring-2 focus:ring-sage-300 focus:ring-offset-1 transition-colors disabled:opacity-60 disabled:cursor-not-allowed min-h-[40px]"
-            >
-              Reporter
-            </button>
-          )}
-          <button
-            onClick={() => {
-              setModal('cancel');
-              setActionError(null);
-            }}
-            disabled={actionLoading}
-            className="inline-flex items-center px-4 py-2 text-sm font-medium font-sans rounded-xl border border-red-300 text-red-700 hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-300 focus:ring-offset-1 transition-colors disabled:opacity-60 disabled:cursor-not-allowed min-h-[40px]"
-          >
-            Annuler
-          </button>
-          {appointment.status === 'payment_received' && appointment.final_price - appointment.credit_applied > 0 && (
-            <span className="inline-flex items-center text-xs text-amber-700 font-sans self-center">
-              ⚠ Annulation : avoir de {Math.round((appointment.final_price - appointment.credit_applied) / 100)}€ émis pour le patient
-            </span>
-          )}
-        </div>
-      )}
+      {/* Avertissement avoir — attaché à l'action Annuler d'un RDV payé. */}
+      {isCancellable &&
+        status === 'payment_received' &&
+        appointment.final_price - appointment.credit_applied > 0 && (
+          <p className="mb-4 text-xs text-amber-700 font-sans">
+            L'annulation émettra un avoir de{' '}
+            {Math.round((appointment.final_price - appointment.credit_applied) / 100)}€
+            au profit du patient.
+          </p>
+        )}
 
       {/* Bouton régénération Calendar / Meet (vidéo uniquement, si event ou lien manquant) */}
       {appointment.appointment_mode === 'video' &&

--- a/src/components/admin/AppointmentCard.tsx
+++ b/src/components/admin/AppointmentCard.tsx
@@ -2,16 +2,19 @@
  * AppointmentCard — React island pour la gestion d'un rendez-vous (back-office)
  *
  * Actions disponibles selon le statut :
- *   pending / rescheduled → Confirmer | Refuser | Reporter
- *   payment_pending       → Voir lien paiement | Refuser
- *   confirmed             → Envoyer rappel avis
- *   payment_received      → Envoyer rappel avis
+ *   pending / rescheduled → Confirmer | Refuser | Reporter | Annuler
+ *   payment_pending       → Voir lien paiement | Refuser | Annuler
+ *   payment_received (vidéo payé) → Reporter (move direct) | Envoyer rappel avis | Annuler
+ *   confirmed             → Envoyer rappel avis | Annuler
  *   declined / cancelled  → lecture seule
+ *
+ * Annuler / Reporter ne s'affichent que dans la fenêtre d'éligibilité (veille incluse).
  */
 
 import { useState } from 'react';
 import { getModeLabel, getTypeLabel } from '../../lib/pricing';
 import type { Appointment, AppointmentStatus } from '../../types/appointment';
+import { isCancellableByTherapist } from '../../lib/appointment-eligibility';
 import { ConfirmModal } from './ConfirmModal';
 import { Modal } from './Modal';
 
@@ -23,7 +26,7 @@ interface AppointmentCardProps {
   appointment: Appointment;
 }
 
-type ModalType = 'confirm' | 'decline' | 'reschedule' | null;
+type ModalType = 'confirm' | 'decline' | 'cancel' | 'reschedule' | 'reschedule_paid' | null;
 
 // ---------------------------------------------------------------------------
 // Constantes statut
@@ -86,6 +89,7 @@ export function AppointmentCard({ appointment }: AppointmentCardProps) {
   // États formulaires modaux
   const [videoLink, setVideoLink] = useState(appointment.video_link ?? '');
   const [declineMessage, setDeclineMessage] = useState('');
+  const [cancelMessage, setCancelMessage] = useState('');
   const [rescheduleDate, setRescheduleDate] = useState('');
   const [rescheduleMessage, setRescheduleMessage] = useState('');
 
@@ -99,6 +103,11 @@ export function AppointmentCard({ appointment }: AppointmentCardProps) {
 
   const { status } = appointment;
   const isReadOnly = status === 'declined' || status === 'cancelled';
+  // Éligibilité à l'annulation / report (fenêtre veille incluse, Europe/Paris).
+  const isCancellable = isCancellableByTherapist(appointment);
+  // Un RDV vidéo déjà payé se reporte par move direct admin (pas de re-facturation).
+  const isPaidVideoReschedule =
+    status === 'payment_received' && appointment.appointment_mode === 'video';
 
   // ── PATCH helper ─────────────────────────────────────────────────────────
 
@@ -151,10 +160,20 @@ export function AppointmentCard({ appointment }: AppointmentCardProps) {
       setActionError('Veuillez sélectionner un nouveau créneau.');
       return;
     }
+    // Pour un RDV vidéo déjà payé : move direct admin (paiement conservé).
+    // Pour les autres : flow de proposition au patient.
+    const action = isPaidVideoReschedule ? 'reschedule_paid' : 'reschedule';
     await callPatch({
-      action: 'reschedule',
+      action,
       rescheduled_to: new Date(rescheduleDate).toISOString(),
       ...(rescheduleMessage ? { therapist_notes: rescheduleMessage } : {}),
+    });
+  }
+
+  async function handleCancel() {
+    await callPatch({
+      action: 'cancel',
+      ...(cancelMessage ? { therapist_notes: cancelMessage } : {}),
     });
   }
 
@@ -506,6 +525,40 @@ export function AppointmentCard({ appointment }: AppointmentCardProps) {
         </div>
       )}
 
+      {/* Action Annuler — visible pour tout RDV non-read-only dans la fenêtre d'éligibilité */}
+      {!isReadOnly && isCancellable && (
+        <div className="flex flex-wrap gap-2 mb-4">
+          {/* Reporter : pour un RDV payé/confirmé éligible (move direct admin pour vidéo payé). */}
+          {(status === 'confirmed' || status === 'payment_received') && (
+            <button
+              onClick={() => {
+                setModal('reschedule');
+                setActionError(null);
+              }}
+              disabled={actionLoading}
+              className="inline-flex items-center px-4 py-2 text-sm font-medium font-sans rounded-xl border border-sage-300 text-sage-700 hover:bg-sage-50 focus:outline-none focus:ring-2 focus:ring-sage-300 focus:ring-offset-1 transition-colors disabled:opacity-60 disabled:cursor-not-allowed min-h-[40px]"
+            >
+              Reporter
+            </button>
+          )}
+          <button
+            onClick={() => {
+              setModal('cancel');
+              setActionError(null);
+            }}
+            disabled={actionLoading}
+            className="inline-flex items-center px-4 py-2 text-sm font-medium font-sans rounded-xl border border-red-300 text-red-700 hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-300 focus:ring-offset-1 transition-colors disabled:opacity-60 disabled:cursor-not-allowed min-h-[40px]"
+          >
+            Annuler
+          </button>
+          {appointment.status === 'payment_received' && appointment.final_price - appointment.credit_applied > 0 && (
+            <span className="inline-flex items-center text-xs text-amber-700 font-sans self-center">
+              ⚠ Annulation : avoir de {Math.round((appointment.final_price - appointment.credit_applied) / 100)}€ émis pour le patient
+            </span>
+          )}
+        </div>
+      )}
+
       {/* Bouton régénération Calendar / Meet (vidéo uniquement, si event ou lien manquant) */}
       {appointment.appointment_mode === 'video' &&
         (!meetLink || !calendarEventId) &&
@@ -700,6 +753,76 @@ export function AppointmentCard({ appointment }: AppointmentCardProps) {
         </Modal>
       )}
 
+      {/* ── Modal : Annuler ───────────────────────────────────────────────── */}
+      {modal === 'cancel' && (
+        <Modal
+          title="Annuler le rendez-vous"
+          onClose={() => {
+            if (
+              cancelMessage.trim() &&
+              !window.confirm('Abandonner ? Votre message sera perdu.')
+            )
+              return;
+            setModal(null);
+          }}
+        >
+          <p className="text-sm text-sage-600 font-sans mb-4">
+            Le patient recevra un email d'annulation.
+            {appointment.status === 'payment_received' && appointment.final_price - appointment.credit_applied > 0 && (
+              <>
+                {' '}
+                <span className="text-amber-700 font-medium">
+                  Un avoir de {Math.round((appointment.final_price - appointment.credit_applied) / 100)}€ (montant payé) sera émis au profit du patient.
+                </span>
+              </>
+            )}
+          </p>
+          <div className="mb-5">
+            <label
+              htmlFor="cancel-msg-input"
+              className="block text-sm font-medium text-sage-700 font-sans mb-1.5"
+            >
+              Message pour le patient{' '}
+              <span className="text-sage-400 font-normal">(optionnel)</span>
+            </label>
+            <textarea
+              id="cancel-msg-input"
+              value={cancelMessage}
+              onChange={(e) => setCancelMessage(e.target.value)}
+              rows={3}
+              placeholder="Expliquez la raison de l'annulation…"
+              className="w-full px-4 py-2.5 rounded-xl border border-sage-200 bg-sage-50 text-sage-900 placeholder-sage-400 font-sans text-sm focus:outline-none focus:ring-2 focus:ring-mint-400 focus:border-transparent resize-none transition-colors"
+            />
+          </div>
+          {actionError && (
+            <p className="mb-4 text-sm text-red-700 font-sans">{actionError}</p>
+          )}
+          <div className="flex gap-2 justify-end">
+            <button
+              onClick={() => {
+                if (
+                  cancelMessage.trim() &&
+                  !window.confirm('Abandonner ? Votre message sera perdu.')
+                )
+                  return;
+                setModal(null);
+              }}
+              disabled={actionLoading}
+              className="px-4 py-2 text-sm font-medium font-sans rounded-xl border border-sage-300 text-sage-700 hover:bg-sage-50 transition-colors disabled:opacity-60 min-h-[40px]"
+            >
+              Fermer
+            </button>
+            <button
+              onClick={handleCancel}
+              disabled={actionLoading}
+              className="px-4 py-2 text-sm font-medium font-sans rounded-xl bg-red-600 text-white hover:bg-red-700 transition-colors disabled:opacity-60 min-h-[40px]"
+            >
+              {actionLoading ? 'En cours…' : 'Annuler le rendez-vous'}
+            </button>
+          </div>
+        </Modal>
+      )}
+
       {/* ── Modal : Reporter ──────────────────────────────────────────────── */}
       {modal === 'reschedule' && (
         <Modal
@@ -716,7 +839,9 @@ export function AppointmentCard({ appointment }: AppointmentCardProps) {
           }}
         >
           <p className="text-sm text-sage-600 font-sans mb-4">
-            Le patient recevra un email avec le nouveau créneau proposé.
+            {isPaidVideoReschedule
+              ? 'Le rendez-vous sera déplacé vers le nouveau créneau. Le paiement déjà effectué est conservé — aucun nouveau paiement ne sera demandé. Le patient sera notifié.'
+              : 'Le patient recevra un email avec le nouveau créneau proposé.'}
           </p>
           <div className="mb-4">
             <label

--- a/src/components/admin/AppointmentCard.tsx
+++ b/src/components/admin/AppointmentCard.tsx
@@ -14,7 +14,7 @@
 import { useState } from 'react';
 import { getModeLabel, getTypeLabel } from '../../lib/pricing';
 import type { Appointment, AppointmentStatus } from '../../types/appointment';
-import { isCancellableByTherapist } from '../../lib/appointment-eligibility';
+import { isCancellableByTherapist } from '../../utils/date';
 import { ConfirmModal } from './ConfirmModal';
 import { Modal } from './Modal';
 

--- a/src/emails/AppointmentCancelled.tsx
+++ b/src/emails/AppointmentCancelled.tsx
@@ -1,0 +1,157 @@
+/**
+ * Template — AppointmentCancelled
+ * Destinataire : Patient
+ * Sujet : "Votre rendez-vous a été annulé"
+ *
+ * Deux variantes :
+ *   - sans avoir : notification simple d'annulation.
+ *   - avec avoir  : mention explicite d'un AVOIR INTERNE (jamais le mot
+ *                   « remboursement »), valide en permanence, à utiliser en
+ *                   contactant la thérapeute (aucune UI patient pour les avoirs).
+ */
+
+import { Section, Text } from '@react-email/components';
+import { BaseLayout } from './BaseLayout';
+import {
+  COLORS,
+  S,
+  SectionDivider,
+  formatDateOnlyFR,
+  formatPrice,
+} from './_helpers';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface Props {
+  patientName: string;
+  scheduledAt: string;
+  /** Vrai si un avoir a été émis (annulation d'un RDV payé en cash). */
+  hasCredit: boolean;
+  /** Montant de l'avoir en centimes (affiché seulement si hasCredit). */
+  creditAmount?: number;
+  /** Mode de séance (pour rappel présentiel/téléconsultation). */
+  appointmentMode?: 'in-person' | 'video';
+  /** Message optionnel de la thérapeute. */
+  therapistNote?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Template
+// ---------------------------------------------------------------------------
+
+export default function AppointmentCancelled({
+  patientName,
+  scheduledAt,
+  hasCredit,
+  creditAmount,
+  appointmentMode,
+  therapistNote,
+}: Props) {
+  return (
+    <BaseLayout preview="Votre rendez-vous a été annulé — OMF Thérapie">
+
+      {/* Titre */}
+      <Text style={S.title}>Votre rendez-vous a été annulé</Text>
+
+      {/* Salutation */}
+      <Text style={S.body}>Bonjour {patientName},</Text>
+
+      <Text style={S.body}>
+        Votre rendez-vous prévu le{' '}
+        <strong>{formatDateOnlyFR(scheduledAt)}</strong>
+        {appointmentMode === 'video' ? ' (téléconsultation)' : ' (au cabinet)'}{' '}
+        a été annulé par Oriane.
+      </Text>
+
+      {/* Bloc AVOIR — formulation soigneuse, jamais « remboursement » */}
+      {hasCredit && creditAmount != null && creditAmount > 0 && (
+        <Section style={{
+          ...S.summaryBox,
+          backgroundColor: COLORS.mint50,
+          borderLeft: `4px solid ${COLORS.mint600}`,
+          borderRadius: '0 8px 8px 0',
+          padding: '16px 20px',
+          margin: '18px 0',
+        }}>
+          <Text style={{
+            fontFamily: 'Inter, Arial, sans-serif',
+            fontSize:   '13px',
+            fontWeight: '700',
+            color:      COLORS.mint600,
+            margin:     '0 0 8px',
+            textTransform: 'uppercase' as const,
+            letterSpacing: '0.06em',
+          }}>
+            Vous disposez d'un avoir
+          </Text>
+          <Text style={{
+            fontFamily: 'Inter, Arial, sans-serif',
+            fontSize:   '15px',
+            fontWeight: '600',
+            color:      COLORS.sage800,
+            margin:     '0 0 8px',
+          }}>
+            Montant : {formatPrice(creditAmount)}
+          </Text>
+          <Text style={{
+            fontFamily: 'Inter, Arial, sans-serif',
+            fontSize:   '14px',
+            color:      COLORS.sage800,
+            margin:     '0',
+            lineHeight: '1.7',
+          }}>
+            Cet avoir est rattaché à votre compte et{' '}
+            <strong>valide en permanence</strong>. Pour l'utiliser lors d'un
+            prochain rendez-vous, contactez Oriane qui se chargera de
+            l'appliquer sur votre nouvelle séance.
+          </Text>
+        </Section>
+      )}
+
+      {/* Message personnalisé */}
+      {therapistNote && (
+        <Section style={{
+          ...S.summaryBox,
+          backgroundColor: COLORS.white,
+          borderLeft: `4px solid ${COLORS.sage600}`,
+          borderRadius: '0 8px 8px 0',
+          padding: '16px 20px',
+          margin: '18px 0',
+        }}>
+          <Text style={{
+            fontFamily: 'Inter, Arial, sans-serif',
+            fontSize:   '13px',
+            fontWeight: '600',
+            color:      COLORS.sage600,
+            margin:     '0 0 8px',
+            textTransform: 'uppercase' as const,
+            letterSpacing: '0.06em',
+          }}>
+            Message d'Oriane
+          </Text>
+          <Text style={{
+            fontFamily: 'Inter, Arial, sans-serif',
+            fontSize:   '14px',
+            color:      COLORS.sage800,
+            margin:     '0',
+            lineHeight: '1.7',
+            fontStyle:  'italic',
+          }}>
+            "{therapistNote}"
+          </Text>
+        </Section>
+      )}
+
+      <SectionDivider />
+
+      <Text style={{ ...S.body, color: COLORS.sage600, fontStyle: 'italic', marginTop: '20px' }}>
+        Cordialement,
+        <br />
+        Oriane Montabonnet — OMF Thérapie
+      </Text>
+
+    </BaseLayout>
+  );
+}

--- a/src/emails/AppointmentRescheduledPaid.tsx
+++ b/src/emails/AppointmentRescheduledPaid.tsx
@@ -1,0 +1,116 @@
+/**
+ * Template — AppointmentRescheduledPaid
+ * Destinataire : Patient
+ * Sujet : "Votre rendez-vous a été reporté"
+ *
+ * Notification simple d'un report effectué par la thérapeute sur une
+ * téléconsultation DÉJÀ PAYÉE. À ne pas confondre avec `AppointmentRescheduled`
+ * (proposition demandant acceptation + nouveau paiement). Ici : pas de bouton
+ * d'acceptation, pas de demande de paiement — le paiement est conservé.
+ */
+
+import { Section, Text } from '@react-email/components';
+import { BaseLayout } from './BaseLayout';
+import {
+  COLORS,
+  S,
+  SectionDivider,
+  formatDateFR,
+} from './_helpers';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface Props {
+  patientName: string;
+  originalScheduledAt: string;
+  newScheduledAt: string;
+  appointmentMode: 'in-person' | 'video';
+  duration: number;
+  finalPrice: number; // centimes
+  therapistNote?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Template
+// ---------------------------------------------------------------------------
+
+export default function AppointmentRescheduledPaid({
+  patientName,
+  originalScheduledAt,
+  newScheduledAt,
+  appointmentMode,
+  duration,
+  // finalPrice est conservé dans l'interface pour cohérence avec les autres
+  // templates mais n'est pas affiché ici (le paiement est conservé, pas redemandé).
+  finalPrice: _finalPrice,
+  therapistNote,
+}: Props) {
+  return (
+    <BaseLayout preview="Votre rendez-vous a été reporté — OMF Thérapie">
+
+      {/* Titre */}
+      <Text style={S.title}>Votre rendez-vous a été reporté</Text>
+
+      {/* Salutation */}
+      <Text style={S.body}>Bonjour {patientName},</Text>
+
+      <Text style={S.body}>
+        Votre rendez-vous {appointmentMode === 'video' ? 'en téléconsultation' : 'au cabinet'}{' '}
+        initialement prévu le{' '}
+        <strong>{formatDateFR(originalScheduledAt)}</strong> a été reporté au{' '}
+        <strong>{formatDateFR(newScheduledAt)}</strong> ({duration} min).
+      </Text>
+
+      <Text style={S.body}>
+        Bonne nouvelle : votre paiement est{' '}
+        <strong>conservé et reste valable</strong> pour ce nouveau créneau.
+        Aucune action n'est attendue de votre part.
+      </Text>
+
+      {/* Message personnalisé */}
+      {therapistNote && (
+        <Section style={{
+          ...S.summaryBox,
+          backgroundColor: COLORS.white,
+          borderLeft: `4px solid ${COLORS.sage600}`,
+          borderRadius: '0 8px 8px 0',
+          padding: '16px 20px',
+          margin: '18px 0',
+        }}>
+          <Text style={{
+            fontFamily: 'Inter, Arial, sans-serif',
+            fontSize:   '13px',
+            fontWeight: '600',
+            color:      COLORS.sage600,
+            margin:     '0 0 8px',
+            textTransform: 'uppercase' as const,
+            letterSpacing: '0.06em',
+          }}>
+            Message d'Oriane
+          </Text>
+          <Text style={{
+            fontFamily: 'Inter, Arial, sans-serif',
+            fontSize:   '14px',
+            color:      COLORS.sage800,
+            margin:     '0',
+            lineHeight: '1.7',
+            fontStyle:  'italic',
+          }}>
+            "{therapistNote}"
+          </Text>
+        </Section>
+      )}
+
+      <SectionDivider />
+
+      <Text style={{ ...S.body, color: COLORS.sage600, fontStyle: 'italic', marginTop: '20px' }}>
+        Cordialement,
+        <br />
+        Oriane Montabonnet — OMF Thérapie
+      </Text>
+
+    </BaseLayout>
+  );
+}

--- a/src/emails/AppointmentRescheduledPaid.tsx
+++ b/src/emails/AppointmentRescheduledPaid.tsx
@@ -3,10 +3,10 @@
  * Destinataire : Patient
  * Sujet : "Votre rendez-vous a été reporté"
  *
- * Notification simple d'un report effectué par la thérapeute sur une
- * téléconsultation DÉJÀ PAYÉE. À ne pas confondre avec `AppointmentRescheduled`
- * (proposition demandant acceptation + nouveau paiement). Ici : pas de bouton
- * d'acceptation, pas de demande de paiement — le paiement est conservé.
+ * Notification simple d'un report effectué par la thérapeute sur un RDV déjà
+ * arrimé (confirmed ∨ payment_received, tous modes). À ne pas confondre avec
+ * `AppointmentRescheduled` (proposition demandant acceptation, flow patient).
+ * Ici : move direct admin, pas de bouton d'acceptation, paiement/avoir conservé.
  */
 
 import { Section, Text } from '@react-email/components';

--- a/src/lib/appointment-eligibility.ts
+++ b/src/lib/appointment-eligibility.ts
@@ -8,7 +8,8 @@
  */
 import type { Period } from '@/types/manual-slots';
 import { fetchManualSlots } from './manual-slots.js';
-import { getParisISOWeekday, toParisDateString } from '../utils/date.js';
+import { getParisISOWeekday, toParisDateString, startOfYesterdayParis } from '../utils/date.js';
+import type { AppointmentStatus } from '../types/appointment';
 
 // ---------------------------------------------------------------------------
 // Demi-journées ouvrées (heure locale Paris)
@@ -104,4 +105,32 @@ export async function isCabinetEligibleSlot(isoDate: string): Promise<boolean> {
   const isWednesday = getParisISOWeekday(new Date(isoDate)) === 3;
   const manualPeriods = await fetchManualPeriodsForDate(isoDate);
   return cabinetEligibility(isWednesday, manualPeriods)[dayHalfFor(isoDate)];
+}
+
+// ---------------------------------------------------------------------------
+// Éligibilité à l'annulation / report par la thérapeute
+// ---------------------------------------------------------------------------
+
+/**
+ * Statuts à partir desquels un RDV ne peut plus être annulé ni reporté
+ * (déjà refusé, déjà annulé).
+ */
+const TERMINAL_STATUSES: ReadonlySet<AppointmentStatus> = new Set(['declined', 'cancelled']);
+
+/**
+ * Un rendez-vous peut-il être annulé ou reporté par la thérapeute ?
+ *
+ * Règle : le RDV doit être dans un statut non-terminal (≠ declined/cancelled)
+ * ET sa date prévue doit être >= début de la veille (Europe/Paris). Cette fenêtre
+ * inclut volontairement la veille : la thérapeute doit pouvoir annuler un RDV
+ * de dernière minute qu'elle n'a pas eu le temps de traiter le jour même.
+ *
+ * Prédicat pur, partagé client/serveur (aucun effet de bord, aucun I/O).
+ */
+export function isCancellableByTherapist(appt: {
+  scheduled_at: string;
+  status: AppointmentStatus;
+}): boolean {
+  if (TERMINAL_STATUSES.has(appt.status)) return false;
+  return new Date(appt.scheduled_at).getTime() >= startOfYesterdayParis().getTime();
 }

--- a/src/lib/appointment-eligibility.ts
+++ b/src/lib/appointment-eligibility.ts
@@ -8,8 +8,12 @@
  */
 import type { Period } from '@/types/manual-slots';
 import { fetchManualSlots } from './manual-slots.js';
-import { getParisISOWeekday, toParisDateString, startOfYesterdayParis } from '../utils/date.js';
-import type { AppointmentStatus } from '../types/appointment';
+import { getParisISOWeekday, toParisDateString } from '../utils/date.js';
+
+// Re-export pour compatibilité des importations serveur existantes.
+// `isCancellableByTherapist` est défini dans `utils/date.ts` (module pur sans I/O)
+// pour rester bundlable côté client — voir la note dans `date.ts`.
+export { isCancellableByTherapist } from '../utils/date.js';
 
 // ---------------------------------------------------------------------------
 // Demi-journées ouvrées (heure locale Paris)
@@ -105,32 +109,4 @@ export async function isCabinetEligibleSlot(isoDate: string): Promise<boolean> {
   const isWednesday = getParisISOWeekday(new Date(isoDate)) === 3;
   const manualPeriods = await fetchManualPeriodsForDate(isoDate);
   return cabinetEligibility(isWednesday, manualPeriods)[dayHalfFor(isoDate)];
-}
-
-// ---------------------------------------------------------------------------
-// Éligibilité à l'annulation / report par la thérapeute
-// ---------------------------------------------------------------------------
-
-/**
- * Statuts à partir desquels un RDV ne peut plus être annulé ni reporté
- * (déjà refusé, déjà annulé).
- */
-const TERMINAL_STATUSES: ReadonlySet<AppointmentStatus> = new Set(['declined', 'cancelled']);
-
-/**
- * Un rendez-vous peut-il être annulé ou reporté par la thérapeute ?
- *
- * Règle : le RDV doit être dans un statut non-terminal (≠ declined/cancelled)
- * ET sa date prévue doit être >= début de la veille (Europe/Paris). Cette fenêtre
- * inclut volontairement la veille : la thérapeute doit pouvoir annuler un RDV
- * de dernière minute qu'elle n'a pas eu le temps de traiter le jour même.
- *
- * Prédicat pur, partagé client/serveur (aucun effet de bord, aucun I/O).
- */
-export function isCancellableByTherapist(appt: {
-  scheduled_at: string;
-  status: AppointmentStatus;
-}): boolean {
-  if (TERMINAL_STATUSES.has(appt.status)) return false;
-  return new Date(appt.scheduled_at).getTime() >= startOfYesterdayParis().getTime();
 }

--- a/src/lib/credits.ts
+++ b/src/lib/credits.ts
@@ -1,0 +1,185 @@
+/**
+ * credits.ts — gestion de l'avoir interne (ledger) — OMF Thérapie
+ *
+ * Source unique de vérité pour la lecture, l'émission, la consommation et la
+ * restitution des avoirs. Aucune autre couche ne doit écrire directement dans
+ * `credits` / `credit_usages` : les handlers API passent par ce module.
+ *
+ * Montants en centimes (cohérent avec `appointments.final_price`).
+ *
+ * Concurrency : la consommation FIFO est atomique via la RPC Postgres
+ * `consume_credits` (SECURITY DEFINER) ; la restitution via `restore_credits`.
+ * L'émission et la lecture sont en JS pur (pas de concurrency critique côté
+ * émetteur — l'idempotence est garantie par l'index UNIQUE(source_appointment_id)).
+ */
+
+import { supabaseAdmin } from './supabase';
+import type { Appointment } from '../types/appointment';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CreditRow {
+  id: string;
+  patient_email: string;
+  source_appointment_id: string | null;
+  amount: number;
+  remaining: number;
+  reason: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreditUsage {
+  credit_id: string;
+  amount: number;
+}
+
+export interface CreditBalance {
+  balance: number;
+  history: CreditRow[];
+}
+
+// ---------------------------------------------------------------------------
+// Lecture
+// ---------------------------------------------------------------------------
+
+/**
+ * Solde d'avoir disponible (centimes) pour un patient, via son email.
+ * Normalisation : lowercase (cohérent avec l'insertion des appointments).
+ */
+export async function getAvailableCredit(patientEmail: string): Promise<number> {
+  const { data, error } = await supabaseAdmin
+    .from('credits')
+    .select('remaining')
+    .eq('patient_email', patientEmail.toLowerCase())
+    .gt('remaining', 0);
+
+  if (error) {
+    console.error('[credits] getAvailableCredit error:', error);
+    return 0;
+  }
+  return (data ?? []).reduce((sum, r) => sum + (r.remaining as number), 0);
+}
+
+/**
+ * Solde + historique complet d'un patient (pour la page admin / affichage).
+ */
+export async function getCreditBalance(patientEmail: string): Promise<CreditBalance> {
+  const { data, error } = await supabaseAdmin
+    .from('credits')
+    .select('*')
+    .eq('patient_email', patientEmail.toLowerCase())
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    console.error('[credits] getCreditBalance error:', error);
+    return { balance: 0, history: [] };
+  }
+  const history = (data ?? []) as unknown as CreditRow[];
+  const balance = history.reduce((sum, c) => sum + c.remaining, 0);
+  return { balance, history };
+}
+
+// ---------------------------------------------------------------------------
+// Émission (annulation d'un RDV payé)
+// ---------------------------------------------------------------------------
+
+/**
+ * Émet un avoir pour l'annulation d'un RDV.
+ *
+ * Idempotent : si un avoir existe déjà pour ce RDV source (index UNIQUE),
+ * l'insertion est ignorée et l'avoir existant est retourné. Permet de tolérer
+ * un re-clic sur « Annuler » ou une retry.
+ *
+ * @param appt       RDV annulé (doit être `payment_received`).
+ * @param amountCash Cash réellement encaissé via Stripe = final_price − credit_applied.
+ *                   Doit être > 0 (l'appelant ne doit pas appeler si 0).
+ */
+export async function issueCreditForCancellation(
+  appt: Pick<Appointment, 'id' | 'patient_email' | 'final_price' | 'credit_applied'>,
+  amountCash: number,
+): Promise<CreditRow | null> {
+  if (amountCash <= 0) return null;
+
+  const { data, error } = await supabaseAdmin
+    .from('credits')
+    .insert({
+      patient_email: appt.patient_email.toLowerCase(),
+      source_appointment_id: appt.id,
+      amount: amountCash,
+      remaining: amountCash,
+      reason: 'cancellation',
+    })
+    .select()
+    .single();
+
+  if (error) {
+    // 23505 = unique_violation → avoir déjà émis pour ce RDV (idempotence).
+    // On retourne l'avoir existant plutôt qu'une erreur.
+    if (error.code === '23505') {
+      const { data: existing } = await supabaseAdmin
+        .from('credits')
+        .select('*')
+        .eq('source_appointment_id', appt.id)
+        .maybeSingle();
+      return (existing as unknown as CreditRow) ?? null;
+    }
+    console.error('[credits] issueCreditForCancellation error:', error);
+    throw new Error(`Erreur émission avoir: ${error.message}`);
+  }
+  return data as unknown as CreditRow;
+}
+
+// ---------------------------------------------------------------------------
+// Consommation (création manuelle avec avoir) — RPC atomique FIFO
+// ---------------------------------------------------------------------------
+
+/**
+ * Consomme `amount` centimes d'avoir pour un RDV, en FIFO (avoirs les plus
+ * anciens d'abord). Atomicité garantie par la RPC Postgres `consume_credits`.
+ *
+ * @returns les tranches consommées (audit). Lève en cas d'avoir insuffisant
+ *          (la RPC RAISE CREDIT_INSUFFICIENT → remontée comme erreur).
+ */
+export async function consumeCredits(
+  patientEmail: string,
+  amount: number,
+  appointmentId: string,
+): Promise<CreditUsage[]> {
+  if (amount <= 0) return [];
+
+  const { data, error } = await supabaseAdmin.rpc('consume_credits', {
+    p_email: patientEmail.toLowerCase(),
+    p_amount: amount,
+    p_appointment_id: appointmentId,
+  });
+
+  if (error) {
+    console.error('[credits] consumeCredits error:', error);
+    throw new Error(`Erreur consommation avoir: ${error.message}`);
+  }
+  return (data ?? []) as unknown as CreditUsage[];
+}
+
+// ---------------------------------------------------------------------------
+// Restitution (annulation d'un RDV qui avait consommé un avoir)
+// ---------------------------------------------------------------------------
+
+/**
+ * Restitue l'avoir consommé par un RDV (restaure les `remaining` sources et
+ * supprime les `credit_usages`). Idempotent (no-op si déjà restitué).
+ *
+ * À appeler systématiquement quand on annule un RDV avec `credit_applied > 0`,
+ * AVANT l'éventuelle émission d'un nouvel avoir.
+ */
+export async function restoreCredits(appointmentId: string): Promise<void> {
+  const { error } = await supabaseAdmin.rpc('restore_credits', {
+    p_appointment_id: appointmentId,
+  });
+  if (error) {
+    console.error('[credits] restoreCredits error:', error);
+    throw new Error(`Erreur restitution avoir: ${error.message}`);
+  }
+}

--- a/src/pages/api/admin/appointments/index.ts
+++ b/src/pages/api/admin/appointments/index.ts
@@ -6,6 +6,7 @@ import { auth } from '../../../../lib/auth';
 import { isAdminSession } from '../../../../lib/authz';
 import { supabaseAdmin } from '../../../../lib/supabase';
 import { calculatePrice } from '../../../../lib/pricing';
+import { getAvailableCredit, consumeCredits } from '../../../../lib/credits';
 import { sendEmail, buildAppointmentConversationSubject } from '../../../../lib/resend';
 import { createAppointmentPaymentLink } from '../../../../lib/stripe';
 import { generateGoogleCalendarLink, generateOutlookCalendarLink, generateAppleCalendarInviteLink, CABINET_ADDRESS } from '../../../../lib/ics';
@@ -71,6 +72,7 @@ export const POST: APIRoute = async ({ request }) => {
     send_email: shouldSendEmail = true,
     video_link,
     override_price,
+    use_credit,
   } = body;
 
   // 3. Validation
@@ -161,13 +163,32 @@ export const POST: APIRoute = async ({ request }) => {
     override_price !== undefined ? Number(override_price) : undefined,
   );
 
-  // 5. Statut initial
-  // in-person → confirmed directement (pas de paiement requis)
-  // video → payment_pending (lien Stripe envoyé si shouldSendEmail)
+  // 5. Avoir (avoir interne) — déduction admin-only
+  // ----------------------------------------------------------------
+  // Si l'admin coche « utiliser l'avoir » et qu'un avoir est disponible pour
+  // cet email, on consomme en FIFO le montant plafonné à final_price.
+  // montant dû = final_price - credit_applied. Si 0 → pas de paiement Stripe,
+  // statut payment_received (video) / confirmed (in-person).
   const isVideo = appointment_mode === 'video';
-  const initialStatus = isVideo ? 'payment_pending' : 'confirmed';
+  const finalPriceCents = pricing.finalPrice * 100;
+  let creditApplied = 0;
 
-  // 6. Insertion en base
+  if (use_credit === true) {
+    const balance = await getAvailableCredit((patient_email as string).toLowerCase());
+    if (balance > 0) {
+      creditApplied = Math.min(balance, finalPriceCents);
+    }
+  }
+  const amountDueCents = Math.max(0, finalPriceCents - creditApplied);
+
+  // 6. Statut initial
+  // in-person → confirmed directement (jamais de paiement en ligne)
+  // video → payment_pending (lien Stripe) SAUF si montant dû = 0 → payment_received
+  const initialStatus: string = isVideo
+    ? (amountDueCents === 0 ? 'payment_received' : 'payment_pending')
+    : 'confirmed';
+
+  // 7. Insertion en base
   const { data: appointment, error: dbError } = await supabaseAdmin
     .from('appointments')
     .insert({
@@ -185,7 +206,8 @@ export const POST: APIRoute = async ({ request }) => {
       status: initialStatus,
       base_price: pricing.basePrice * 100,
       discount: pricing.discount * 100,
-      final_price: pricing.finalPrice * 100,
+      final_price: finalPriceCents,
+      credit_applied: creditApplied,
       video_link: isVideo ? (video_link ?? null) : null,
     })
     .select()
@@ -194,6 +216,22 @@ export const POST: APIRoute = async ({ request }) => {
   if (dbError || !appointment) {
     console.error('[admin/appointments] DB insert error:', dbError);
     return errorResponse(500, 'Erreur lors de la création du rendez-vous');
+  }
+
+  // 8. Consommer l'avoir (atomique, FIFO) — après l'insert (besoin de l'id).
+  if (creditApplied > 0) {
+    try {
+      await consumeCredits(
+        (patient_email as string).toLowerCase(),
+        creditApplied,
+        appointment.id,
+      );
+    } catch (creditErr) {
+      // Échec consommation : on annule le RDV (cohérence — pas de credit_applied sans usage).
+      console.error('[admin/appointments] Erreur consommation avoir:', creditErr);
+      await supabaseAdmin.from('appointments').delete().eq('id', appointment.id);
+      return errorResponse(409, 'Avoir insuffisant ou erreur lors de la consommation de l\'avoir.');
+    }
   }
 
   await invalidateAvailabilityCache().catch(console.error);
@@ -231,19 +269,23 @@ export const POST: APIRoute = async ({ request }) => {
     }
   }
 
-  // 7. Envoi email
+  // 9. Paiement Stripe + envoi email
+  // ----------------------------------------------------------------
+  // Video + montant dû > 0  → lien Stripe pour le SOLDE (final_price - credit_applied).
+  // Video + montant dû = 0  → aucun Stripe (avoir couvre tout), confirmation directe.
+  // In-person               → confirmation directe (jamais de paiement en ligne).
   if (shouldSendEmail) {
     const origin = new URL(request.url).origin;
     const successUrl = import.meta.env.STRIPE_SUCCESS_URL ?? `${origin}/rdv/merci/?source=payment-success`;
 
-    if (isVideo) {
-      // Créer le lien Stripe et envoyer une demande de paiement
+    if (isVideo && amountDueCents > 0) {
+      // Créer le lien Stripe (pour le solde dû) et envoyer une demande de paiement
       try {
         const paymentLink = await createAppointmentPaymentLink({
           appointmentId: appointment.id,
           patientEmail: appointment.patient_email,
           patientName: appointment.patient_name,
-          amount: appointment.final_price,
+          amount: amountDueCents,
           description: `Séance de thérapie — ${new Date(appointment.scheduled_at).toLocaleDateString('fr-FR')}`,
           successUrl,
         });
@@ -265,7 +307,7 @@ export const POST: APIRoute = async ({ request }) => {
             scheduledAt: appointment.scheduled_at,
             appointmentType: appointment.appointment_type,
             duration: appointment.duration,
-            finalPrice: appointment.final_price,
+            finalPrice: amountDueCents,
             stripePaymentUrl: paymentLink.url,
           }),
         });
@@ -275,8 +317,58 @@ export const POST: APIRoute = async ({ request }) => {
       } catch (e) {
         console.error('[admin/appointments] Stripe error (non-bloquant):', e);
       }
+    } else if (isVideo && amountDueCents === 0) {
+      // Avoir couvre l'intégralité : envoyer une confirmation (séance réglée par avoir).
+      try {
+        const start = new Date(appointment.scheduled_at);
+        const end = new Date(start.getTime() + appointment.duration * 60 * 1000);
+        const calendarEvent = {
+          uid: appointment.id,
+          summary: 'Séance de thérapie — OMF Therapie',
+          description: `Patient: ${appointment.patient_name}\nMode: Téléconsultation`,
+          location: resolvedVideoLink ?? undefined,
+          url: resolvedVideoLink ?? undefined,
+          start,
+          end,
+          organizerName: 'Oriane Montabonnet — OMF Thérapie',
+          organizerEmail: import.meta.env.RESEND_FROM_EMAIL ?? 'contact@omf-therapie.fr',
+        };
+        const gcalLink = generateGoogleCalendarLink(calendarEvent);
+        const outlookLink = generateOutlookCalendarLink(calendarEvent);
+        const baseUrl = import.meta.env.BETTER_AUTH_URL ?? new URL(request.url).origin;
+        const inviteToken = createSecureLinkToken({
+          appointmentId: appointment.id,
+          purpose: 'ics-invite',
+          expiresInSeconds: 60 * 60 * 24 * 180,
+          nonce: appointment.scheduled_at,
+        });
+        const appleLink = generateAppleCalendarInviteLink(baseUrl, appointment.id, inviteToken);
+
+        await sendEmail({
+          to: appointment.patient_email,
+          threadKey: `appointment:${appointment.id}:patient`,
+          subject: buildAppointmentConversationSubject(
+            `Votre rendez-vous est confirmé — ${new Date(appointment.scheduled_at).toLocaleDateString('fr-FR')}`,
+            appointment.id,
+          ),
+          react: createElement(AppointmentConfirmed, {
+            patientName: appointment.patient_name,
+            appointmentType: appointment.appointment_type,
+            appointmentMode: appointment.appointment_mode,
+            scheduledAt: appointment.scheduled_at,
+            duration: appointment.duration,
+            finalPrice: appointment.final_price,
+            videoLink: resolvedVideoLink,
+            googleCalendarLink: gcalLink,
+            appleCalendarLink: appleLink,
+            outlookCalendarLink: outlookLink,
+          }),
+        });
+      } catch (e) {
+        console.error('[admin/appointments] email confirmation (avoir) error (non-bloquant):', e);
+      }
     } else {
-      // Confirmer directement et envoyer l'email de confirmation
+      // In-person : confirmer directement et envoyer l'email de confirmation
       const start = new Date(appointment.scheduled_at);
       const end = new Date(start.getTime() + appointment.duration * 60 * 1000);
       const calendarEvent = {

--- a/src/pages/api/admin/credits.ts
+++ b/src/pages/api/admin/credits.ts
@@ -1,0 +1,44 @@
+export const prerender = false;
+
+import type { APIRoute } from 'astro';
+import { auth } from '../../../lib/auth';
+import { isAdminSession } from '../../../lib/authz';
+import { getCreditBalance } from '../../../lib/credits';
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function errorResponse(status: number, message: string): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+/**
+ * GET /api/admin/credits?email=...
+ *
+ * Retourne le solde d'avoir (centimes) et l'historique des avoirs d'un patient
+ * (identifié par son email, normalisé en lowercase). Admin-only.
+ *
+ * Sert :
+ *   - à la case « Utiliser l'avoir » du formulaire de création manuelle
+ *     (AdminCreateButton) pour afficher le montant disponible ;
+ *   - (future) au badge d'avoir sur la page Patients.
+ */
+export const GET: APIRoute = async ({ request, url }) => {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session?.user) return errorResponse(401, 'Non authentifié');
+  if (!isAdminSession(session)) return errorResponse(403, 'Accès refusé');
+
+  const emailParam = url.searchParams.get('email');
+  if (!emailParam || !EMAIL_RE.test(emailParam)) {
+    return errorResponse(400, 'Email invalide');
+  }
+
+  const { balance, history } = await getCreditBalance(emailParam.toLowerCase());
+
+  return new Response(
+    JSON.stringify({ balance, history }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  );
+};

--- a/src/pages/api/appointments/[id].ts
+++ b/src/pages/api/appointments/[id].ts
@@ -12,7 +12,6 @@ import { getTypeLabel, getModeLabel, calculatePrice } from '../../../lib/pricing
 import { stripe, createAppointmentPaymentLink } from '../../../lib/stripe';
 import { createCalendarEvent, updateCalendarEvent, deleteCalendarEvent } from '../../../lib/google-calendar';
 import { hasAppointmentConflict } from '../../../lib/appointment-conflicts';
-import { isWithinBusinessHours } from '../../../utils/date';
 import { isCabinetEligibleSlot } from '../../../lib/appointment-eligibility';
 import { invalidateAvailabilityCache } from '../../../lib/calendar-cache.js';
 import AppointmentConfirmed from '../../../emails/AppointmentConfirmed';
@@ -508,8 +507,8 @@ export const PATCH: APIRoute = async ({ request, params }) => {
     if (newDate.getTime() < Date.now())
       return errorResponse(422, 'Le nouveau créneau doit être dans le futur');
 
-    if (!isWithinBusinessHours(rescheduled_to as string, appointment.duration))
-      return errorResponse(422, 'Le créneau doit être dans les plages horaires (8h-12h ou 14h-19h).');
+    // Pas de garde isWithinBusinessHours : action thérapeute, même flexibilité
+    // que la création manuelle admin. (Vidéo = pas de contrainte cabinet non plus.)
 
     try {
       const slotEnd = new Date(newDate.getTime() + appointment.duration * 60 * 1000);
@@ -621,8 +620,9 @@ export const PATCH: APIRoute = async ({ request, params }) => {
     if (appointment.appointment_mode === 'in-person' && !(await isCabinetEligibleSlot(rescheduled_to as string)))
       return errorResponse(422, 'Les rendez-vous en présentiel ne sont pas disponibles sur ce créneau.');
 
-    if (!isWithinBusinessHours(rescheduled_to as string, appointment.duration))
-      return errorResponse(422, 'Le créneau doit être dans les plages horaires (8h-12h ou 14h-19h).');
+    // Note : pas de garde isWithinBusinessHours ici (contrairement aux flux patient).
+    // La thérapeute propose un créneau — elle connaît son agenda et peut reporter
+    // hors des plages affichées (ex. urgence). Cohérent avec la création manuelle admin.
 
     try {
       const slotEnd = new Date(newDate.getTime() + appointment.duration * 60 * 1000);

--- a/src/pages/api/appointments/[id].ts
+++ b/src/pages/api/appointments/[id].ts
@@ -493,8 +493,11 @@ export const PATCH: APIRoute = async ({ request, params }) => {
   // Conditions : vidéo + payment_received + éligible (fenêtre veille).
   // ---------------------------------------------------------------------------
   if (action === 'reschedule_paid') {
-    if (appointment.appointment_mode !== 'video' || appointment.status !== 'payment_received')
-      return errorResponse(409, 'Le report direct ne s\'applique qu\'aux téléconsultations déjà payées.');
+    // Move direct admin : tout RDV déjà arrimé (confirmed ∨ payment_received),
+    // tous modes confondus. La thérapeute déplace le créneau, le paiement/avoir
+    // est conservé, le patient est notifié (pas de re-validation).
+    if (appointment.status !== 'confirmed' && appointment.status !== 'payment_received')
+      return errorResponse(409, 'Le report direct ne s\'applique qu\'aux rendez-vous déjà confirmés.');
     if (!isCancellableByTherapist(appointment))
       return errorResponse(409, 'Ce rendez-vous ne peut pas être reporté (hors fenêtre).');
 
@@ -507,8 +510,11 @@ export const PATCH: APIRoute = async ({ request, params }) => {
     if (newDate.getTime() < Date.now())
       return errorResponse(422, 'Le nouveau créneau doit être dans le futur');
 
+    // Présentiel : contrainte cabinet (mercredi), cohérent avec la création admin.
     // Pas de garde isWithinBusinessHours : action thérapeute, même flexibilité
-    // que la création manuelle admin. (Vidéo = pas de contrainte cabinet non plus.)
+    // que la création manuelle admin.
+    if (appointment.appointment_mode === 'in-person' && !(await isCabinetEligibleSlot(rescheduled_to as string)))
+      return errorResponse(422, 'Les rendez-vous en présentiel ne sont pas disponibles sur ce créneau.');
 
     try {
       const slotEnd = new Date(newDate.getTime() + appointment.duration * 60 * 1000);

--- a/src/pages/api/appointments/[id].ts
+++ b/src/pages/api/appointments/[id].ts
@@ -18,8 +18,12 @@ import { invalidateAvailabilityCache } from '../../../lib/calendar-cache.js';
 import AppointmentConfirmed from '../../../emails/AppointmentConfirmed';
 import AppointmentDeclined from '../../../emails/AppointmentDeclined';
 import AppointmentRescheduled from '../../../emails/AppointmentRescheduled';
+import AppointmentRescheduledPaid from '../../../emails/AppointmentRescheduledPaid';
+import AppointmentCancelled from '../../../emails/AppointmentCancelled';
 import PaymentRequest from '../../../emails/PaymentRequest';
 import type { Appointment } from '../../../types/appointment';
+import { issueCreditForCancellation, restoreCredits } from '../../../lib/credits';
+import { isCancellableByTherapist } from '../../../lib/appointment-eligibility';
 
 function errorResponse(status: number, message: string): Response {
   return new Response(JSON.stringify({ error: message }), {
@@ -100,8 +104,8 @@ export const PATCH: APIRoute = async ({ request, params }) => {
   const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
   if (!UUID_RE.test(id)) return errorResponse(400, 'Identifiant de rendez-vous invalide');
 
-  if (!action || !['confirm', 'decline', 'reschedule', 'save_notes', 'accept_reschedule', 'cancel_reschedule'].includes(action as string))
-    return errorResponse(422, 'Action invalide (confirm | decline | reschedule | save_notes | accept_reschedule | cancel_reschedule)');
+  if (!action || !['confirm', 'decline', 'cancel', 'reschedule', 'reschedule_paid', 'save_notes', 'accept_reschedule', 'cancel_reschedule'].includes(action as string))
+    return errorResponse(422, 'Action invalide (confirm | decline | cancel | reschedule | reschedule_paid | save_notes | accept_reschedule | cancel_reschedule)');
 
   // 3. Récupérer le rendez-vous
   const { data: appt, error: fetchError } = await supabaseAdmin
@@ -378,6 +382,201 @@ export const PATCH: APIRoute = async ({ request, params }) => {
     }
 
     return jsonResponse({ appointment: updatedAppt, message: 'Rendez-vous refusé.' });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Action: cancel — annule un RDV (confirmé/payé/etc.), gère l'avoir
+  // ---------------------------------------------------------------------------
+  // Règle consolidée :
+  //   1. Toujours restituer l'avoir consommé par ce RDV (si credit_applied > 0).
+  //   2. Émettre un nouvel avoir du cash réellement encaissé (final_price −
+  //      credit_applied) UNIQUEMENT si status === 'payment_received' et si ce
+  //      montant > 0 (sinon : aucun cash, aucun nouvel avoir).
+  // Aucune exclusion pour les RDV déjà écoulés : la fenêtre d'éligibilité
+  // (veille incluse) est validée par isCancellableByTherapist — le jugement
+  // de la thérapeute est le garde-fou intentionnel (annulation de dernière minute).
+  // ---------------------------------------------------------------------------
+  if (action === 'cancel') {
+    if (!isCancellableByTherapist(appointment))
+      return errorResponse(409, 'Ce rendez-vous ne peut pas être annulé (hors fenêtre ou statut terminal).');
+
+    // 1. Restituer l'avoir consommé par ce RDV (avant toute autre écriture).
+    let restoredAmount = 0;
+    if (appointment.credit_applied > 0) {
+      try {
+        await restoreCredits(appointment.id);
+        restoredAmount = appointment.credit_applied;
+      } catch (restoreErr) {
+        // La cohérence du ledger prime : on bloque l'annulation si la restitution échoue.
+        console.error('[appointments/patch] Erreur restitution avoir (cancel):', restoreErr);
+        return errorResponse(500, 'Erreur lors de la restitution de l\'avoir');
+      }
+    }
+
+    // 2. Émettre un nouvel avoir pour le cash encaissé (RDV payé uniquement).
+    let issuedCredit = false;
+    let creditCashAmount = 0;
+    if (appointment.status === 'payment_received') {
+      creditCashAmount = appointment.final_price - appointment.credit_applied;
+      if (creditCashAmount > 0) {
+        try {
+          await issueCreditForCancellation(appointment, creditCashAmount);
+          issuedCredit = true;
+        } catch (creditErr) {
+          console.error('[appointments/patch] Erreur émission avoir (cancel):', creditErr);
+          return errorResponse(500, 'Erreur lors de l\'émission de l\'avoir');
+        }
+      }
+    }
+
+    // 3. Passer le RDV en cancelled.
+    const { data: updated, error: updateError } = await supabaseAdmin
+      .from('appointments')
+      .update({
+        status: 'cancelled',
+        therapist_notes: therapist_notes ?? appointment.therapist_notes,
+      })
+      .eq('id', id)
+      .select()
+      .single();
+
+    if (updateError || !updated) {
+      console.error('[appointments/patch] Erreur cancel:', updateError);
+      return errorResponse(500, 'Erreur lors de l\'annulation');
+    }
+
+    const updatedAppt = updated as Appointment;
+
+    await invalidateAvailabilityCache().catch(console.error);
+
+    // 4. Supprimer l'événement Google Calendar (non-bloquant).
+    if (appointment.google_calendar_event_id) {
+      await deleteCalendarEvent(appointment.google_calendar_event_id).catch((calendarErr: unknown) => {
+        console.error('[appointments/patch] Erreur suppression événement agenda (cancel):', calendarErr);
+      });
+    }
+
+    // 5. Notifier le patient par email (non-bloquant).
+    //    Wording contract : jamais le mot « remboursement ». L'avoir est interne.
+    await sendEmail({
+      to: updatedAppt.patient_email,
+      threadKey: `appointment:${updatedAppt.id}:patient`,
+      subject: buildAppointmentConversationSubject(
+        'Votre rendez-vous a été annulé',
+        updatedAppt.id,
+      ),
+      react: createElement(AppointmentCancelled, {
+        patientName: updatedAppt.patient_name,
+        scheduledAt: updatedAppt.scheduled_at,
+        appointmentMode: updatedAppt.appointment_mode,
+        hasCredit: issuedCredit,
+        creditAmount: issuedCredit ? creditCashAmount : undefined,
+        therapistNote: typeof therapist_notes === 'string' ? therapist_notes : undefined,
+      }),
+    }).catch((emailErr: unknown) => {
+      console.error('[appointments/patch] Erreur envoi email (cancel):', emailErr);
+    });
+
+    const messageParts = ['Rendez-vous annulé.'];
+    if (issuedCredit) messageParts.push(`Avoir de ${creditCashAmount / 100}€ émis.`);
+    if (restoredAmount > 0) messageParts.push(`Avoir de ${restoredAmount / 100}€ restitué.`);
+
+    return jsonResponse({ appointment: updatedAppt, message: messageParts.join(' ') });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Action: reschedule_paid — move direct admin d'un RDV vidéo déjà payé
+  // ---------------------------------------------------------------------------
+  // Corrige le bug de double-facturation : l'action `reschedule` classique
+  // expire le Payment Link et accept_reschedule en régénère un nouveau,
+  // re-facturant un RDV déjà payé. Ici : on déplace juste le créneau, le
+  // paiement est conservé, aucun lien Stripe, aucune re-accept patient.
+  // Conditions : vidéo + payment_received + éligible (fenêtre veille).
+  // ---------------------------------------------------------------------------
+  if (action === 'reschedule_paid') {
+    if (appointment.appointment_mode !== 'video' || appointment.status !== 'payment_received')
+      return errorResponse(409, 'Le report direct ne s\'applique qu\'aux téléconsultations déjà payées.');
+    if (!isCancellableByTherapist(appointment))
+      return errorResponse(409, 'Ce rendez-vous ne peut pas être reporté (hors fenêtre).');
+
+    if (!rescheduled_to || typeof rescheduled_to !== 'string')
+      return errorResponse(422, 'Nouveau créneau requis pour un report');
+
+    const newDate = new Date(rescheduled_to as string);
+    if (isNaN(newDate.getTime()))
+      return errorResponse(422, 'Format de date invalide pour le report');
+    if (newDate.getTime() < Date.now())
+      return errorResponse(422, 'Le nouveau créneau doit être dans le futur');
+
+    if (!isWithinBusinessHours(rescheduled_to as string, appointment.duration))
+      return errorResponse(422, 'Le créneau doit être dans les plages horaires (8h-12h ou 14h-19h).');
+
+    try {
+      const slotEnd = new Date(newDate.getTime() + appointment.duration * 60 * 1000);
+      const hasConflict = await hasAppointmentConflict({
+        slotStartIso: newDate.toISOString(),
+        slotEndIso: slotEnd.toISOString(),
+        excludeAppointmentId: appointment.id,
+      });
+      if (hasConflict) {
+        return errorResponse(409, 'Ce créneau n\'est plus disponible. Veuillez sélectionner un autre horaire.');
+      }
+    } catch (conflictError) {
+      console.error('[appointments/patch] Erreur vérification doublon (reschedule_paid):', conflictError);
+      return errorResponse(500, 'Erreur lors de la vérification du créneau');
+    }
+
+    // AUCUN appel Stripe, AUCUN changement de status/prix/credit_applied.
+    const { data: updated, error: updateError } = await supabaseAdmin
+      .from('appointments')
+      .update({
+        scheduled_at: newDate.toISOString(),
+        therapist_notes: therapist_notes ?? appointment.therapist_notes,
+      })
+      .eq('id', id)
+      .select()
+      .single();
+
+    if (updateError || !updated) {
+      console.error('[appointments/patch] Erreur reschedule_paid:', updateError);
+      return errorResponse(500, 'Erreur lors du report');
+    }
+
+    const updatedAppt = updated as Appointment;
+
+    await invalidateAvailabilityCache().catch(console.error);
+
+    // Mettre à jour l'événement Google Calendar existant (non-bloquant).
+    if (appointment.google_calendar_event_id) {
+      const start = new Date(updatedAppt.scheduled_at);
+      const end = new Date(start.getTime() + updatedAppt.duration * 60 * 1000);
+      await updateCalendarEvent(appointment.google_calendar_event_id, { start, end }).catch((calendarErr: unknown) => {
+        console.error('[appointments/patch] Erreur MAJ événement agenda (reschedule_paid):', calendarErr);
+      });
+    }
+
+    // Notifier le patient (email simple de notification, PAS de demande de paiement).
+    await sendEmail({
+      to: updatedAppt.patient_email,
+      threadKey: `appointment:${updatedAppt.id}:patient`,
+      subject: buildAppointmentConversationSubject(
+        'Votre rendez-vous a été reporté',
+        updatedAppt.id,
+      ),
+      react: createElement(AppointmentRescheduledPaid, {
+        patientName: updatedAppt.patient_name,
+        originalScheduledAt: appointment.scheduled_at,
+        newScheduledAt: newDate.toISOString(),
+        appointmentMode: updatedAppt.appointment_mode,
+        duration: updatedAppt.duration,
+        finalPrice: updatedAppt.final_price,
+        therapistNote: typeof therapist_notes === 'string' ? therapist_notes : undefined,
+      }),
+    }).catch((emailErr: unknown) => {
+      console.error('[appointments/patch] Erreur envoi email (reschedule_paid):', emailErr);
+    });
+
+    return jsonResponse({ appointment: updatedAppt, message: 'Rendez-vous reporté (paiement conservé).' });
   }
 
   // ---------------------------------------------------------------------------

--- a/src/types/appointment.ts
+++ b/src/types/appointment.ts
@@ -54,6 +54,7 @@ export interface Appointment {
   base_price: number;
   discount: number;
   final_price: number;
+  credit_applied: number; // avoir consommé à la création ; montant Stripe = final_price - credit_applied
 
   // Planification
   scheduled_at: string; // ISO 8601

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,3 +1,32 @@
+import type { AppointmentStatus } from '../types/appointment';
+
+/**
+ * Statuts à partir desquels un RDV ne peut plus être annulé ni reporté
+ * (déjà refusé, déjà annulé).
+ */
+const TERMINAL_STATUSES: ReadonlySet<AppointmentStatus> = new Set(['declined', 'cancelled']);
+
+/**
+ * Un rendez-vous peut-il être annulé ou reporté par la thérapeute ?
+ *
+ * Règle : le RDV doit être dans un statut non-terminal (≠ declined/cancelled)
+ * ET sa date prévue doit être >= début de la veille (Europe/Paris). Cette fenêtre
+ * inclut volontairement la veille : la thérapeute doit pouvoir annuler un RDV
+ * de dernière minute qu'elle n'a pas eu le temps de traiter le jour même.
+ *
+ * Prédicat pur, partagé client/serveur. Vit ici (et non dans
+ * `appointment-eligibility.ts`) pour éviter de tirer la chaîne d'imports
+ * `manual-slots.ts` → `supabaseAdmin` dans le bundle client des islands React
+ * (`AppointmentCard`). Ce module (`utils/date.ts`) n'a aucune dépendance I/O.
+ */
+export function isCancellableByTherapist(appt: {
+  scheduled_at: string;
+  status: AppointmentStatus;
+}): boolean {
+  if (TERMINAL_STATUSES.has(appt.status)) return false;
+  return new Date(appt.scheduled_at).getTime() >= startOfYesterdayParis().getTime();
+}
+
 /** ISO weekday in Paris time (1 = lundi, …, 7 = dimanche). */
 export function getParisISOWeekday(date: Date): number {
   // en-US short abbreviations are stable across runtimes, unlike fr-FR ones.

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -24,6 +24,52 @@ export function toParisDateString(date: Date): string {
 }
 
 /**
+ * Minuit (00:00) du jour précédent, en heure de Paris (Europe/Paris).
+ *
+ * Sert de borne inférieure à la fenêtre d'éligibilité d'annulation/report :
+ * un RDV est annulable par la thérapeute si `scheduled_at >= startOfYesterdayParis()`.
+ * Inclure la veille permet l'annulation de dernière minute quand la thérapeute
+ * n'a pas eu le temps de l'annuler le jour même.
+ *
+ * Insensible à la TZ du runtime et au DST : on obtient la date Paris de la veille
+ * (YYYY-MM-DD), puis on sonde l'instant UTC exact où l'heure de Paris vaut 00:00
+ * ce jour-là. Comme Paris est en UTC+1/+2, « minuit Paris du jour D » tombe entre
+ * 22:00 et 23:00 UTC la veille (jour D-1 en UTC) — on sonde donc une fenêtre
+ * autour de `D 00:00 UTC` par pas fins et on retient le premier candidat dont
+ * le formatage Paris vaut 00:00 sur la bonne date.
+ */
+export function startOfYesterdayParis(now: Date = new Date()): Date {
+  const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+  const ymd = toParisDateString(yesterday); // YYYY-MM-DD Paris (jour D)
+
+  const parisMidnightOnYmd = (utcMs: number): boolean => {
+    const dtf = new Intl.DateTimeFormat('en-CA', {
+      timeZone: 'Europe/Paris',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    });
+    const parts = dtf.formatToParts(new Date(utcMs));
+    const get = (t: string) => parts.find((p) => p.type === t)?.value ?? '';
+    // On veut exactement 00:00 sur la date ymd (évite de capter le minuit du jour suivant).
+    return `${get('year')}-${get('month')}-${get('day')}` === ymd && `${get('hour')}:${get('minute')}` === '00:00';
+  };
+
+  // Minuit Paris du jour D est dans [D-1 22:00 UTC, D 00:00 UTC].
+  // On sonde depuis D 00:00 UTC en reculant par pas de 5 min sur 3 h.
+  const baseUtc = Date.parse(`${ymd}T00:00:00Z`);
+  for (let delta = 0; delta <= 3 * 60 * 60 * 1000; delta += 5 * 60 * 1000) {
+    const candidate = baseUtc - delta;
+    if (parisMidnightOnYmd(candidate)) return new Date(candidate);
+  }
+  // Repli (ne devrait jamais se produire) : la veille à 22:00 UTC.
+  return new Date(Date.parse(`${ymd}T00:00:00Z`) - 2 * 60 * 60 * 1000);
+}
+
+/**
  * Vérifie qu'une séance tient dans les plages horaires d'ouverture (heure Paris).
  * Matin  : 8h00–12h00  (480–720 min)
  * Après-midi : 14h00–19h00 (840–1140 min)

--- a/supabase/migrations/008_credits.sql
+++ b/supabase/migrations/008_credits.sql
@@ -1,0 +1,177 @@
+-- ===========================================================================
+-- Migration 008 — Système d'avoir interne (credits)
+-- Issue #63 : annulation RDV payé → avoir réutilisable en création manuelle.
+--
+-- Aucun remboursement Stripe réel : l'avoir est un crédit interne, rattaché au
+-- patient_email. La consommation est FIFO et atomique (RPC SECURITY DEFINER).
+-- ===========================================================================
+
+-- ---------------------------------------------------------------------------
+-- TABLE : credits  (une ligne par avoir émis)
+-- ---------------------------------------------------------------------------
+CREATE TABLE credits (
+  id                    UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  patient_email         TEXT        NOT NULL,
+  source_appointment_id UUID        REFERENCES appointments(id) ON DELETE SET NULL,
+  amount                INTEGER     NOT NULL CHECK (amount > 0),       -- centimes, montant d'origine
+  remaining             INTEGER     NOT NULL CHECK (remaining >= 0 AND remaining <= amount),
+  reason                TEXT        NOT NULL DEFAULT 'cancellation',   -- extensible ('manual' future)
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at            TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Un seul avoir par RDV source (idempotence : re-clic sur Annuler ne crée pas de doublon).
+-- Plusieurs NULL autorisés (avoirs sans RDV source, ex. création manuelle future).
+CREATE UNIQUE INDEX credits_source_appointment_uniq
+  ON credits(source_appointment_id)
+  WHERE source_appointment_id IS NOT NULL;
+
+-- Recherche rapide du solde disponible par patient (FIFO + lookup).
+CREATE INDEX credits_patient_email_idx
+  ON credits(patient_email, created_at)
+  WHERE remaining > 0;
+
+-- ---------------------------------------------------------------------------
+-- TABLE : credit_usages  (lien RDV consommateur → avoir consommé, par tranche FIFO)
+-- ---------------------------------------------------------------------------
+CREATE TABLE credit_usages (
+  id            UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  credit_id     UUID        NOT NULL REFERENCES credits(id) ON DELETE CASCADE,
+  appointment_id UUID       NOT NULL REFERENCES appointments(id) ON DELETE CASCADE,
+  amount        INTEGER     NOT NULL CHECK (amount > 0),
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Empêche la double-consommation d'un même avoir pour un même RDV.
+CREATE UNIQUE INDEX credit_usages_once_per_appt_credit
+  ON credit_usages(credit_id, appointment_id);
+
+-- Restitution : recherche par RDV consommateur.
+CREATE INDEX credit_usages_appointment_idx
+  ON credit_usages(appointment_id);
+
+-- ---------------------------------------------------------------------------
+-- COLONNE : appointments.credit_applied
+-- Avoir consommé à la création. Montant Stripe = final_price - credit_applied.
+-- ---------------------------------------------------------------------------
+ALTER TABLE appointments ADD COLUMN credit_applied INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE appointments ADD CONSTRAINT appointments_credit_applied_chk
+  CHECK (credit_applied >= 0);
+
+-- ---------------------------------------------------------------------------
+-- TRIGGER : updated_at (réutilise update_updated_at() défini dans 001_init.sql)
+-- ---------------------------------------------------------------------------
+CREATE TRIGGER credits_updated_at
+  BEFORE UPDATE ON credits
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+-- ---------------------------------------------------------------------------
+-- ROW LEVEL SECURITY — service_role only (comme appointments)
+-- ---------------------------------------------------------------------------
+ALTER TABLE credits ENABLE ROW LEVEL SECURITY;
+ALTER TABLE credit_usages ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "credits service_role full access" ON credits
+  FOR ALL
+  USING (auth.role() = 'service_role');
+
+CREATE POLICY "credit_usages service_role full access" ON credit_usages
+  FOR ALL
+  USING (auth.role() = 'service_role');
+
+-- ===========================================================================
+-- RPC : consume_credits — consommation FIFO atomique
+-- ===========================================================================
+-- Verrouille les avoirs disponibles (FOR UPDATE), vérifie la couverture,
+-- consomme en FIFO (plus ancien d'abord) et enregistre les tranches dans
+-- credit_usages. SECURITY DEFINER : le propriétaire de la fonction (postgres)
+-- exécute le corps en bypassant la RLS ; l'accès est limité à service_role.
+--
+-- Retourne les tranches consommées (credit_id, amount) pour audit.
+-- Lève 'CREDIT_INSUFFICIENT' si la demande dépasse le disponible.
+-- Lève 'CREDIT_NO_OP' si p_amount = 0 (aucune consommation, sortie propre).
+-- ===========================================================================
+CREATE OR REPLACE FUNCTION consume_credits(
+  p_email          TEXT,
+  p_amount         INTEGER,
+  p_appointment_id UUID
+) RETURNS TABLE(credit_id UUID, amount INTEGER)
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_total_available INTEGER;
+  v_remaining_to_take INTEGER;
+  v_credit_rec RECORD;
+BEGIN
+  IF p_amount IS NULL OR p_amount <= 0 THEN
+    RAISE EXCEPTION 'CREDIT_NO_OP';
+  END IF;
+
+  -- Verrouiller et sommer le disponible pour ce patient.
+  SELECT COALESCE(SUM(remaining), 0) INTO v_total_available
+    FROM credits
+    WHERE patient_email = LOWER(p_email) AND remaining > 0
+    FOR UPDATE;
+
+  IF v_total_available < p_amount THEN
+    RAISE EXCEPTION 'CREDIT_INSUFFICIENT: disponible %, demandé %', v_total_available, p_amount
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  v_remaining_to_take := p_amount;
+
+  -- FIFO : parcourir les avoirs les plus anciens et consommer jusqu'à couvrir p_amount.
+  FOR v_credit_rec IN
+    SELECT id, remaining
+      FROM credits
+      WHERE patient_email = LOWER(p_email) AND remaining > 0
+      ORDER BY created_at ASC, id ASC
+      FOR UPDATE
+  LOOP
+    EXIT WHEN v_remaining_to_take <= 0;
+    DECLARE
+      v_take INTEGER;
+    BEGIN
+      v_take := LEAST(v_credit_rec.remaining, v_remaining_to_take);
+      UPDATE credits SET remaining = remaining - v_take WHERE id = v_credit_rec.id;
+      INSERT INTO credit_usages(credit_id, appointment_id, amount)
+        VALUES (v_credit_rec.id, p_appointment_id, v_take);
+      v_remaining_to_take := v_remaining_to_take - v_take;
+      credit_id := v_credit_rec.id;
+      amount := v_take;
+      RETURN NEXT;
+    END;
+  END LOOP;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION consume_credits(TEXT, INTEGER, UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION consume_credits(TEXT, INTEGER, UUID) TO service_role;
+
+-- ===========================================================================
+-- RPC : restore_credits — restitution d'un avoir consommé (annulation du RDV bénéficiaire)
+-- ===========================================================================
+-- Sélectionne les credit_usages d'un RDV, restaure les remaining des avoirs
+-- sources, puis supprime les usages. Idempotent (si déjà restauré, no-op).
+-- ===========================================================================
+CREATE OR REPLACE FUNCTION restore_credits(p_appointment_id UUID)
+RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  -- Restaurer le remaining de chaque avoir consommé par ce RDV.
+  UPDATE credits c
+    SET remaining = c.remaining + cu.consumed
+    FROM (
+      SELECT credit_id, SUM(amount) AS consumed
+        FROM credit_usages
+        WHERE appointment_id = p_appointment_id
+        GROUP BY credit_id
+    ) cu
+    WHERE c.id = cu.credit_id;
+
+  -- Supprimer les usages (idempotent : si déjà supprimés, no-op).
+  DELETE FROM credit_usages WHERE appointment_id = p_appointment_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION restore_credits(UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION restore_credits(UUID) TO service_role;

--- a/tests/unit/cancel-eligibility.test.ts
+++ b/tests/unit/cancel-eligibility.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi, beforeAll } from 'vitest';
+
+// `isCancellableByTherapist` est un prédicat pur, mais son module importe
+// appointment-eligibility.ts qui importe manual-slots.ts (Supabase). On mocke
+// manual-slots pour ne pas déclencher d'I/O à l'import.
+vi.mock('@/lib/manual-slots', () => ({
+  fetchManualSlots: vi.fn(),
+}));
+
+import { isCancellableByTherapist } from '@/lib/appointment-eligibility';
+import type { AppointmentStatus } from '@/types/appointment';
+
+function appt(scheduled_at: string, status: AppointmentStatus = 'confirmed') {
+  return { scheduled_at, status };
+}
+
+// Référence : aujourd'hui supposé = 2026-07-03 (test déterministe via injection).
+// La veille Paris = 2026-07-02 à 00:00 Europe/Paris = 2026-07-01T22:00:00Z (UTC+2 été).
+// Donc tout scheduled_at >= 2026-07-01T22:00:00Z est éligible.
+
+describe('isCancellableByTherapist', () => {
+  beforeAll(() => {
+    // Fixe "maintenant" au 2026-07-03 10:00 UTC (12:00 Paris).
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-03T10:00:00Z'));
+  });
+
+  it('rend éligible un RDV de la veille (UTC correspondant à 00:00 Paris)', () => {
+    // 2026-07-02 08:00 Paris = 2026-07-02T06:00:00Z : clairement dans la fenêtre.
+    expect(isCancellableByTherapist(appt('2026-07-02T06:00:00Z'))).toBe(true);
+  });
+
+  it('rend éligible un RDV plus récent que la veille', () => {
+    expect(isCancellableByTherapist(appt('2026-07-03T08:00:00Z'))).toBe(true);
+  });
+
+  it('rend inéligible un RDV avant le début de la veille', () => {
+    // 2026-07-01 10:00 Paris = 2026-07-01T08:00:00Z : avant la veille (2026-07-01T22:00Z).
+    expect(isCancellableByTherapist(appt('2026-07-01T08:00:00Z'))).toBe(false);
+  });
+
+  it('borne exacte : exactement début de la veille = éligible (>=)', () => {
+    // 2026-07-02 00:00 Paris = 2026-07-01T22:00:00Z.
+    expect(isCancellableByTherapist(appt('2026-07-01T22:00:00Z'))).toBe(true);
+  });
+
+  it('statut declined → inéligible même si dans la fenêtre', () => {
+    expect(isCancellableByTherapist(appt('2026-07-02T06:00:00Z', 'declined'))).toBe(false);
+  });
+
+  it('statut cancelled → inéligible', () => {
+    expect(isCancellableByTherapist(appt('2026-07-02T06:00:00Z', 'cancelled'))).toBe(false);
+  });
+
+  it('statut payment_received → éligible (cas annulation payée)', () => {
+    expect(isCancellableByTherapist(appt('2026-07-02T06:00:00Z', 'payment_received'))).toBe(true);
+  });
+
+  it('statut payment_pending → éligible', () => {
+    expect(isCancellableByTherapist(appt('2026-07-02T06:00:00Z', 'payment_pending'))).toBe(true);
+  });
+});

--- a/tests/unit/credits.test.ts
+++ b/tests/unit/credits.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// On mocke supabaseAdmin pour tester credits.ts en isolation (pas de DB).
+// Chaque test configure le comportement du mock via mockResolvedValueOnce.
+vi.mock('@/lib/supabase', () => {
+  const mock = {
+    from: vi.fn(),
+    rpc: vi.fn(),
+  };
+  return { supabaseAdmin: mock };
+});
+
+import { supabaseAdmin } from '@/lib/supabase';
+import {
+  getAvailableCredit,
+  getCreditBalance,
+  issueCreditForCancellation,
+  consumeCredits,
+  restoreCredits,
+} from '@/lib/credits';
+
+/**
+ * Construit un faux builder Supabase : un objet chainable (select/eq/gt/order/insert
+ * retournent le builder) ET thenable (l'attendre résout `result`). Les méthodes
+ * terminales single()/maybeSingle() retournent une promesse résolue sur `result`.
+ */
+function chainReturning(result: { data: unknown; error: unknown }) {
+  // Builder thenable : `await chain` résout `result`.
+  const builder: Record<string, unknown> = {};
+  const promise = Promise.resolve(result);
+  // Rendre le builder thenable pour `await from()` (cas sans terminal).
+  builder.then = (resolve: (v: unknown) => unknown) => promise.then(resolve);
+
+  const selfReturning = () => builder;
+  builder.select = vi.fn(selfReturning);
+  builder.eq = vi.fn(selfReturning);
+  builder.gt = vi.fn(selfReturning);
+  builder.order = vi.fn(selfReturning);
+  builder.insert = vi.fn(selfReturning);
+  builder.update = vi.fn(selfReturning);
+  builder.single = vi.fn(() => promise);
+  builder.maybeSingle = vi.fn(() => promise);
+  return builder;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('getAvailableCredit', () => {
+  it('somme les remaining > 0 du patient', async () => {
+    const chain = chainReturning({ data: [{ remaining: 2000 }, { remaining: 1500 }], error: null });
+    (supabaseAdmin.from as ReturnType<typeof vi.fn>).mockReturnValue(chain);
+
+    const balance = await getAvailableCredit('Alice@Example.com');
+    expect(balance).toBe(3500);
+    // Normalisation lowercase
+    expect(chain.eq).toHaveBeenCalledWith('patient_email', 'alice@example.com');
+  });
+
+  it('retourne 0 en cas d\'erreur (dégradation)', async () => {
+    const chain = chainReturning({ data: null, error: { message: 'boom' } });
+    (supabaseAdmin.from as ReturnType<typeof vi.fn>).mockReturnValue(chain);
+    await expect(getAvailableCredit('a@b.com')).resolves.toBe(0);
+  });
+
+  it('retourne 0 si aucun avoir', async () => {
+    const chain = chainReturning({ data: [], error: null });
+    (supabaseAdmin.from as ReturnType<typeof vi.fn>).mockReturnValue(chain);
+    await expect(getAvailableCredit('a@b.com')).resolves.toBe(0);
+  });
+});
+
+describe('issueCreditForCancellation', () => {
+  const appt = { id: 'rdv-1', patient_email: 'Bob@x.com', final_price: 6500, credit_applied: 0 };
+
+  it('insère un avoir du montant cash et retourne la ligne', async () => {
+    const inserted = { id: 'credit-1', amount: 6500, remaining: 6500 };
+    const chain = chainReturning({ data: inserted, error: null });
+    (supabaseAdmin.from as ReturnType<typeof vi.fn>).mockReturnValue(chain);
+
+    const credit = await issueCreditForCancellation(appt, 6500);
+    expect(credit).toEqual(inserted);
+    expect(chain.insert).toHaveBeenCalledWith(expect.objectContaining({
+      patient_email: 'bob@x.com',
+      source_appointment_id: 'rdv-1',
+      amount: 6500,
+      remaining: 6500,
+      reason: 'cancellation',
+    }));
+  });
+
+  it('retourne null si amountCash <= 0 (pas d\'avoir)', async () => {
+    await expect(issueCreditForCancellation(appt, 0)).resolves.toBeNull();
+    await expect(issueCreditForCancellation(appt, -100)).resolves.toBeNull();
+  });
+
+  it('est idempotente : unique_violation → retourne l\'avoir existant', async () => {
+    // Premier insert → 23505 (existe déjà)
+    const existing = { id: 'credit-existing', amount: 6500, remaining: 6500 };
+    const insertChain = chainReturning({ data: null, error: { code: '23505', message: 'dup' } });
+    // Recherche de l'existant via maybeSingle()
+    const lookupChain = chainReturning({ data: existing, error: null });
+    (supabaseAdmin.from as ReturnType<typeof vi.fn>)
+      .mockReturnValueOnce(insertChain) // insert
+      .mockReturnValueOnce(lookupChain); // select existant
+
+    const credit = await issueCreditForCancellation(appt, 6500);
+    expect(credit).toEqual(existing);
+  });
+
+  it('propage les erreurs non-23505', async () => {
+    const chain = chainReturning({ data: null, error: { code: '42P01', message: 'table absente' } });
+    (supabaseAdmin.from as ReturnType<typeof vi.fn>).mockReturnValue(chain);
+    await expect(issueCreditForCancellation(appt, 6500)).rejects.toThrow(/table absente/);
+  });
+});
+
+describe('consumeCredits', () => {
+  it('appelle la RPC consume_credits et retourne les tranches', async () => {
+    const usages = [{ credit_id: 'c1', amount: 2000 }, { credit_id: 'c2', amount: 1000 }];
+    (supabaseAdmin.rpc as ReturnType<typeof vi.fn>).mockResolvedValue({ data: usages, error: null });
+
+    const result = await consumeCredits('alice@example.com', 3000, 'rdv-2');
+    expect(result).toEqual(usages);
+    expect(supabaseAdmin.rpc).toHaveBeenCalledWith('consume_credits', {
+      p_email: 'alice@example.com',
+      p_amount: 3000,
+      p_appointment_id: 'rdv-2',
+    });
+  });
+
+  it('retourne [] sans appeler la RPC si amount <= 0', async () => {
+    await expect(consumeCredits('a@b.com', 0, 'rdv-3')).resolves.toEqual([]);
+    expect(supabaseAdmin.rpc).not.toHaveBeenCalled();
+  });
+
+  it('propage l\'erreur (avoir insuffisant côté RPC)', async () => {
+    (supabaseAdmin.rpc as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: null,
+      error: { message: 'CREDIT_INSUFFICIENT' },
+    });
+    await expect(consumeCredits('a@b.com', 99999, 'rdv-4')).rejects.toThrow(/CREDIT_INSUFFICIENT/);
+  });
+});
+
+describe('restoreCredits', () => {
+  it('appelle la RPC restore_credits avec l\'id du RDV', async () => {
+    (supabaseAdmin.rpc as ReturnType<typeof vi.fn>).mockResolvedValue({ data: null, error: null });
+    await restoreCredits('rdv-5');
+    expect(supabaseAdmin.rpc).toHaveBeenCalledWith('restore_credits', { p_appointment_id: 'rdv-5' });
+  });
+
+  it('propage l\'erreur RPC', async () => {
+    (supabaseAdmin.rpc as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: null,
+      error: { message: 'fk violation' },
+    });
+    await expect(restoreCredits('rdv-6')).rejects.toThrow(/fk violation/);
+  });
+});
+
+describe('getCreditBalance', () => {
+  it('retourne balance + historique trié', async () => {
+    const history = [
+      { id: 'c2', remaining: 0, amount: 1000 },
+      { id: 'c1', remaining: 2500, amount: 2500 },
+    ];
+    const chain = chainReturning({ data: history, error: null });
+    (supabaseAdmin.from as ReturnType<typeof vi.fn>).mockReturnValue(chain);
+
+    const result = await getCreditBalance('alice@example.com');
+    expect(result.balance).toBe(2500);
+    expect(result.history).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Résumé

Closes #63. Permet à la thérapeute d'**annuler ou reporter tout RDV** depuis `/mes-rdvs/`, émet un **avoir interne** sur l'annulation d'un RDV vidéo déjà payé, et permet de **réutiliser cet avoir** lors d'une création manuelle. **Aucun remboursement Stripe réel** (l'argent reste).

## Changements

### Annulation (nouveau statut `cancelled`, jusque-là mort)
- Action `cancel` dans `PATCH /api/appointments/[id]` : status → cancelled, supprime l'événement Google Calendar, envoie un email `AppointmentCancelled` au patient.
- Bouton **« Annuler »** sur `AppointmentCard`, visible dans la fenêtre d'éligibilité (veille incluse).

### Avoir automatique sur annulation payée
- Si le RDV est `payment_received` → un avoir de `final_price − credit_applied` est émis (le cash réellement encaissé). Aucun Stripe refund.
- Idempotent via `UNIQUE(source_appointment_id)`.

### Restitution d'avoir sur re-annulation
- Si un RDV créé avec un avoir est lui-même annulé → l'avoir est **restitué** (via la RPC `restore_credits`).

### Report vidéo payé (corrige un bug de double-facturation)
- Nouvelle action `reschedule_paid` : move direct admin, paiement conservé, Meet/Calendar mis à jour, notification email au patient. **Aucune régénération de lien Stripe** (le `reschedule` classique re-facturait les RDV vidéo déjà payés).

### Création manuelle avec avoir (admin-only)
- Case **« Utiliser l'avoir (XX€ disponibles) »** dans `AdminCreateButton` quand le `patient_email` a un solde disponible.
- Consommation FIFO atomique (RPC Postgres `consume_credits`). Reliquat conservé.
- Si le prix final après déduction = 0 → statut `payment_received` (video) / `confirmed` (in-person), **aucun lien Stripe**.
- Si > 0 et vidéo → lien Stripe pour le **solde dû**.

### Migration DB (`008_credits.sql`)
- Tables `credits` + `credit_usages`, colonne `appointments.credit_applied`.
- RPC `consume_credits` (FIFO atomique, `SECURITY DEFINER`, `REVOKE EXECUTE FROM PUBLIC`) et `restore_credits`.
- RLS service_role-only.

## Décisions produit

- Avoirs **admin-only** : aucune UI patient (le patient contacte la thérapeute).
- Email d'annulation : mentionne « avoir » mais **jamais le mot « remboursement »**.
- Fenêtre d'éligibilité : `scheduled_at ≥ début de la veille` (Europe/Paris) — la veille est incluse volontairement (annulation de dernière minute).
- Statut unifié : `payment_received` = « séance réglée » (Stripe ou avoir).

## Hors périmètre

Remboursement Stripe réel · UI patient pour les avoirs · création manuelle d'avoir depuis la page Patients · annulation self-service patient.

## Vérifications

- ✅ `npm run lint` (nouveaux fichiers)
- ✅ `npx tsc --noEmit` (aucune erreur dans les fichiers modifiés)
- ✅ `npx vitest run` — 46 tests (21 nouveaux : credits + éligibilité)
- ✅ `npx astro build` — Complete!

> Note : `package-lock.json` est inclus (le lockfile de `main` était désynchronisé de `package.json` — esbuild platform packages manquants — `npm install` l'a réconcilié).

## Migration à appliquer en prod

Après merge : `008_credits.sql` doit être exécuté sur la base de prod (création des tables + RPC + colonne).