### PR TITLE
docs: sync + structure + nettoyage stale + AGENTS.md (4 volets)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 # Instructions pour les agents AI Copilot
 
-**Dernière mise à jour :** 14 mai 2026
+**Dernière mise à jour :** 5 juillet 2026
 
 ## 🎯 Aperçu du Projet
 
@@ -34,7 +34,7 @@ Entrées disponibles : Project Overview · Architecture · Coding Conventions ·
 omf-therapie/
 ├── src/
 │   ├── components/     # Composants React (islands/) et Astro
-│   │   ├── admin/      # Dashboard admin (AppointmentCard, AdminCreateButton)
+│   │   ├── admin/      # Dashboard admin (AppointmentCard, AdminCreateButton, AppointmentsManager)
 │   │   ├── islands/    # React islands hydratés côté client (Navbar, BlogClientWrapper)
 │   │   └── ...         # home/, blog/, contact/, footer/, navigation/, pricing/
 │   ├── config/         # Configuration globale
@@ -43,17 +43,17 @@ omf-therapie/
 │   ├── emails/         # Templates React Email (Nodemailer/Resend)
 │   ├── hooks/          # Hooks React personnalisés (utilisés dans les islands)
 │   ├── layouts/        # Layouts Astro (Layout.astro, ServiceLayout.astro)
-│   ├── lib/            # Librairies serveur (auth.server.ts, pricing.ts, stripe.ts, google-calendar.ts, supabase.ts)
+│   ├── lib/            # Librairies serveur (auth.server.ts, pricing.ts, stripe.ts, credits.ts, google-calendar.ts, supabase.ts)
 │   ├── pages/          # Routes Astro (fichiers .astro → URLs)
 │   │   ├── api/        # Endpoints API SSR (appointments, auth, availability, stripe-webhook, admin/)
 │   │   ├── rdv/        # Pages patient post-booking (accepter-report, merci)
 │   │   ├── rendez-vous.astro  # Wizard de prise de rendez-vous (patient)
-│   │   ├── mes-rdvs.astro     # Dashboard admin (BetterAuth requis)
+│   │   ├── mes-rdvs.astro     # Dashboard admin (BetterAuth requis) — liste compacte gérée par <AppointmentsManager>
 │   │   └── login.astro        # Authentification admin
 │   ├── types/          # Définitions TypeScript
 │   └── utils/          # Utilitaires (schema.ts, blogApi.ts, etc.)
 ├── supabase/
-│   └── migrations/     # Schéma PostgreSQL (001_init.sql)
+│   └── migrations/     # Schéma PostgreSQL (001_init.sql → 008_credits.sql)
 ├── scripts/            # Scripts utilitaires (seed-admin.ts)
 ├── memory-bank/        # Standards de développement (astro.md, conventions.md, etc.)
 └── public/             # Assets statiques et rapports

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,128 @@
+# AGENTS.md
+
+Workspace instructions for ZCode agents working on **omf-therapie** — a therapy practice website (Astro 5 SSG + React islands + Tailwind). French-language site for a single practitioner (Oriane Montabonnet), deployed at omf-therapie.fr.
+
+> **Read first for sensitive areas:** `CLAUDE.md` (conventions, commands), `memory-bank/architecture.md` (system design + data flow), `memory-bank/decisions.md` (ADRs), `.claude/stack.yml` (declared stack & commands). This file is a quick-reference layer on top of those.
+
+## Commands
+
+```bash
+npm run dev              # Astro dev server (port 4321)
+npm run build            # Production build (SSG → dist/)
+npm run preview          # Preview built site
+npm run lint             # ESLint (eslint.config.js, flat config)
+npm run typecheck        # `astro check` — advisory in CI (see #68 for ~20 residual errors)
+npm run test             # Vitest (tests/unit/**, node env)
+npm run test:watch       # Vitest watch mode
+npm run audit:a11y       # Pa11y WCAG audit (needs dev server running) — REQUIRED before UI PRs
+npm run db:start         # Start Postgres + Mailpit via docker compose
+npm run db:reset         # ⚠️ Drops & re-creates schema, replays ONLY 001_init.sql
+```
+
+**Run `npm run audit:a11y` before any UI/visual PR** — accessibility (WCAG 2.1 AA) is a hard requirement, not a nice-to-have.
+
+**CI (`.github/workflows/ci.yml`, on `origin/main`):** `lint → test → build` is the blocking gate; `typecheck` runs as advisory (`continue-on-error: true`) until issue #68 clears residual type errors. Node 20 pinned via `.nvmrc` (matches `netlify.toml`). After the first workflow run on `main`, branch protection should require `CI / build`.
+
+> **Drift note:** local `main` may lag `origin/main`. If `.nvmrc` or `.github/workflows/` are missing from your working tree, run `git pull` / rebase before assuming CI config.
+
+## Architecture boundaries
+
+**Astro SSG + Islands** — server-rendered `.astro` pages by default, React hydrated only where interactivity is needed.
+
+```
+src/
+├── pages/              # Astro file-based routes — each .astro = one URL
+│   ├── api/            # SSR API endpoints (NOT pre-rendered)
+│   │   ├── admin/      # Admin-only (auth required): appointments, patients, time-slots, google-oauth
+│   │   ├── appointments/  # Patient-facing booking CRUD + actions
+│   │   ├── auth/[...all].ts     # BetterAuth handler
+│   │   ├── availability.ts      # Slots (Google Calendar mock or real)
+│   │   └── stripe-webhook.ts    # Stripe → status updates
+│   ├── rendez-vous.astro  # Patient booking wizard (multi-step)
+│   ├── mes-rdvs.astro     # Admin dashboard (BetterAuth-gated) — <AppointmentsManager> island
+│   ├── rdv/               # Post-booking patient pages (accepter-report, merci)
+│   └── blog/, services/   # Marketing/content
+├── components/
+│   ├── islands/        # React components receiving client:* directives (Navbar, BlogClientWrapper, AppointmentsManager)
+│   ├── admin/          # Admin UI (auth-required context only)
+│   └── ...             # home/, blog/, contact/, footer/, navigation/, pricing/
+├── lib/                # SERVER-side only — never import from client islands
+│   ├── auth.server.ts        # BetterAuth config (monocompte — single practitioner)
+│   ├── supabase.ts, stripe.ts, google-calendar.ts, resend.ts
+│   ├── credits.ts            # Internal credit (avoir) system — FIFO via Postgres RPC
+│   ├── appointment-eligibility.ts  # Pure module — cancel/reschedule rules (unit-tested)
+│   └── secure-links.ts, rate-limit.ts, authz.ts
+├── emails/             # React Email templates → Nodemailer (dev/Mailpit) / Resend (prod)
+├── hooks/              # React hooks — islands only
+├── content/blog/       # Markdown posts via Content Collections (Zod-validated)
+├── types/, utils/, config/, layouts/
+supabase/migrations/    # Postgres schema (001_init.sql → 008_credits.sql)
+tests/unit/             # Vitest
+e2e/                    # Playwright specs
+```
+
+**Layer rules:**
+- `src/lib/**` is **server-only**. Never import from `src/components/islands/` or anything shipped to the browser.
+- `.astro` pages can import from both `lib/` (server) and `components/` (client). They mediate.
+- API routes under `pages/api/admin/**` must verify the session via `auth.api.getSession()` — no exceptions.
+- Auth is **monocompte**: one practitioner account. The `beforeUserCreated` hook blocks signup.
+
+## Critical conventions
+
+**Trailing slash on every client-side URL** (ADR-013). Every `fetch()` and `window.location.href` MUST end with `/`:
+
+```ts
+fetch("/api/appointments/", ...)                      // ✅ trailing /
+fetch(`/api/appointments/${id}/`, ...)                // ✅ template + trailing /
+window.location.href = "/mes-rdvs/"                   // ✅
+```
+
+Without it, Astro returns an HTML redirect page instead of JSON → `Unexpected token '<'`. (Note: `astro.config.mjs` currently has `trailingSlash: 'ignore'`, but the codebase + ADR-013 enforce `'always'` as the de-facto rule — follow the convention regardless.)
+
+**Language:**
+- Code, types, comments → English
+- User-facing text (UI labels, error messages, emails) → **French**
+- Commit messages → **French, present tense** ("Ajoute" not "Ajouté")
+
+**Styling:** Tailwind utility-first only. No custom CSS except base styles in `src/index.css`. No inline styles except dynamic values. Organize classes: layout → spacing → typography → colors → responsive.
+
+**Imports:** path alias `@/*` → `./src/*` (configured in `tsconfig.json`). Both `@/lib/foo` and relative `../lib/foo` are used; relative imports are more prevalent — match the surrounding file.
+
+**TypeScript:** strict mode, no `any`. Interfaces for objects, types for unions/primitives. Optional chaining + nullish coalescing preferred.
+
+**Astro islands:** `client:load` (above-fold), `client:idle` (below-fold, preferred), `client:visible` (avoid with `useMotionVariants` — visible snap on mobile).
+
+## Domain concepts agents must know
+
+- **Appointment statuses:** `pending → confirmed | declined | rescheduled → payment_pending → payment_received | cancelled`
+- **`payment_received`** = "séance réglée" (paid via Stripe **or** internal credit/avoir) — unified status, NOT `confirmed`.
+- **Avoirs internes** (#63/#66): cancelling a paid video RDV emits an internal credit (`credits`/`credit_usages` tables, FIFO via `consume_credits` RPC) — **no real Stripe refund**. Admin-only; no patient self-service UI.
+- **`reschedule_paid`** action: reschedules a paid video RDV without re-charging (avoids double-billing).
+- Stripe only for `appointment_mode = 'video'`; in-person is paid on-site.
+- Migration `008_credits.sql` must be applied manually — `npm run db:reset` only replays `001_init.sql`.
+
+## Env vars (Astro `import.meta.env.*`)
+
+Required for full functionality: `DATABASE_URL`, `SUPABASE_*` (database/anon/service-role), `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`, `STRIPE_*` (secret/publishable/webhook-secret/success-url), `RESEND_API_KEY`, `RESEND_FROM_EMAIL`, `SMTP_HOST`/`SMTP_PORT` (dev: Mailpit), `GOOGLE_CALENDAR_*` / `GOOGLE_OAUTH_*`, `SITE_URL`. See `docs/LOCAL_DEV.md` for local setup and `docs/INFRA.md` for prod.
+
+**Mocks when placeholders:** `STRIPE_SECRET_KEY=sk_test_placeholder` → Stripe mock (no real API calls). `GOOGLE_CALENDAR_MOCK=true` → fictional Wednesday slots.
+
+## Gotchas
+
+- **Local `main` drifts from `origin/main`.** Check `git log origin/main` before assuming what's merged. Recent merges (#85 CI, #66 avoirs, #65 /mes-rdvs redesign) may not be in your working tree.
+- **`npm run db:reset` is destructive AND incomplete** — drops the schema and only replays `001_init.sql`. Migrations `002`–`008` must be applied manually after.
+- **Astro static output** with Netlify adapter — API routes (`pages/api/**`) are SSR/hybrid despite `output: 'static'`.
+- **Legacy SPA aliases** (`/Tarifs`, `/Services`, `/About`, `/Process`, `/Formations`) are filtered from the sitemap and redirected in `netlify.toml`. Don't recreate them.
+- **`framer-motion`** animations are disabled on touch/WKWebView via `useMotionVariants` (returns `staticProps`). Use Tailwind `animate-spin` for continuous animations, never framer-motion.
+- **`vite.config` aliases** null out `react-router-dom` and `react-helmet-async` (legacy deps no longer installed). Don't reintroduce them.
+
+## Before editing sensitive areas
+
+| Area | Read first |
+|------|-----------|
+| Appointment lifecycle, statuses, cancel/reschedule | `memory-bank/architecture.md` (Booking System), `src/lib/appointment-eligibility.ts`, `tests/unit/appointment-eligibility.test.ts` |
+| Stripe / payments / avoirs | `memory-bank/decisions.md` ADR-014 (Stripe video-only), ADR-015 (avoirs); `src/lib/credits.ts`, `src/lib/stripe.ts` |
+| Auth / admin routes | `src/lib/auth.server.ts`, `src/lib/authz.ts` — verify session pattern |
+| DB schema / migrations | `supabase/migrations/` (apply in order; `008_credits.sql` is the latest) |
+| SEO / structured data | `src/utils/schema.ts`, sitemap filter in `astro.config.mjs` |
+| CI / deploy | `.github/workflows/ci.yml`, `netlify.toml` (after `git pull` if missing locally) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,11 @@ npm run dev              # Start dev server (Astro)
 npm run build            # Production build (SSG via astro build)
 npm run preview          # Preview production build locally
 npm run lint             # Run ESLint
+npm run typecheck        # Type-check via `astro check` (advisory in CI — see #68 for the 20 pre-existing errors)
+npm run test             # Vitest unit/integration tests
 ```
+
+> **CI:** `.github/workflows/ci.yml` gates merges to `main` with `lint → test → build`. Typecheck runs as a non-blocking advisory until #68 clears the remaining type errors. After the workflow reports once on `main`, require `CI / build` in branch protection.
 
 ### Accessibility Audits
 ```bash
@@ -301,10 +305,12 @@ Reports saved to `public/reports/latest/` with:
 - Don't add error handling for impossible scenarios
 
 ### Deployment
-- **Platform:** Netlify (automatic deployment from main branch)
+- **Platform:** Netlify (automatic deployment from `main`)
+- **CI gate:** GitHub Actions (`CI / build` = `lint → test → build`) must pass before merge — see `.github/workflows/ci.yml`. Typecheck is advisory (see issue #68).
+- **Node version:** pinned via `.nvmrc` (matches `netlify.toml`)
 - **Build command:** `npm run build`
 - **Publish directory:** `dist/`
-- **Custom domain:** Configured via CNAME in public/
+- **Custom domain:** Configured via CNAME in `public/`
 
 ### Git Workflow
 - **Main branch:** Production-ready code

--- a/docs/LOCAL_DEV.md
+++ b/docs/LOCAL_DEV.md
@@ -237,8 +237,12 @@ npx playwright show-report public/reports/playwright
 
 ```bash
 npm run lint              # ESLint
+npm run typecheck         # astro check (advisory — voir #68 pour les erreurs résiduelles)
+npm run test              # Vitest (tests unit/integration)
 npm run audit:a11y        # Audit pa11y (nécessite le dev server actif)
 ```
+
+> **CI** (`.github/workflows/ci.yml`) : `lint → test → build` bloquants, `typecheck` advisory. Node 20 via `.nvmrc`.
 
 ---
 
@@ -293,9 +297,12 @@ Vérifier `GOOGLE_CALENDAR_MOCK=true` dans `.env`. En mode mock, seuls les **mer
 
 Avec `STRIPE_SECRET_KEY=sk_test_placeholder` (valeur par défaut), le mode **Stripe mock** est actif :
 - La confirmation d'une téléconsultation passe en statut `payment_pending` et envoie un email de demande de paiement avec un **lien fictif** (pas de vrai appel Stripe).
+- Une fois « payé », le RDV passe en `payment_received` (statut unifié « réglé » — Stripe ou avoir, depuis #63/#66).
 - Aucune erreur 500 — le bypass est intentionnel pour le développement local.
 
 Pour tester le vrai tunnel de paiement, remplacer par de vraies clés de test [dashboard.stripe.com/test/apikeys](https://dashboard.stripe.com/test/apikeys).
+
+> **Avoirs internes (#63/#66)** : l'annulation d'un RDV `payment_received` émet un avoir interne (tables `credits`/`credit_usages`) — **pas de Stripe refund**. La migration `008_credits.sql` doit être appliquée à la base locale avant de tester ce flux (`npm run db:reset` ne rejoue que `001_init.sql` — appliquer `008_credits.sql` manuellement après).
 
 ### BetterAuth — erreur `INVALID_ORIGIN` à la connexion
 

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -1,0 +1,83 @@
+# Architecture
+
+> High-level system design for omf-therapie. For ADRs see `docs/architecture/adr/`. For deeper context, `memory-bank/architecture.md` is the canonical narrative.
+
+## Overview
+
+OMF Therapie is a **single-app Astro 5 website** (not a monorepo) for a one-person therapy practice. It is statically generated (SSG) by default, with **SSR API routes** (`src/pages/api/**`) hosted on Netlify for booking, auth, payments, and email. React is hydrated client-side only where interactivity is required (Astro Islands Architecture).
+
+The system is **decomposed by domain, not by layer** (ADR-001): every business capability — appointment, payment, calendar, email, auth, patient/admin, blog, contact — lands as one slice composed of a `lib/*` module + `types/*` + `pages/api/*` endpoint + `components/*`. Cross-cutting concerns (auth, rate-limit, secure-links, analytics) live as infrastructure-shaped libs that domains import rather than re-implement.
+
+## Layers (Astro strata, fixed by framework)
+
+| Layer | Path | Role |
+|-------|------|------|
+| Pages (SSG) | `src/pages/**.astro` | One file = one URL. Server-rendered to static HTML at build. |
+| Pages (SSR API) | `src/pages/api/**.ts` | Hybrid endpoints — patient booking, admin actions, webhooks. |
+| Components | `src/components/{domain}/` | Astro components (static) + React islands (hydrated). |
+| Islands | `src/components/islands/` | React components receiving `client:*` directives. |
+| Server libs | `src/lib/**.ts` | **Server-only.** Domain primitives + infra concerns. Never imported from client. |
+| Hooks | `src/hooks/` | React hooks — islands only. |
+| Emails | `src/emails/` | React Email templates → Nodemailer (dev) / Resend (prod). |
+| Types | `src/types/` | Domain-partitioned type definitions. |
+| Content | `src/content/blog/` | Markdown posts via Content Collections (Zod-validated). |
+| Config | `src/config/` | Site metadata, footer links. |
+| Layouts | `src/layouts/` | `Layout.astro` (base), `ServiceLayout.astro`. |
+| Utils | `src/utils/` | Helpers (schema.ts, date.ts, blogApi.ts). |
+
+## Domains (the multiplying axis)
+
+**Business domains** (grow over time — each new capability lands here):
+
+| Domain | Lib(s) | API endpoint(s) | Notes |
+|--------|--------|-----------------|-------|
+| appointment/booking | `appointment-conflicts.ts`, `appointment-eligibility.ts`, `manual-slots.ts` | `api/appointments/`, `api/admin/appointments/`, `api/availability.ts` | Status flow: `pending → confirmed \| declined \| rescheduled → payment_pending → payment_received \| cancelled` |
+| payment | `stripe.ts`, `pricing.ts`, `credits.ts` | `api/stripe-webhook.ts` | Stripe video-only; `payment_received` = paid (Stripe **or** avoir); no real refunds |
+| calendar | `google-calendar.ts`, `calendar-cache.ts`, `ics.ts` | `api/admin/google-oauth/`, `api/calendar/invite/` | Google Calendar API + Meet; `GOOGLE_CALENDAR_MOCK=true` in dev |
+| email | `resend.ts`, `emails/*` | (composed into other endpoints) | Resend (prod) / Mailpit (dev) |
+| patient / admin | `authz.ts` | `api/admin/patients.ts` | Admin-only operations |
+| blog | (Content Collections) | `blog/[slug].astro`, `blog/index.astro` | Static pre-rendered |
+| contact | (EmailJS, client-side) | `api/contact.ts` | No backend persistence |
+| services | (static) | `services/*.astro` | Marketing pages |
+
+**Infrastructure domains** (must stay concern-shaped, free of business logic):
+
+| Domain | Lib | Role |
+|--------|-----|------|
+| auth | `auth.server.ts`, `auth.ts`, `auth.client.ts`, `authz.ts` | BetterAuth (monocompte) + session checks |
+| persistence | `supabase.ts` | PostgREST / Supabase client |
+| rate-limit | `rate-limit.ts` | API rate limiting |
+| secure-links | `secure-links.ts` | Signed tokens for patient actions |
+| analytics | `analytics.ts` | GA4 (partytown) |
+
+## Request lifecycle (booking example)
+
+```
+Patient → /rendez-vous/ (Astro SSG wizard)
+       → POST /api/appointments/         (status=pending)
+       → PostgreSQL + email (admin notif)
+       → Admin acts at /mes-rdvs/        (BetterAuth session)
+       → PATCH /api/appointments/[id]/   (confirm | decline | reschedule | cancel | reschedule_paid)
+       → If video: Stripe Payment Link → patient pays → /api/stripe-webhook → status=payment_received
+       → If avoir applied: consume_credits RPC (FIFO) → status=payment_received (no Stripe)
+```
+
+## Deployment
+
+- **Platform:** Netlify (auto-deploy from `main`)
+- **Build:** `npm run build` → `dist/`
+- **CI gate** (`.github/workflows/ci.yml`): `lint → test → build` blocking; `typecheck` advisory (see #68)
+- **Node:** 20 (`.nvmrc`, matches `netlify.toml`)
+- **Branch protection:** require `CI / build` after first run on `main`
+
+See `docs/guides/deployment.md` for prod setup and `docs/INFRA.md` for infra env vars.
+
+## Key decisions
+
+See `docs/architecture/adr/` and `memory-bank/decisions.md`. Highlights:
+
+- **ADR-001:** Domain is the primary axis of decomposition (not layer, not adapter).
+- **ADR-013:** `trailingSlash: 'always'` — every client-side URL ends with `/`.
+- **ADR-014:** Stripe only for `appointment_mode = 'video'`.
+- **ADR-015:** Internal avoirs (credits) instead of Stripe refunds.
+- **ADR-016:** CI blocking (lint+test+build), typecheck advisory.

--- a/docs/architecture/patterns.md
+++ b/docs/architecture/patterns.md
@@ -1,0 +1,123 @@
+# Patterns
+
+> Recurring code patterns in omf-therapie. Concrete rules agents must follow, derived from CLAUDE.md, ADR-001, and codebase inspection.
+
+## Domain slice composition
+
+Every business capability is a **slice**, not a layer. Adding a new domain means one row across the existing layers — never a new top-level directory.
+
+```
+New domain "intake-forms" →
+  src/lib/intake-forms.ts          (server primitive)
+  src/types/intake-form.ts         (types)
+  src/pages/api/intake-forms/      (endpoints)
+  src/components/intake-forms/     (UI)
+  supabase/migrations/009_*.sql    (schema)
+```
+
+**Compose, don't duplicate.** A domain endpoint imports cross-cutting concerns from their canonical infra libs:
+
+```ts
+// ✅ Compose
+import { isAdminSession } from "@/lib/authz";
+import { checkRateLimit } from "@/lib/rate-limit";
+import { createSecureLinkToken } from "@/lib/secure-links";
+
+// ❌ Never re-implement inside a business domain
+function isAdminSession() { /* ... */ } // layer-pollution anti-pattern
+```
+
+## Astro Islands hydration
+
+Pick the directive by interactivity timing:
+
+| Directive | When | Example |
+|-----------|------|---------|
+| `client:load` | Above-fold, hydrate immediately | Navbar, contact form |
+| `client:idle` | Below-fold, hydrate when idle (**preferred**) | Most islands |
+| `client:visible` | Hydrate on viewport entry | Avoid with `useMotionVariants` (visible snap on mobile) |
+
+**Rule:** only components in `src/components/islands/` (and React components reached via islands) get `client:*` directives. Everything else is server-rendered `.astro`.
+
+## Trailing slash (ADR-013, hard rule)
+
+Every client-side URL ends with `/`:
+
+```ts
+fetch("/api/appointments/", { ... })              // ✅
+fetch(`/api/appointments/${id}/`, { ... })        // ✅
+window.location.href = "/mes-rdvs/"               // ✅
+```
+
+Without it, Astro returns an HTML redirect page instead of JSON → `Unexpected token '<'`.
+
+> **Note:** `astro.config.mjs` currently has `trailingSlash: 'ignore'`, but ADR-013, `memory-bank/decisions.md`, and every existing `fetch()` enforce `'always'`. Follow the convention.
+
+## Server/client boundary
+
+`src/lib/**` is **server-only**. The build will fail (or ship secrets) if a client island imports from it.
+
+| From → To | Allowed? |
+|-----------|----------|
+| `.astro` page → `lib/` | ✅ (page runs on server) |
+| `.astro` page → `components/` | ✅ |
+| API route → `lib/` | ✅ |
+| Island (React) → `lib/` | ❌ server-only |
+| Island → `hooks/`, `types/`, `utils/` | ✅ (these are isomorphic) |
+
+## Admin endpoint pattern
+
+Every endpoint under `src/pages/api/admin/**` must verify the session:
+
+```ts
+import { auth } from "@/lib/auth.server";
+import { isAdminSession } from "@/lib/authz";
+
+export const POST: APIRoute = async ({ request }) => {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!isAdminSession(session)) return new Response("Unauthorized", { status: 401 });
+  // ...
+};
+```
+
+No exceptions. The `beforeUserCreated` BetterAuth hook blocks all signups — auth is **monocompte** (one practitioner).
+
+## Status state machine (appointments)
+
+```
+pending ──→ confirmed (présentiel)
+        ├──→ declined
+        ├──→ rescheduled ──→ (patient accepts at /rdv/accepter-report/[id]/)
+        └──→ payment_pending ──→ payment_received (Stripe or avoir)
+                              └──→ cancelled (emits avoir if payment_received)
+```
+
+- `payment_received` = "séance réglée" (unified — Stripe **or** internal credit). Do **not** use `confirmed` for paid video RDVs.
+- `cancelled` is reachable from most active states; cancelling a `payment_received` video RDV emits an avoir (`credits`/`credit_usages` tables).
+- `reschedule_paid` action: reschedules a paid video RDV without re-charging.
+
+## Stripe / payment rules
+
+- Stripe Payment Links **only** for `appointment_mode = 'video'` (ADR-014). In-person is paid on-site.
+- **No real Stripe refunds** (ADR-015). Cancellation of a paid RDV → internal avoir (FIFO via `consume_credits` RPC).
+- Mock mode: `STRIPE_SECRET_KEY=sk_test_placeholder` → fictional payment link, no real API call.
+- Manual creation with avoir (admin): if balance due = 0 → `payment_received`/`confirmed` with no Stripe link; else Stripe link for the remainder only.
+
+## Email rules
+
+- Templates in `src/emails/` (React Email).
+- Transport: Nodemailer → Mailpit (`localhost:1025`) in dev; Resend API in prod.
+- **Cancellation email** (`AppointmentCancelled`) may mention "avoir" but **never** "remboursement".
+
+## AI Quick Reference
+
+- **ALWAYS** end client-side URLs (fetch, `window.location.href`) with a trailing `/`.
+- **ALWAYS** verify the session in `src/pages/api/admin/**` endpoints via `auth.api.getSession()` + `isAdminSession()`.
+- **NEVER** import from `src/lib/` inside a React island or any client-shipped code.
+- **NEVER** issue a real Stripe refund — emit an internal avoir (`credits`/`credit_usages`) instead.
+- **NEVER** re-implement `isAdminSession`, `checkRateLimit`, or `createSecureLinkToken` inside a business domain — import from their canonical `src/lib/*`.
+- **ALWAYS** co-locate a new domain's files across `lib/` + `types/` + `pages/api/` + `components/` (slice, not layer).
+- **PREFER** `client:idle` for below-fold islands; avoid `client:visible` with `useMotionVariants`.
+- **NEVER** add a new top-level `src/` directory for a feature — extend an existing layer.
+- **ALWAYS** write user-facing text, error messages, and emails in **French**; code/types/comments in English.
+- **ALWAYS** run `npm run audit:a11y` before a UI/visual PR.

--- a/docs/architecture/ubiquitous-language.md
+++ b/docs/architecture/ubiquitous-language.md
@@ -1,0 +1,47 @@
+# Ubiquitous Language
+
+> Domain glossary for omf-therapie. Terms used consistently across code, types, UI, emails, and docs. French terms are the canonical user-facing form; the English column is for code/types.
+
+| Term (FR / user-facing) | Code term | Definition |
+|------------------------|-----------|------------|
+| Rendez-vous (RDV) | `Appointment` | A scheduled session between practitioner and patient. |
+| Séance | `Appointment` (instance) | A therapy session (individual, couple, family, or TCA-focused). |
+| Téléconsultation | `appointment_mode = 'video'` | Video session via Google Meet. Triggers Stripe prepayment. |
+| Présentiel | `appointment_mode = 'in-person'` | On-site session. Paid on site (cash/card). |
+| Patient | `Patient` | The person booking. Identified by email + phone. No patient account (admin-only management). |
+| Thérapeute / Praticienne | `Admin` (session) | The single practitioner (Oriane Montabonnet). Auth is monocompte — one account. |
+| Créneau | `Slot` / `scheduled_at` | A bookable time window. Sourced from Google Calendar or manual overrides. |
+| Plage horaire | `ManualSlot` | A manually-defined available slot (`src/lib/manual-slots.ts`). |
+| Statut | `AppointmentStatus` | Lifecycle state of an RDV (see state machine in `patterns.md`). |
+| En attente | `pending` | Initial state after patient books; awaiting practitioner action. |
+| Confirmé | `confirmed` | Practitioner confirmed (présentiel, or video after payment). |
+| Refusé | `declined` | Practitioner declined the request. |
+| Reporté | `rescheduled` | Practitioner proposed a new slot; patient must accept at `/rdv/accepter-report/[id]/`. |
+| En attente de paiement | `payment_pending` | Video RDV awaiting Stripe payment (link sent). |
+| Réglé | `payment_received` | **Unified status:** paid via Stripe **or** internal avoir. Replaces `confirmed` for paid video RDVs. |
+| Annulé | `cancelled` | Practitioner cancelled. If the RDV was `payment_received`, an avoir is emitted. |
+| Avoir | `Credit` | Internal credit issued on cancellation of a paid RDV. Stored in `credits` table, consumed FIFO via `consume_credits` RPC. **No real Stripe refund.** |
+| Restitution d'avoir | `restore_credits` RPC | Re-credits an avoir when an RDV created with that avoir is itself cancelled. |
+| Tarif de base | `basePrice` | Standard session price (e.g. 50€ for 60min individual). |
+| Remise nouveau client | `override_first_session` | −15€ discount for first session. Mutually exclusive with solidarity. |
+| Tarif solidaire | `is_solidarity` | −20€ reduced rate. Mutually exclusive with first-session discount. |
+| Prix final | `finalPrice` | Price after discounts and avoir deduction. Stored ×100 (centimes) in DB. |
+| Lien sécurisé | `SecureLink` / `secure-links.ts` | Signed token URL for patient actions (accept reschedule, view invite). |
+| Lien de paiement | `Stripe Payment Link` | Stripe-hosted payment URL generated for video RDVs. |
+| Wizard de prise de RDV | `/rendez-vous/` | Multi-step patient booking flow (type → mode → duration → slot → info → confirm). |
+| Espace admin | `/mes-rdvs/` | Practitioner dashboard (BetterAuth-gated). Compact list via `<AppointmentsManager>` island. |
+| Tableau de bord | `/mes-rdvs/` | Synonym for the admin dashboard. |
+| Content Collection | `defineCollection` | Astro's typed content schema (blog posts in `src/content/blog/`). |
+| Île (island) | `client:*` directive | A React component hydrated client-side within an Astro page. |
+
+## Status flow (canonical)
+
+```
+pending → confirmed | declined | rescheduled
+pending → payment_pending → payment_received
+payment_received → cancelled (+ avoir)
+confirmed → cancelled
+rescheduled → (patient accepts) → confirmed | payment_pending
+```
+
+See `docs/architecture/patterns.md` § "Status state machine" for the full graph.

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -1,0 +1,89 @@
+# Deployment Guide
+
+> How omf-therapie ships to production. For local dev setup see `docs/LOCAL_DEV.md`; for infra/env vars see `docs/INFRA.md`.
+
+## Platform
+
+- **Netlify** — auto-deploys from `main` on push.
+- **Build command:** `npm run build` (`astro build` → `dist/`)
+- **Publish directory:** `dist/`
+- **Node version:** 20 (`.nvmrc` + `netlify.toml` `NODE_VERSION = "20"`)
+- **Custom domain:** omf-therapie.fr (CNAME in `public/`)
+- **Adapter:** `@astrojs/netlify` — generates `_redirects` + edge functions for SSR API routes.
+
+> **CI gate** (`.github/workflows/ci.yml`, merged via PR #85): the `build` job runs `lint → test → build` and must pass before merge. `typecheck-advisory` runs non-blocking (`continue-on-error: true`) until issue #68 clears residual type errors. **Branch protection** (manual): after the first workflow run on `main`, require `CI / build` + enable "Dismiss stale pull request approvals" in Settings → Branches.
+
+## Pre-deploy checklist
+
+Before merging to `main`:
+
+- [ ] `npm run lint` ✅
+- [ ] `npm run test` ✅ (Vitest)
+- [ ] `npm run build` ✅ (local build succeeds)
+- [ ] **UI/visual change:** `npm run audit:a11y` ✅ (WCAG 2.1 AA)
+- [ ] **E2E-relevant change:** Playwright specs pass locally
+- [ ] New env vars documented in `docs/INFRA.md` + set in Netlify (prod scope)
+- [ ] **DB migration:** new `.sql` in `supabase/migrations/` → **applied manually to prod** (Netlify doesn't run migrations)
+
+## Database migrations (manual)
+
+Netlify does **not** run migrations — they're applied manually to the prod Postgres:
+
+1. New migration file lands in `supabase/migrations/` (e.g. `008_credits.sql`).
+2. After merge to `main`, apply it to the prod Supabase/Postgres via SQL editor or `psql`.
+3. Verify with a smoke test on the affected flow.
+
+> ⚠️ **`npm run db:reset`** (local) drops the schema and replays **only `001_init.sql`**. Migrations 002–008 must be applied manually after reset. Do not run `db:reset` against prod.
+
+## Environment variables
+
+Prod env vars are set in Netlify: **Site settings → Environment variables**. Variables that differ between deploy contexts (`deploy-preview` vs `production`) must be scoped per-context.
+
+See `docs/INFRA.md` for the full list. Critical ones:
+
+| Var | Prod value |
+|-----|------------|
+| `DATABASE_URL` / `SUPABASE_DATABASE_URL` | Prod Postgres connection string |
+| `SUPABASE_SERVICE_ROLE_KEY` | Service role key (server-only, never `PUBLIC_`) |
+| `BETTER_AUTH_SECRET` | Strong random secret |
+| `BETTER_AUTH_URL` | `https://omf-therapie.fr` |
+| `STRIPE_SECRET_KEY` | `sk_live_…` |
+| `STRIPE_WEBHOOK_SECRET` | `whsec_…` (live) |
+| `RESEND_API_KEY` | Prod Resend key |
+| `GOOGLE_CALENDAR_*` / `GOOGLE_OAUTH_*` | Service account / OAuth creds |
+| `GOOGLE_CALENDAR_MOCK` | `false` in prod |
+
+## Stripe webhook (prod)
+
+- **Endpoint:** `https://omf-therapie.fr/api/stripe-webhook`
+- **Events:** payment confirmation → status `payment_received`.
+- Configure in Stripe Dashboard → Webhooks → Add endpoint with the live URL + `STRIPE_WEBHOOK_SECRET`.
+
+## DNS / redirects
+
+- Legacy SPA paths (`/Tarifs`, `/Services`, `/About`, `/Process`, `/Formations`) redirected via `[[redirects]]` in `netlify.toml`.
+- Sitemap (`@astrojs/sitemap`) auto-generated at build, filtered to exclude legacy paths.
+
+## Post-deploy verification
+
+After a deploy:
+
+1. Visit `https://omf-therapie.fr/` — homepage loads, no console errors.
+2. Test the booking wizard end-to-end (`/rendez-vous/`).
+3. If auth-related: log in at `/login/` → `/mes-rdvs/` loads.
+4. If Stripe-related: confirm webhook receives events (Stripe Dashboard → Webhooks → logs).
+5. If migration applied: smoke-test the affected flow.
+
+## Rollback
+
+- Netlify keeps deploy history — **Deploys** tab → "Publish" a previous deploy to roll back instantly.
+- For DB changes: have a down-migration or backup ready before applying prod migrations.
+
+## AI Quick Reference
+
+- **ALWAYS** apply new DB migrations manually to prod after merge (Netlify doesn't run them).
+- **NEVER** run `npm run db:reset` against prod (drops schema, only replays `001_init.sql`).
+- **ALWAYS** set new env vars in Netlify with the correct scope (`production` vs `deploy-preview`).
+- **NEVER** prefix server-only env vars with `PUBLIC_` (they'd ship to the client).
+- **ALWAYS** confirm `GOOGLE_CALENDAR_MOCK=false` in prod (otherwise fictional slots).
+- **ALWAYS** require `CI / build` green before merge (after branch protection is enabled).

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -1,0 +1,114 @@
+# Troubleshooting
+
+> Common issues and fixes. For local dev setup see `docs/LOCAL_DEV.md`; for prod infra see `docs/INFRA.md`.
+
+## Local dev
+
+### `Unexpected token '<'` in a fetch response
+
+**Cause:** missing trailing slash on the URL (ADR-013). Astro returns an HTML redirect page instead of JSON.
+
+**Fix:** ensure every `fetch()` and `window.location.href` ends with `/`:
+```ts
+fetch("/api/appointments/", { ... })              // ✅
+fetch(`/api/appointments/${id}/`, { ... })        // ✅
+```
+
+> Note: `astro.config.mjs` has `trailingSlash: 'ignore'` but ADR-013 + the codebase enforce `'always'`. Follow the convention.
+
+### BetterAuth `INVALID_ORIGIN` at login
+
+**Symptom:** `{"message":"Invalid origin","code":"INVALID_ORIGIN"}`.
+
+**Cause:** browser connects via `http://localhost:4321` but `BETTER_AUTH_URL=http://127.0.0.1:4321` (different origins).
+
+**Fix:** both origins are in `trustedOrigins` (`src/lib/auth.server.ts`). Set `BETTER_AUTH_URL=http://localhost:4321` in `.env`.
+
+### Database won't start
+
+```bash
+docker compose logs postgres
+# If SQL error on startup: drop volume and recreate
+docker compose down -v && docker compose up -d
+```
+
+### `auth.handler()` returns 500
+
+Verify `DATABASE_URL` in `.env` points to `localhost:5432` and Docker is running:
+```bash
+docker compose ps   # postgres must be "healthy"
+```
+
+### Emails not arriving
+
+Open **Mailpit** at `http://localhost:8025`. Verify `SMTP_HOST=localhost` and `SMTP_PORT=1025` in `.env`.
+
+### RDV slots empty
+
+Verify `GOOGLE_CALENDAR_MOCK=true` in `.env`. In mock mode, only **Wednesdays** have available slots.
+
+### Stripe payments not working
+
+With `STRIPE_SECRET_KEY=sk_test_placeholder`, **Stripe mock mode** is active — payment links are fictional, no real API calls. To test the real flow, get test keys at [dashboard.stripe.com/test/apikeys](https://dashboard.stripe.com/test/apikeys).
+
+### `db:reset` didn't apply later migrations
+
+`npm run db:reset` only replays `001_init.sql`. Migrations `002`–`008` (including `008_credits.sql` for the avoir system) must be applied manually:
+```bash
+docker compose exec postgres psql -U postgres -d omf_therapie -f /path/to/migrations/008_credits.sql
+```
+Or apply each in order after reset.
+
+### Avoirs / credits flow broken locally
+
+The credits system (`008_credits.sql`) must be applied. After `db:reset`, manually apply `002` through `008`. Symptoms: `consume_credits` RPC not found, `credits` table missing, `credit_applied` column absent.
+
+## CI
+
+### Typecheck fails with ~20 errors but CI is green
+
+This is expected (PR #85). Typecheck runs as `typecheck-advisory` with `continue-on-error: true`. The 20 residual errors are library-typing mismatches (googleapis, better-auth, stripe version drift, react-email) tracked in issue #68. Don't add **new** type errors; fixing existing ones is appreciated but out of scope for most PRs.
+
+### `.nvmrc` or `.github/workflows/ci.yml` missing locally
+
+Your local `main` is behind `origin/main`. Run `git pull` / rebase. These files exist on `origin/main` (merged in PR #85).
+
+### CI build job fails on `npm install`
+
+Likely `package-lock.json` desync. Reconcile with `npm install` (don't delete the lockfile). PR #66 reconciled a prior desync.
+
+## Build
+
+### `astro build` fails on `react-router-dom` / `react-helmet-async`
+
+These legacy deps are no longer installed but referenced by old components. `astro.config.mjs` aliases them to `/dev/null` to suppress errors. Don't reintroduce them — if you hit this, you've likely imported a legacy component that should be migrated.
+
+### `framer-motion` SSR/hydration race (opacity:0 content stuck invisible)
+
+Use `client:idle` instead of `client:load` for below-fold motion sections. The race: `opacity:0` initial state becomes visible before JS hydrates. `client:idle` avoids this.
+
+## Production
+
+### Deploy succeeded but page 404s
+
+Check `netlify.toml` redirects — legacy SPA paths (`/Tarifs`, `/Services`, etc.) are redirected. If you created a new page at one of these paths, the redirect wins. Use a different URL.
+
+### Stripe webhook not updating status
+
+1. Stripe Dashboard → Webhooks → check if events are being delivered (200 response).
+2. Verify `STRIPE_WEBHOOK_SECRET` matches the live endpoint's signing secret.
+3. Check Netlify function logs for `/api/stripe-webhook` errors.
+
+### Google Calendar sync broken (prod)
+
+Likely OAuth token expired. The `CalendarAuthAlert` email notifies when auth fails. Re-authorize via `/mes-rdvs/` → Google Calendar reconnect flow (`api/admin/google-oauth/`).
+
+## AI Quick Reference
+
+- **ALWAYS** check for missing trailing `/` first when debugging `Unexpected token '<'` errors.
+- **ALWAYS** apply migrations 002–008 manually after `npm run db:reset` (only `001_init.sql` is replayed).
+- **NEVER** delete `package-lock.json` to fix install errors — run `npm install` to reconcile.
+- **ALWAYS** check `GOOGLE_CALENDAR_MOCK` value when slots behave unexpectedly (mock = Wednesdays only).
+- **ALWAYS** suspect local `main` drift when CI/nvmrc files are missing locally (run `git pull`).
+- **NEVER** reintroduce `react-router-dom` or `react-helmet-async` — they're legacy, aliased to `/dev/null`.
+- **PREFER** `client:idle` over `client:load` for below-fold framer-motion sections (avoids hydration race).

--- a/docs/processes/dev-process.md
+++ b/docs/processes/dev-process.md
@@ -1,0 +1,101 @@
+# Development Process
+
+> How work flows through omf-therapie. For issue/PR conventions see `issue-management.md`; for review checklist see `../standards/code-review.md`.
+
+## Branching
+
+- **`main`** — production. Auto-deploys to omf-therapie.fr via Netlify on merge.
+- **Feature branches** — `feat/<issue#>-<slug>` (e.g. `feat/63-admin-annulation-avoir-credit-rdv`). Branch from `main`, merge via PR.
+- **Bugfix branches** — `fix/<issue#>-<slug>` or `fix/<slug>`.
+- **Doc branches** — `docs/<slug>`.
+
+> **Always branch from `main`** — don't commit directly. CI gate (`CI / build`) must pass before merge.
+
+## Dev-core workflow (frame → spec → plan → implement)
+
+Larger features follow the dev-core artifact lifecycle. Each phase produces an artifact in `artifacts/`:
+
+| Phase | Tool | Artifact location | Output |
+|-------|------|-------------------|--------|
+| 1. Intent | GitHub issue | (issue body) | Problem statement + acceptance criteria |
+| 2. Frame | `/frame` | `artifacts/frames/<N>-*.mdx` | Scope, options, decision |
+| 3. Spec | `/spec` | `artifacts/specs/<N>-*.mdx` | Approved requirements |
+| 4. Plan | `/plan` | `artifacts/plans/<N>-*.mdx` | Sliced implementation plan |
+| 5. Implement | `/implement` | (feature branch) | Code + commits |
+| 6. PR | `/pr` | GitHub PR | Review + merge |
+
+Artifacts are committed to the repo (in the feature branch) so context travels with the code.
+
+### When to use the full workflow
+
+- **Full lifecycle:** medium-large features (multiple slices, architectural decisions, new domain). Recent examples: #63 (avoirs), #67 (CI), #68 (Stripe idempotency).
+- **Lightweight (`/dev` or direct):** trivial fixes, typos, one-line config changes. Recent example: cookieYes/GA4 fixes.
+
+If unsure, default to at least a `/frame` — it surfaces scope before code is written.
+
+## Commit conventions
+
+- **French, present tense:** "Ajoute" not "Ajouté".
+- **Conventional prefix** (lowercase): `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`, `ci:`.
+- **Scope optional but encouraged:** `feat(admin):`, `fix(#63):`, `docs(plan):`.
+- **Reference issue** in the subject or body: `fix(#63): report thérapeute sans contrainte d'horaires`.
+- **Co-authored commits** are standard practice for AI pair programming.
+
+Examples from `git log`:
+```
+fix(ci): add lint+test+build pipeline with typecheck advisory (#67)
+feat(#63): annulation/report RDV + système d'avoir interne (#66)
+feat(admin): refonte /mes-rdvs — liste compacte, recherche et groupes par date (#65)
+docs: synchronisation doc PRs #85, #66, #65
+```
+
+## PR conventions
+
+- **Branch → `main`** via GitHub PR.
+- **Title:** conventional-commit format, French.
+- **Body:** Résumé (what + why), Changements (file-by-file table), Vérifications (lint/typecheck/test/build results), Test Plan (checklist), Lifecycle table (if dev-core flow).
+- **Close the issue** in the body: `Fixes #N` or `Closes #N`.
+- **Verification line required:** `✅ npm run lint`, `✅ npm run test`, `✅ npm run build`, and (for UI) `✅ npm run audit:a11y`.
+
+## Local dev loop
+
+```bash
+git pull origin main                           # avoid drift
+git checkout -b feat/<issue#>-<slug>
+npm install                                    # if deps changed
+npm run db:start                               # Postgres + Mailpit
+npm run dev -- --port 4321                     # Astro dev server
+
+# In another terminal:
+npm run test:watch                             # Vitest
+npm run audit:a11y                             # before UI PRs
+npx playwright test --project=chromium         # for e2e changes
+```
+
+## Before merging
+
+- [ ] `npm run lint` ✅
+- [ ] `npm run test` ✅
+- [ ] `npm run build` ✅
+- [ ] `npm run audit:a11y` ✅ (UI changes)
+- [ ] PR description complete + `Fixes #N`
+- [ ] DB migration (if any) ready to apply to prod post-merge
+- [ ] New env vars (if any) documented + ready to set in Netlify
+
+## Post-merge
+
+- [ ] **DB migration applied to prod** (Netlify doesn't run them).
+- [ ] New env vars set in Netlify (production scope).
+- [ ] Smoke-test the deployed flow on omf-therapie.fr.
+- [ ] Close any tracking issue if not auto-closed.
+
+## AI Quick Reference
+
+- **ALWAYS** branch from `main` — never commit directly to `main`.
+- **ALWAYS** write commit messages in **French, present tense** with a conventional prefix.
+- **ALWAYS** reference the issue (`Fixes #N`) in the PR body.
+- **ALWAYS** apply DB migrations manually to prod after merge.
+- **ALWAYS** report verification results (`lint`/`test`/`build`/`audit:a11y`) in the PR body.
+- **PREFER** the dev-core `/frame → /spec → /plan → /implement` flow for medium-large features.
+- **ALWAYS** run `git pull` before branching (local `main` drifts from `origin/main`).
+- **NEVER** assume CI/nvmrc files are present locally — verify after `git pull`.

--- a/docs/processes/issue-management.md
+++ b/docs/processes/issue-management.md
@@ -1,0 +1,86 @@
+# Issue Management
+
+> How GitHub issues are triaged and tracked for omf-therapie. For the dev workflow see `dev-process.md`.
+
+## Issue lifecycle
+
+```
+Open → Triaged (label + priority) → In Progress (branch linked) → PR → Merged → Closed
+```
+
+Issues are the **source of truth for intent**. Every non-trivial change starts as an issue.
+
+## Labels
+
+omf-therapie uses GitHub labels for triage. Conventional categories:
+
+| Label group | Examples | Purpose |
+|-------------|----------|---------|
+| Type | `bug`, `feature`, `enhancement`, `docs`, `chore`, `ci` | What kind of work |
+| Priority | `P1` (urgent), `P2` (next), `P3` (backlog) | Scheduling |
+| Size | `S`, `M`, `L` | Effort estimate |
+| Scope | `admin`, `booking`, `payment`, `a11y`, `seo`, `infra` | Affected domain |
+| Status | `blocked`, `needs-info`, `wontfix` | State beyond open/closed |
+
+> If labels are missing in the repo, infer from issue title/body. Recent issues use the `#<N>` convention in titles (`#63`, `#67`, `#68`) and "Size: M" notation.
+
+## Triage rules
+
+- **New issue →** acknowledge within a session; assign type + priority + size.
+- **`P1`** = production broken or security; preempts other work.
+- **`P2`** = next up (planned for the current week/cycle).
+- **`P3`** = backlog (valuable but not urgent).
+- **`needs-info`** → ping the requester; don't start work until clarified.
+- **`blocked`** → note the blocker in a comment; unblock before resuming.
+
+## Linking issues to PRs
+
+- **Branch name:** `feat/<issue#>-<slug>` or `fix/<issue#>-<slug>`.
+- **PR body:** `Fixes #N` (auto-closes on merge) or `Closes #N`.
+- **Commit subject:** reference the issue (`fix(#63): …`).
+- **One issue per PR** when feasible. If a PR closes multiple issues, list all (`Fixes #63, closes #64`).
+
+## Naming convention (observed)
+
+Recent issues follow a structured title format:
+- `#63` — annulation/report RDV + système d'avoir interne
+- `#67` — fix(ci): add lint + typecheck + test + build pipeline with branch protection
+- `#68` — Stripe payment confirmation reconciliation + idempotency
+
+PR titles echo the issue but with a conventional prefix and the issue number in parentheses:
+- `feat(#63): annulation/report RDV + système d'avoir interne (#66)`
+
+## Dev-core artifacts
+
+Larger issues produce artifacts in `artifacts/` (committed to the feature branch):
+
+| Artifact | Path | When |
+|----------|------|------|
+| Analysis | `artifacts/analyses/<N>-*.mdx` | Expert review / risk assessment (optional) |
+| Frame | `artifacts/frames/<N>-*.mdx` | Scope + options + decision |
+| Spec | `artifacts/specs/<N>-*.mdx` | Approved requirements |
+| Plan | `artifacts/plans/<N>-*.mdx` | Sliced implementation plan |
+
+The PR body's **Lifecycle table** links these artifacts so reviewers can trace the decision trail.
+
+## Closing issues
+
+- **Auto-close** via `Fixes #N` in the PR body (preferred).
+- **Manual close** with a comment explaining why (if closed without a PR, e.g. `wontfix`).
+- **Don't close** until the work is merged AND (if applicable) the migration/env vars are deployed.
+
+## Stale issues
+
+- Review open issues periodically.
+- Comment on issues with no activity for >1 cycle: "Still relevant?" → close if no response.
+- `needs-info` issues with no response after a reasonable period → close.
+
+## AI Quick Reference
+
+- **ALWAYS** create or reference an issue before starting non-trivial work.
+- **ALWAYS** use `Fixes #N` in the PR body to auto-close the issue on merge.
+- **ALWAYS** name branches `<type>/<issue#>-<slug>`.
+- **NEVER** close an issue before its PR is merged (and deployed, if it touches prod state).
+- **ALWAYS** assign type + priority + size labels during triage.
+- **ALWAYS** link dev-core artifacts (frame/spec/plan) in the PR body's Lifecycle table when they exist.
+- **PREFER** one issue per PR; list multiple `Fixes #N` only when genuinely coupled.

--- a/docs/standards/backend-patterns.md
+++ b/docs/standards/backend-patterns.md
@@ -1,0 +1,81 @@
+# Backend Patterns
+
+> Conventions for `src/pages/api/**` endpoints and `src/lib/**` server modules. Astro SSR via Netlify adapter (hybrid: `output: 'static'` + SSR API routes).
+
+## API route structure
+
+API routes live in `src/pages/api/` and export HTTP-method named functions:
+
+```ts
+import type { APIRoute } from "astro";
+
+export const GET: APIRoute = async ({ request, params }) => { /* ... */ };
+export const POST: APIRoute = async ({ request }) => { /* ... */ };
+export const PATCH: APIRoute = async ({ request, params }) => { /* ... */ };
+```
+
+**Routing:** Astro file-based. `src/pages/api/appointments/[id].ts` → `PATCH /api/appointments/:id/`. Dynamic segments use `[param]` syntax.
+
+## Database access
+
+- **No ORM** (stack.yml: `orm: none`). Raw SQL via `@supabase/supabase-js` (PostgREST) or `pg`.
+- Client: `src/lib/supabase.ts` — exports the singleton; import it, don't instantiate per-request.
+- Migrations: `supabase/migrations/*.sql`, sequenced (`001_init.sql` → `008_credits.sql`).
+- **`db:reset` only replays `001_init.sql`** — migrations 002–008 must be applied manually after.
+- Money: stored ×100 (centimes) as integers. Convert on read/write.
+
+## Auth & authorization
+
+- **BetterAuth** (`src/lib/auth.server.ts`) — session-based, PostgreSQL backend. Monocompte (one practitioner; `beforeUserCreated` blocks signups).
+- Session check pattern:
+  ```ts
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!isAdminSession(session)) return new Response("Unauthorized", { status: 401 });
+  ```
+- `src/pages/api/admin/**` — **always** verify session. No exceptions.
+- `src/pages/api/auth/[...all].ts` — BetterAuth handler (login, logout, session refresh).
+- Trusted origins declared in `auth.server.ts` (`trustedOrigins`): `localhost:4321` + `127.0.0.1:4321` for dev.
+
+## Cross-cutting concerns (import, never re-implement)
+
+| Concern | Lib | Symbol |
+|---------|-----|--------|
+| Admin session check | `src/lib/authz.ts` | `isAdminSession(session)` |
+| Rate limiting | `src/lib/rate-limit.ts` | `checkRateLimit(...)` |
+| Signed links | `src/lib/secure-links.ts` | `createSecureLinkToken(...)` |
+| Stripe | `src/lib/stripe.ts` | (domain-specific) |
+| Email transport | `src/lib/resend.ts` | (domain-specific) |
+| Google Calendar | `src/lib/google-calendar.ts` | (domain-specific) |
+
+Re-implementing any of these inside a business domain is the **layer-pollution anti-pattern** (ADR-001).
+
+## Idempotency & money
+
+- Stripe webhook: dedupe by event ID; treat `payment_received` as the idempotent "paid" state.
+- Avoir emission: idempotent via `UNIQUE(source_appointment_id)` constraint on `credits`.
+- Credit consumption: FIFO via `consume_credits` RPC (`SECURITY DEFINER`, `REVOKE EXECUTE FROM PUBLIC`) — atomic, no race.
+- Credit restoration: `restore_credits` RPC when an RDV created with an avoir is itself cancelled.
+
+## Error handling
+
+- Return `Response` with explicit status codes (`401`, `404`, `409`, `500`).
+- Never leak stack traces to the client — log server-side, return generic French message.
+- Validation: Zod for inbound payloads; reject early with `400` + French message.
+- Money/state errors: log + `409 Conflict` (don't silently succeed on inconsistent state).
+
+## Environment
+
+- All env access via `import.meta.env.*` (Astro convention), typed in `src/types/env.d.ts` if present.
+- Server-only vars (Supabase service role, Stripe secret, Resend key) must **never** be prefixed `PUBLIC_` — they'd ship to the client.
+- Mocks: `STRIPE_SECRET_KEY=sk_test_placeholder` → Stripe mock; `GOOGLE_CALENDAR_MOCK=true` → fictional Wednesday slots.
+
+## AI Quick Reference
+
+- **ALWAYS** verify the session in `src/pages/api/admin/**` via `auth.api.getSession()` + `isAdminSession()`.
+- **ALWAYS** use the singleton `supabase` client from `src/lib/supabase.ts` — never instantiate per-request.
+- **ALWAYS** apply migrations manually after `npm run db:reset` (only `001_init.sql` is replayed).
+- **NEVER** re-implement `isAdminSession`, `checkRateLimit`, `createSecureLinkToken` — import from canonical libs.
+- **NEVER** ship secrets: server-only env vars must not be prefixed `PUBLIC_`.
+- **NEVER** issue a real Stripe refund — emit an internal avoir instead.
+- **ALWAYS** make money/state mutations idempotent (unique constraint or RPC).
+- **ALWAYS** return explicit HTTP status codes with French user-facing messages on errors.

--- a/docs/standards/code-review.md
+++ b/docs/standards/code-review.md
@@ -1,0 +1,95 @@
+# Code Review
+
+> Checklist and conventions for reviewing PRs to omf-therapie. Reviewers should block on the items below; authors should self-check before requesting review.
+
+## Self-check before requesting review
+
+- [ ] `npm run lint` passes
+- [ ] `npm run test` passes (Vitest)
+- [ ] `npm run build` passes
+- [ ] `npm run typecheck` — note any new errors (advisory only; don't introduce new ones)
+- [ ] **UI/visual change:** `npm run audit:a11y` passes (WCAG 2.1 AA)
+- [ ] **E2E-relevant change:** relevant Playwright specs pass locally
+
+## Review checklist
+
+### Architecture (ADR-001)
+
+- [ ] New code extends an **existing layer** (`lib/`, `types/`, `pages/api/`, `components/`) — no new top-level `src/` directory.
+- [ ] A new domain is a **slice** (lib + types + api + component), not a layer proliferation.
+- [ ] Cross-cutting concerns (`isAdminSession`, `checkRateLimit`, `createSecureLinkToken`) are **imported**, not re-implemented.
+- [ ] No top-level `src/components/*.tsx` added (legacy pattern — use `src/components/{domain}/`).
+
+### Server/client boundary
+
+- [ ] `src/lib/**` is **not** imported from any client-shipped code (islands, client components).
+- [ ] Secrets/server env vars are **not** prefixed `PUBLIC_`.
+
+### Auth & security
+
+- [ ] Every endpoint under `src/pages/api/admin/**` verifies the session via `auth.api.getSession()` + `isAdminSession()`.
+- [ ] No real Stripe refund — internal avoir used instead (ADR-015).
+- [ ] Money mutations are idempotent (unique constraint or RPC).
+- [ ] User input validated (Zod or explicit checks) before use.
+
+### Conventions
+
+- [ ] **Trailing slash** on every client-side URL (fetch, `window.location.href`, `<a href>`) — ADR-013.
+- [ ] **User-facing text in French**; code/types/comments in English.
+- [ ] **Commit messages in French**, present tense ("Ajoute" not "Ajouté").
+- [ ] Function declarations for exported React components (not arrow functions).
+- [ ] Tailwind utility-first; no custom CSS outside `src/index.css`; no inline styles except dynamic values.
+- [ ] `client:idle` preferred for below-fold islands; no `client:visible` + `useMotionVariants`.
+
+### Data & state
+
+- [ ] `payment_received` used for paid RDVs (not `confirmed`).
+- [ ] Status transitions follow the state machine (see `architecture/patterns.md`).
+- [ ] DB migrations applied manually if testing locally (`db:reset` only replays `001_init.sql`).
+- [ ] Money stored ×100 (centimes); converted on read/write.
+
+### Accessibility
+
+- [ ] Semantic HTML (`<nav>`, `<main>`, `<article>`, `<section>`).
+- [ ] ARIA labels on icon buttons; `aria-labelledby`/`describedby` where needed.
+- [ ] Keyboard navigation works (tab order, focus indicators, skip-links).
+- [ ] Alt text: descriptive for meaningful images, empty for decorative.
+
+### Tests
+
+- [ ] New `src/lib/**` business logic has unit tests (pure module preferred).
+- [ ] Status/eligibility/credits changes covered by `tests/unit/`.
+- [ ] No real network calls in unit tests (mocked at module boundary).
+
+## Common blockers
+
+| Issue | Why it blocks |
+|-------|---------------|
+| Missing trailing `/` on a fetch | Causes `Unexpected token '<'` in prod (HTML redirect returned instead of JSON) |
+| `lib/` import in an island | Ships server code/secrets to browser |
+| Missing session check in `api/admin/**` | Security hole — unauthenticated admin actions |
+| Real Stripe refund code | Violates ADR-015; should be internal avoir |
+| Re-implemented `isAdminSession` etc. | Layer-pollution anti-pattern (ADR-001) |
+| New top-level `src/components/*.tsx` | Legacy pattern; should be `src/components/{domain}/` |
+| `dark:` Tailwind variants | Dark mode not implemented |
+| framer-motion for continuous animation | Use `animate-spin`; framer-motion continuous anims are heavy |
+| Stale `confirmed` for paid video RDV | Should be `payment_received` |
+
+## Artifact lifecycle (dev-core workflow)
+
+If the PR follows the dev-core `/frame → /spec → /plan → /implement` flow:
+
+- [ ] Frame, spec, plan artifacts exist in `artifacts/{frames,specs,plans}/` and are marked approved.
+- [ ] PR description links the issue and lists verification results (lint/typecheck/test/build status).
+- [ ] Issue closed via "Fixes #N" in the PR body.
+
+## AI Quick Reference
+
+- **ALWAYS** verify the trailing-slash rule on every modified/added `fetch()` or navigation.
+- **ALWAYS** block on missing session checks in `src/pages/api/admin/**`.
+- **ALWAYS** block on `lib/` imports inside client-shipped code.
+- **NEVER** approve a real Stripe refund — redirect to internal avoir (ADR-015).
+- **NEVER** approve re-implementation of `isAdminSession`/`checkRateLimit`/`createSecureLinkToken`.
+- **ALWAYS** require `npm run audit:a11y` for UI/visual changes.
+- **ALWAYS** confirm `payment_received` (not `confirmed`) is used for paid video RDVs.
+- **ALWAYS** check that a new domain is a slice, not a new top-level directory.

--- a/docs/standards/frontend-patterns.md
+++ b/docs/standards/frontend-patterns.md
@@ -1,0 +1,115 @@
+# Frontend Patterns
+
+> Conventions for `src/components/`, `src/hooks/`, `src/layouts/`, and `src/pages/**.astro`. Astro Islands Architecture with React hydration.
+
+## File organization
+
+| Type | Location | Naming | Example |
+|------|----------|--------|---------|
+| Astro page | `src/pages/` | kebab-case `.astro` | `rendez-vous.astro` |
+| Astro component | `src/components/{domain}/` | PascalCase `.astro` | `home/HeroSection.astro` |
+| React island | `src/components/islands/` | PascalCase `.tsx` | `Navbar.tsx` |
+| React component | `src/components/{domain}/` | PascalCase `.tsx` | `admin/AppointmentCard.tsx` |
+| Hook | `src/hooks/` | camelCase, `use` prefix | `useContactForm.ts` |
+| Layout | `src/layouts/` | PascalCase `.astro` | `ServiceLayout.astro` |
+| Type | `src/types/` | camelCase `.ts` | `appointment.ts` |
+| Util | `src/utils/` | camelCase `.ts` | `date.ts` |
+
+**Co-locate by domain** (ADR-001): a feature's components live in `src/components/{domain}/`, not scattered. Top-level `src/components/*.{astro,tsx}` is legacy (`Footer.tsx`, `SEO.tsx`) — don't add new ones.
+
+## Component structure (React)
+
+```tsx
+// 1. Imports: React → third-party → local
+import { useState } from "react";
+import { motion } from "framer-motion";
+import { BlogPost } from "../types/blog";
+
+// 2. Props interface
+interface ComponentProps {
+  title: string;
+  onSubmit: () => void;
+}
+
+// 3. Function declaration (not arrow for exports)
+export default function Component({ title, onSubmit }: ComponentProps) {
+  // 4. Hooks
+  const [state, setState] = useState("");
+  // 5. Handlers (handle prefix)
+  const handleClick = () => { /* ... */ };
+  // 6. Effects
+  useEffect(() => { /* ... */ }, []);
+  // 7. Return JSX
+  return <div>{/* ... */}</div>;
+}
+```
+
+- **Function declarations** for exported components (not arrow functions).
+- **Destructure props** in parameters; define `Props` interface.
+- **Handler prefix:** `handle*` (`handleSubmit`, `handleClick`).
+
+## Hydration directives
+
+| Directive | Use when |
+|-----------|----------|
+| `client:load` | Above-fold, hydrate immediately (Navbar, contact form) |
+| `client:idle` | Below-fold — **preferred default** |
+| `client:visible` | Lazy on viewport entry — **avoid with `useMotionVariants`** (visible snap on mobile) |
+
+Only `src/components/islands/*` (and React components reached through them) receive `client:*`.
+
+## Styling (Tailwind)
+
+- **Utility-first only.** No custom CSS except base styles in `src/index.css`.
+- **No inline styles** except for dynamic values.
+- **Class organization** (order matters for readability):
+  ```tsx
+  <div className="
+    flex flex-col           // Layout
+    p-4 gap-2              // Spacing
+    text-lg font-semibold  // Typography
+    bg-white text-gray-900 // Colors
+    md:flex-row md:p-6     // Responsive
+  " />
+  ```
+- **Dark mode:** not implemented. Don't add `dark:` variants.
+
+## Animation (`framer-motion`)
+
+- Use `useMotionVariants` hook (respects `prefers-reduced-motion`).
+- **Touch / WKWebView** (iOS Messages): animations auto-disabled — hook returns `staticProps` (no IntersectionObserver, no WAAPI).
+- **Continuous animations** (spinners): use Tailwind `animate-spin` — **never** framer-motion.
+- Disable on `hover: none` + `pointer: coarse` devices.
+
+## Routing & links
+
+- Astro file-based: each `.astro` in `src/pages/` = one URL.
+- **Trailing slash required** on every client-side URL (ADR-013): `<a href="/services/">`, `fetch("/api/foo/")`, `window.location.href = "/mes-rdvs/"`.
+- Legacy SPA paths (`/Tarifs`, `/Services`, `/About`, `/Process`, `/Formations`) are redirected in `netlify.toml` — don't recreate them.
+- Sitemap filter in `astro.config.mjs` excludes those legacy paths.
+
+## State management
+
+- **No global state library.** `useState` + custom hooks + props drilling (sufficient at current scale).
+- Persistence: `sessionStorage['mes-rdvs-filter']` for admin filter state. Match this pattern for ephemeral UI state.
+
+## Accessibility (WCAG 2.1 AA — mandatory)
+
+- **Semantic HTML:** `<nav>`, `<main>`, `<article>`, `<section>` — not `<div>` soup.
+- **ARIA:** `aria-label` on icon buttons, `aria-labelledby`/`aria-describedby` for complex labels.
+- **Keyboard:** logical tab order, visible focus indicators, skip-links for main content.
+- **Alt text:** descriptive for meaningful images, empty `alt=""` for decorative.
+- **Test before PR:** `npm run audit:a11y` (pa11y, needs dev server running).
+
+## AI Quick Reference
+
+- **ALWAYS** co-locate components in `src/components/{domain}/` — never top-level `src/components/`.
+- **ALWAYS** use function declarations for exported React components (not arrow).
+- **ALWAYS** end internal links/fetches with a trailing `/` (ADR-013).
+- **PREFER** `client:idle` for below-fold islands; avoid `client:visible` with `useMotionVariants`.
+- **NEVER** add `dark:` Tailwind variants (dark mode not implemented).
+- **NEVER** use framer-motion for continuous animations — use Tailwind `animate-spin`.
+- **NEVER** use inline styles except for dynamic values; no custom CSS outside `src/index.css`.
+- **ALWAYS** use semantic HTML + ARIA + keyboard nav + alt text; run `npm run audit:a11y` before UI PRs.
+- **ALWAYS** write user-facing text in **French**; code/types/comments in English.
+- **ORGANIZE** Tailwind classes: layout → spacing → typography → colors → responsive.

--- a/docs/standards/testing.md
+++ b/docs/standards/testing.md
@@ -1,0 +1,99 @@
+# Testing
+
+> Test conventions for omf-therapie. Three layers: unit (Vitest), e2e (Playwright), accessibility audits (pa11y/Lighthouse).
+
+## Current state
+
+| Layer | Tool | Location | Status |
+|-------|------|----------|--------|
+| Unit / integration | Vitest | `tests/unit/**/*.test.ts` | Active (node env) |
+| E2E | Playwright | `e2e/*.spec.ts` | Active |
+| Accessibility | pa11y + Lighthouse | `npm run audit:a11y` | **Required before UI PRs** |
+
+> **Note:** `memory-bank/conventions.md` says "no automated tests" — that's **stale** (Jan 2025). Unit + e2e tests now exist.
+
+## Commands
+
+```bash
+npm run test              # Vitest run (tests/unit/**, node env)
+npm run test:watch        # Vitest watch
+npm run audit:a11y        # pa11y WCAG audit (needs dev server running)
+
+# Playwright (manual, not in package.json scripts)
+npx playwright test --project=chromium
+npx playwright test --headed -g "charge la page du wizard"
+```
+
+## Unit tests (Vitest)
+
+**Location:** `tests/unit/**/*.test.ts`  
+**Config:** `vitest.config.ts` — `environment: 'node'`, `setupFiles: ['tests/unit/setup.ts']` (stubs `import.meta.env`).  
+**Include pattern:** `tests/unit/**/*.test.ts`.
+
+### Conventions
+
+- **Describe/it naming:** describe the unit under test, `it` describes behavior.
+- **Pure modules preferred:** `src/lib/appointment-eligibility.ts` is a pure module specifically so it's unit-testable without Supabase/Stripe. Follow this pattern for new business logic.
+- **No network in unit tests:** stub `import.meta.env` in `setup.ts`; mock `supabase`/`stripe`/`google-calendar` at the module boundary.
+- **Co-locate fixtures** in `tests/unit/` if shared.
+
+### Example shape
+
+```ts
+// tests/unit/cancel-eligibility.test.ts
+import { describe, it, expect } from "vitest";
+import { isCancellableByTherapist } from "@/lib/appointment-eligibility";
+
+describe("isCancellableByTherapist", () => {
+  it("returns true for a confirmed RDV within the eligibility window", () => {
+    // ...
+  });
+});
+```
+
+## E2E tests (Playwright)
+
+**Location:** `e2e/*.spec.ts`  
+**Config:** `playwright.config.ts`.
+
+- **Selectors:** prefer data attributes (`[data-testid]`) over CSS/text selectors — they're stable across refactors. Existing tests use selectors like `[data-testid="tab-rendez-vous"]`.
+- **Auth:** e2e tests that need admin state should seed via the dev DB (`scripts/seed-admin.ts`) and log in through the UI flow.
+- **Headless by default** in CI; `--headed` for local debugging.
+
+### Current specs
+
+- `e2e/smoke.spec.ts` — page load smoke tests.
+- `e2e/manual-slots.spec.ts` — manual slot management flow.
+
+## Accessibility audits (mandatory)
+
+`npm run audit:a11y` runs pa11y against running URLs (dev server must be active on `:4321`).
+
+- **Reports:** `public/reports/latest/` — HTML index + per-URL JSON.
+- **WCAG 2.1 AA** is the target. Failures block UI PRs.
+- `npm run audit:lighthouse` — Lighthouse accessibility against production (`https://omf-therapie.fr`).
+
+## CI integration
+
+`.github/workflows/ci.yml` runs `npm run test` (Vitest) in the blocking `build` job. Playwright and pa11y are **not** in CI yet — run them locally before merging UI changes.
+
+## What to test
+
+| Change type | Required tests |
+|-------------|----------------|
+| `src/lib/**` business logic | Unit test (pure module if possible) |
+| Appointment status / eligibility | `tests/unit/appointment-eligibility.test.ts` pattern |
+| Credits / avoir math | `tests/unit/credits.test.ts` pattern |
+| Booking flow / admin UI | Playwright e2e + `npm run audit:a11y` |
+| Visual / a11y change | `npm run audit:a11y` (blocking) |
+| API endpoint | Unit test the handler logic; e2e for the full flow |
+
+## AI Quick Reference
+
+- **ALWAYS** write a unit test when adding pure business logic to `src/lib/` (e.g. eligibility, pricing math).
+- **ALWAYS** extract business rules into pure modules so they're unit-testable without network mocks.
+- **ALWAYS** run `npm run audit:a11y` before merging UI/visual changes (WCAG 2.1 AA is mandatory).
+- **PREFER** `[data-testid]` selectors in Playwright over CSS/text selectors.
+- **NEVER** hit real Supabase/Stripe/Google in unit tests — mock at the module boundary.
+- **NEVER** trust `memory-bank/conventions.md`'s "no automated tests" line — it's stale; tests exist.
+- **ALWAYS** stub `import.meta.env` in `tests/unit/setup.ts` before importing modules under test.

--- a/memory-bank/active-context.md
+++ b/memory-bank/active-context.md
@@ -1,39 +1,52 @@
 # Active Context
 
-**Last Updated:** May 14, 2026
+**Last Updated:** July 5, 2026
 
 This document tracks current work in progress, recent changes, and immediate next steps. Update this regularly to maintain continuity between development sessions.
 
 ## Current Status
 
-**Project State:** 🚀 Feature branch `feat/15-prise-de-rendez-vous` — PR #18 ouverte vers `main`
+**Project State:** ✅ `main` — 3 PRs mergées cette semaine (#85, #66, #65)
 
-**Recent Activity:** Système complet de prise de rendez-vous (issues #15, #21, #22, #24–#27) — tests E2E validés, artifacts mis à jour `implemented`, issues à fermer sur GitHub
+**Recent Activity:** CI pipeline en place, système d'avoirs interne livré, refonte de l'espace admin `/mes-rdvs/`.
 
-**Active Work:** PR #18 prête à merger — issues #21, #22, #24, #25, #26, #27 à fermer
+**Active Work:** Issue #68 — Stripe payment confirmation reconciliation + idempotency (frame ✅, spec ✅, plan ✅ — à implémenter). Dépendance : débloquer le typecheck bloquant (#68 trace aussi les ~20 erreurs de typage préexistantes).
 
-**Remaining (P2):** Issue #23 — Vue patients admin (historique + nouveau RDV pré-rempli) — pas encore commencé
+**Next:**
+- Appliquer `008_credits.sql` en production (tables `credits`/`credit_usages` + RPC + colonne `credit_applied`)
+- Activer la branch protection sur `CI / build` après le 1er run sur `main` (suivi de #85)
+- #68 — implémenter la réconciliation d'idempotencité Stripe
 
 ## Recent Changes
 
-### Mai 2026 — Système de prise de rendez-vous complet
+### Semaine du 29 juin – 5 juillet 2026
+
+- ✅ **#85** (PR merged) — CI pipeline GitHub Actions : job `build` bloquant (`lint → test → build`) + job `typecheck-advisory` non bloquant. Ajoute `.nvmrc` (Node 20), script `typecheck`, devDep `@astrojs/check`. Nettoie 13 des 33 erreurs de typage (les 20 restantes tracées dans #68).
+- ✅ **#66** (PR merged, ferme #63) — Annulation/report RDV + système d'avoir interne :
+  - Nouveau statut `cancelled` (action `cancel` dans `PATCH /api/appointments/[id]`) + email `AppointmentCancelled`.
+  - Avoir automatique sur annulation d'un RDV vidéo `payment_received` (cash réellement encaissé, idempotent via `UNIQUE(source_appointment_id)`). **Aucun Stripe refund.**
+  - Restitution d'avoir sur re-annulation d'un RDV créé avec avoir (`restore_credits`).
+  - Action `reschedule_paid` : report d'un RDV vidéo payé sans re-facturer (corrige la double-facturation du `reschedule` classique).
+  - Création manuelle avec avoir (admin) : case « Utiliser l'avoir » dans `AdminCreateButton`, consommation FIFO atomique (`consume_credits`).
+  - Migration `008_credits.sql` (tables `credits` + `credit_usages`, RPC FIFO, RLS service_role-only).
+  - Statut unifié : `payment_received` = « réglé » (Stripe ou avoir).
+- ✅ **#65** (PR merged, ferme #64) — Refonte `/mes-rdvs/` : îlot React `<AppointmentsManager>` (liste compacte ~56 px/ligne, recherche instantanée via `useDeferredValue`, partition À venir / Passés, regroupement par jour). Corrige `google_calendar_event_id` et `patient_city` absents de la projection SQL. Gain : scroll d'ouverture ~35 000 px → ~3 500 px.
+
+### Migration à appliquer en prod
+
+`008_credits.sql` (post-merge de #66) — créer les tables/RPC + colonne `appointments.credit_applied`. À exécuter manuellement en prod et en local (`npm run db:reset` ne rejoue que `001_init.sql`).
+
+### Mai 2026 — Système de prise de rendez-vous complet (historique)
 
 Issues implémentées et testées E2E (Playwright MCP) :
 
-- ✅ **#15** — Wizard patient multi-étapes (`/rendez-vous/`) : type, mode, durée, créneau, infos, confirmation
-- ✅ **#21** — Contrôle des tarifs admin : remise nouveau client & tarif solidaire (cases à cocher mutuellement exclusives dans modal de confirmation)
-- ✅ **#22** — Création manuelle de RDV par l'admin (`/mes-rdvs/` → bouton "Nouveau rendez-vous")
-- ✅ **#24** — Remise nouveau client disponible aussi dans AdminCreateButton
-- ✅ **#25** — Génération automatique Google Meet via `src/lib/google-calendar.ts` (mock local, Google Calendar API en prod)
-- ✅ **#26** — Flow acceptation report patient : page `/rdv/accepter-report/[id]/`, email prépaiement (télé) ou confirmation directe (présentiel), action `cancel_reschedule` pour l'admin
-- ✅ **#27** — Blocage des créneaux dès statuts actifs (`confirmed`, `payment_pending`) — pas pour `pending`
-
-### Bugs corrigés durant les tests
-
-- Trailing slashes manquants dans `accepter-report.astro` et `AdminCreateButton.tsx`
-- `cancel_reschedule` absent de la whitelist dans `appointments/[id].ts`
-- AdminCreate 500 : colonnes NOT NULL manquantes dans l'insert (`patient_postal_code`, `patient_city`, `base_price`)
-- `.playwright-mcp/` et `test-booking.cjs` exclus du tracking git
+- ✅ **#15** — Wizard patient multi-étapes (`/rendez-vous/`)
+- ✅ **#21** — Contrôle des tarifs admin : remise nouveau client & tarif solidaire
+- ✅ **#22** — Création manuelle de RDV par l'admin
+- ✅ **#24** — Remise nouveau client dans `AdminCreateButton`
+- ✅ **#25** — Génération Google Meet via `src/lib/google-calendar.ts`
+- ✅ **#26** — Flow acceptation report patient (page `/rdv/accepter-report/[id]/`)
+- ✅ **#27** — Blocage des créneaux dès statuts actifs
 
 ## Infrastructure locale
 
@@ -45,4 +58,4 @@ Issues implémentées et testées E2E (Playwright MCP) :
 
 ## Current Branch
 
-**Branch:** feat/15-prise-de-rendez-vous → PR #18 → main
+**Branch:** `main` (clean) — dernières PRs : #85, #66, #65 toutes mergées.

--- a/memory-bank/architecture.md
+++ b/memory-bank/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-**Last Updated:** May 14, 2026
+**Last Updated:** July 5, 2026
 
 ## Project Structure
 
@@ -13,7 +13,7 @@ omf-therapie/
 │   └── robots.txt            # Search engine directives
 ├── src/
 │   ├── components/           # Astro + React components
-│   │   ├── admin/           # Admin dashboard (AppointmentCard, AdminCreateButton)
+│   │   ├── admin/           # Admin dashboard (AppointmentCard, AdminCreateButton, AppointmentsManager)
 │   │   ├── blog/            # Blog-specific components
 │   │   ├── common/          # Shared components
 │   │   ├── contact/         # Contact page components
@@ -29,9 +29,19 @@ omf-therapie/
 │   ├── hooks/               # Custom React hooks (used in islands only)
 │   ├── layouts/             # Astro layouts (Layout.astro, ServiceLayout.astro)
 │   ├── lib/                 # Server-side libraries
+│   │   ├── appointment-conflicts.ts  # Slot-conflict detection
+│   │   ├── appointment-eligibility.ts  # Cancel/reschedule eligibility (pure module)
 │   │   ├── auth.server.ts  # BetterAuth configuration
+│   │   ├── authz.ts        # Authorization checks
+│   │   ├── calendar-cache.ts  # Google Calendar caching
+│   │   ├── credits.ts      # Internal credit (avoir) system — FIFO consumption
 │   │   ├── google-calendar.ts  # Google Calendar / Meet link generation
+│   │   ├── ics.ts          # .ics calendar file generation
+│   │   ├── manual-slots.ts # Manual slot overrides
 │   │   ├── pricing.ts      # Pricing calculation (basePrice, discount, finalPrice)
+│   │   ├── rate-limit.ts   # API rate limiting
+│   │   ├── resend.ts       # Resend (prod) email transport
+│   │   ├── secure-links.ts # Signed-link generation for patient actions
 │   │   ├── stripe.ts       # Stripe payment links
 │   │   └── supabase.ts     # Supabase/PostgREST client
 │   ├── pages/               # Astro file-based routes
@@ -52,7 +62,7 @@ omf-therapie/
 │   └── utils/               # Utility functions (blogApi.ts, schema.ts)
 ├── scripts/                  # Utility scripts (seed-admin.ts)
 ├── supabase/
-│   └── migrations/          # PostgreSQL schema (001_init.sql)
+│   └── migrations/          # PostgreSQL schema (001_init.sql → 008_credits.sql)
 ├── docker-compose.yml        # Local dev infrastructure
 ├── memory-bank/             # Project knowledge repository
 └── artifacts/               # Dev workflow artifacts (frames, specs, plans)
@@ -73,7 +83,7 @@ omf-therapie/
 Patient                     Admin (Thérapeute)
    │                              │
    ▼                              ▼
-/rendez-vous/             /mes-rdvs/  (BetterAuth)
+/rendez-vous/             /mes-rdvs/  (BetterAuth) — liste compacte gérée par <AppointmentsManager>
    │                        │
    └── POST /api/appointments/       ← créé avec status=pending
               │
@@ -85,25 +95,27 @@ Patient                     Admin (Thérapeute)
   Mailpit (dev)     Resend (prod)
   Admin notif       Patient ack
               │
-              ▼ Admin action (confirm/decline/reschedule)
+              ▼ Admin action (confirm/decline/reschedule/cancel/reschedule_paid)
      PATCH /api/appointments/[id]/
               │
-    ┌─────────┼──────────┐
-    ▼         ▼          ▼
- confirm   decline   reschedule
-    │                    │
-    │              Email patient
-    │              (bouton "Accepter")
-    │                    │
-    │              /rdv/accepter-report/[id]/
-    ▼                    ▼
+    ┌─────────┬──────────┬───────────────┐
+    ▼         ▼          ▼               ▼
+ confirm   decline   reschedule       cancel / reschedule_paid
+    │                    │               │
+    │              Email patient         │ Annulation → email AppointmentCancelled
+    │              (bouton "Accepter")   │ Si RDV vidéo déjà payé → émission d'un avoir interne
+    │                    │               │ (statut `payment_received` + crédit final_price − credit_applied)
+    │              /rdv/accepter-report/[id]/   │ Report d'un RDV vidéo payé → action `reschedule_paid`
+    ▼                    ▼                       (paiement conservé, pas de nouveau lien Stripe)
 Email confirm      payment_pending (télé)
 (présentiel)       ou confirmed (présentiel)
     │                    │
     └────────────────────┘
               │
-    payment_pending → Stripe link → stripe-webhook → confirmed
+    payment_pending → Stripe link → stripe-webhook → payment_received (= "réglé", Stripe ou avoir)
 ```
+
+**Statuts unifiés (depuis #63/#66)** : `payment_received` = « séance réglée » (Stripe **ou** avoir) — remplace `confirmed` comme statut de paiement pour les RDV vidéo. `confirmed` reste pour le présentiel.
 
 ### Authentication
 
@@ -112,12 +124,19 @@ Email confirm      payment_pending (télé)
 - Login : `/login/` → `/mes-rdvs/` (redirect protégée)
 - API routes admin : vérifient `session.user` via `auth.api.getSession()`
 
+### CI / Quality Gates
+
+- **Workflow** `.github/workflows/ci.yml` (#85) : job `build` bloquant = `lint → test → build`. Job `typecheck-advisory` non bloquant (`continue-on-error: true`) qui surfacera les erreurs résiduelles (#68 suit les ~20 erreurs de typage préexistantes — googleapis, better-auth, stripe, react-email).
+- **Node** : `.nvmrc` pinne Node 20 (parité avec `netlify.toml`).
+- **Branch protection** (manuel) : après le 1er run sur `main`, exiger `CI / build` + « Dismiss stale pull request approvals ».
+
 ### Database (PostgreSQL 16)
 
-Schema défini dans `supabase/migrations/001_init.sql`. Table principale `appointments` :
-- Colonnes critiques NOT NULL : `patient_name`, `patient_email`, `patient_phone`, `patient_postal_code`, `patient_city`, `patient_reason`, `appointment_type`, `appointment_mode`, `duration`, `base_price`, `final_price`, `scheduled_at`
-- Statuts : `pending → confirmed | declined | rescheduled → payment_pending → confirmed | cancelled`
-- Créneaux bloqués : statuts `confirmed` et `payment_pending` uniquement (pas `pending`)
+Schema défini dans `supabase/migrations/` (`001_init.sql` → `008_credits.sql`). Table principale `appointments` :
+- Colonnes critiques NOT NULL : `patient_name`, `patient_email`, `patient_phone`, `patient_postal_code`, `patient_city`, `patient_reason`, `appointment_type`, `appointment_mode`, `duration`, `base_price`, `final_price`, `scheduled_at`, `credit_applied` (depuis `008_credits.sql`)
+- Statuts : `pending → confirmed | declined | rescheduled → payment_pending → payment_received | cancelled`
+- Créneaux bloqués : statuts `confirmed`, `payment_pending` et `payment_received` (pas `pending`)
+- **Système d'avoirs** (`008_credits.sql`, #63/#66) : tables `credits` + `credit_usages`, RPC `consume_credits` (FIFO atomique, `SECURITY DEFINER`) et `restore_credits` (restitution sur re-annulation). RLS service_role-only — l'émission et la consommation d'avoirs sont **admin-only** (aucune UI patient).
 
 ### Pricing
 
@@ -140,9 +159,13 @@ Templates React Email dans `src/emails/` :
 - `AppointmentConfirmed` — confirmation (présentiel ou télé après paiement)
 - `AppointmentDeclined` — refus
 - `AppointmentRescheduled` — proposition nouveau créneau
-- `AdminNewAppointment` — notification admin
-- `PaymentRequest` — demande de prépaiement (télé)
+- `AppointmentCancelled` — annulation par l'admin (mentionne l'avoir éventuel, **jamais** le mot « remboursement »)
+- `AppointmentRequestNotification` / `AppointmentRequestReceived` — notification admin / accusé patient
+- `AppointmentReminder` — rappel avant séance
+- `PaymentRequest` / `PaymentReminder` — demande / relance de prépaiement (télé)
+- `PaymentReceivedNotification` — confirmation d'encaissement
 - `ReviewRequest` — demande d'avis post-séance
+- `CalendarAuthAlert` — alerte technique (auth Google expirée)
 
 **Local** : Nodemailer → Mailpit (SMTP `localhost:1025`)  
 **Production** : Resend API
@@ -150,7 +173,9 @@ Templates React Email dans `src/emails/` :
 ### Stripe Integration
 
 - Paiement uniquement pour les téléconsultations (`appointment_mode = 'video'`)
-- Flow : admin confirme → création Payment Link Stripe → email patient → patient paie → webhook → `status = confirmed`
+- Flow : admin confirme → création Payment Link Stripe → email patient → patient paie → webhook → `status = payment_received`
+- **Statut unifié `payment_received`** (#63/#66) : « séance réglée » via Stripe **ou** avoir interne. L'action `reschedule_paid` reporte un RDV vidéo déjà payé sans régénérer de lien Stripe (corrige la double-facturation). L'action `cancel` sur un RDV `payment_received` émet un avoir interne — **aucun remboursement Stripe réel**.
+- **Création manuelle avec avoir** (admin) : déduction FIFO via `consume_credits` ; si le solde dû = 0 → `payment_received`/`confirmed` sans lien Stripe, sinon lien Stripe pour le reliquat uniquement.
 - **Local mock** : si `STRIPE_SECRET_KEY` est un placeholder, lien fictif généré (pas d'erreur)
 
 ## Data Flow
@@ -174,3 +199,5 @@ Templates React Email dans `src/emails/` :
 - **BetterAuth** : choisi pour session PostgreSQL native, pas de dépendance Supabase Auth
 - **PostgREST** : simule Supabase en local pour compatibilité SDK `@supabase/supabase-js`
 - **trailingSlash: 'always'** : tous les fetch() et redirects côté client DOIVENT inclure le slash final
+- **Avoirs internes plutôt que remboursements Stripe** (#63/#66) : annulation d'un RDV vidéo payé → avoir interne réutilisable (cash conservé). Aucun Stripe refund — `payment_received` = statut unifié « réglé ».
+- **CI bloquant, typecheck advisory** (#85) : lint+test+build ferment le merge ; typecheck reste advisory jusqu'à résolution de #68.

--- a/memory-bank/conventions.md
+++ b/memory-bank/conventions.md
@@ -1,6 +1,8 @@
 # Coding Conventions
 
-**Last Updated:** January 14, 2025
+**Last Updated:** July 5, 2026
+
+> ⚠️ **Note de révision** — ce fichier a été écrit pour l'ancienne stack React SPA (jan 2025). La migration vers **Astro 5 SSG + Islands** a remplacé plusieurs patterns ci-dessous (lazy loading par route, gestion SPA du state, tests absents). Les sections obsolètes sont marquées ; pour la version à jour voir `docs/standards/frontend-patterns.md`, `docs/standards/testing.md`, et `AGENTS.md`.
 
 ## Language & Tooling
 
@@ -311,8 +313,10 @@ try {
 
 ### Component Optimization
 
-- **Lazy load routes** with React.lazy()
-- **Code splitting** at route level
+> ⚠️ **Obsolète pour Astro** — Le lazy loading par route via `React.lazy()` concernait l'ancienne stack SPA. Sous Astro 5 SSG + Islands, le code splitting est géré automatiquement par le framework : chaque page `.astro` est pré-rendue statiquement, et React n'est hydraté que pour les îles (`client:load`/`client:idle`/`client:visible`). Ne pas utiliser `React.lazy()` pour le routing (qui n'existe plus — voir ADR-001). Voir `docs/standards/frontend-patterns.md` § Hydration directives.
+
+- ~~**Lazy load routes** with React.lazy()~~ → remplacé par Islands Architecture d'Astro
+- **Code splitting** automatique par Astro (une page = un chunk statique)
 - **Avoid premature optimization** - measure first
 
 ### Asset Optimization
@@ -329,17 +333,25 @@ try {
 
 ## Testing Conventions
 
+> ℹ️ **Mis à jour juillet 2026** — L'ancienne section "No automated tests" (jan 2025) est obsolète. Tests Vitest + Playwright désormais en place.
+
 ### Current State
 
-- **No automated tests** currently implemented
-- **Manual testing** for features
-- **Accessibility audits** via pa11y and Lighthouse
+- **Vitest** — tests unitaires / intégration dans `tests/unit/**` (env `node`). Couvre notamment `appointment-eligibility.ts`, `credits.ts`, `google-calendar.ts`.
+- **Playwright** — tests e2e dans `e2e/*.spec.ts` (`smoke.spec.ts`, `manual-slots.spec.ts`).
+- **pa11y + Lighthouse** — audits accessibilité WCAG 2.1 AA, **requis avant tout PR UI** (`npm run audit:a11y`).
+- **CI** (`.github/workflows/ci.yml`) — `lint → test → build` bloquant ; `typecheck` advisory (issue #68).
 
-### Future Recommendations
+### Commands
 
-- **Vitest** for unit tests
-- **React Testing Library** for component tests
-- **E2E tests** with Playwright/Cypress
+```bash
+npm run test              # Vitest run
+npm run test:watch        # Vitest watch
+npm run audit:a11y        # pa11y (nécessite le dev server)
+npx playwright test --project=chromium
+```
+
+Voir `docs/standards/testing.md` pour les conventions détaillées (modules purs, mocks au boundary, selectors `[data-testid]`).
 
 ## Documentation
 

--- a/memory-bank/decisions.md
+++ b/memory-bank/decisions.md
@@ -266,6 +266,54 @@ Each decision entry should include:
 
 ---
 
+## ADR-015: Avoirs internes plutôt que remboursements Stripe
+
+**Date:** Juillet 2026 (#63 / PR #66)
+
+**Context:** Lorsqu'un RDV vidéo déjà payé doit être annulé ou reporté, comment compenser le patient sans complexité comptable ni friction opérationnelle ?
+
+**Decision:** Émettre un **avoir interne** (tables `credits` / `credit_usages`, RPC FIFO `consume_credits`/`restore_credits`) plutôt qu'un remboursement Stripe. Le statut `payment_received` devient le statut unifié « séance réglée » (Stripe **ou** avoir). L'action `reschedule_paid` permet de reporter un RDV vidéo payé sans régénérer de lien Stripe.
+
+**Rationale:**
+
+- Évite les frais Stripe et la latence des refunds
+- L'argent reste chez le praticien ; le patient réutilise l'avoir sur un prochain RDV
+- Consommation FIFO atomique côté Postgres (`SECURITY DEFINER`, `REVOKE EXECUTE FROM PUBLIC`) — pas de race possible
+- Email d'annulation mentionne « avoir » mais jamais « remboursement » (gestion d'attente patient)
+
+**Consequences:**
+
+- ✅ Pas de Stripe refund à gérer ; comptabilité simplifiée
+- ✅ `payment_received` clarifie le statut « réglé » quel que soit le moyen
+- ⚠️ Avoirs **admin-only** (aucune UI patient self-service) — le patient doit contacter la thérapeute
+- ⚠️ Migration `008_credits.sql` à exécuter en prod après merge
+- ⚠️ Restitution d'avoir sur re-annulation d'un RDV créé avec avoir (via `restore_credits`) — cas à tester
+
+---
+
+## ADR-016: CI bloquant (lint + test + build), typecheck advisory
+
+**Date:** Juillet 2026 (#67 / PR #85)
+
+**Context:** Le repo se déploie en production via Netlify à chaque push sur `main`, **sans aucun quality gate**. Il faut fermer la porte aux régressions sans bloquer l'équipe sur des erreurs de typage préexistantes.
+
+**Decision:** Workflow GitHub Actions (`.github/workflows/ci.yml`) avec un job `build` **bloquant** (`lint → test → build`) et un job `typecheck-advisory` **non bloquant** (`continue-on-error: true`). `.nvmrc` pinne Node 20 (parité avec `netlify.toml`). Branch protection à activer manuellement une fois le 1er run sur `main` passé.
+
+**Rationale:**
+
+- Lint + tests + build sont déjà verts : passage en bloquant sans douleur
+- Le typecheck révèle 33 erreurs préexistantes (Netlify ne typecheckait pas) — 13 fixées mécaniquement, 20 restantes (googleapis, better-auth, stripe, react-email) nécessitent une investigation par sous-système (tracées dans #68)
+- `continue-on-error` évite de bloquer les merges tout en surfaceant le drift de types
+
+**Consequences:**
+
+- ✅ Plus aucun push direct en prod sans lint + tests + build verts
+- ✅ Type drift désormais visible (au lieu de silencieux)
+- ⚠️ Tant que #68 n'est pas résolu, le typecheck reste advisory — basculer `continue-on-error: false` une fois les 20 erreurs éliminées
+- ⚠️ Branch protection (manuel) : exige `CI / build` + « Dismiss stale pull request approvals »
+
+---
+
 ## Future Decisions to Document
 
 - Multi-language support approach (if implemented)

--- a/memory-bank/technical-stack.md
+++ b/memory-bank/technical-stack.md
@@ -1,145 +1,67 @@
 # Technical Stack
 
-**Last Updated:** January 14, 2025
+**Last Updated:** July 5, 2026
 
-## Core Technologies
+> ⚠️ **Note de révision** — ce fichier décrivait la stack React SPA d'origine (React Router, Vite direct, React Helmet, `port 5173`). La migration vers **Astro 5 SSG + Islands** a remplacé toute cette stack. Voir aussi `CLAUDE.md`, `AGENTS.md`, et `docs/architecture/` pour la source de vérité actuelle.
 
-### Frontend Framework
+## Core Framework
 
-- **React 18.3.1** - Modern UI library with hooks and concurrent features
-- **TypeScript 5.5.3** - Type-safe JavaScript with enhanced IDE support
-- **Vite 5.4.2** - Fast build tool and dev server with HMR
+- **Astro 5.18+** — Static Site Generation (SSG) par défaut, SSR hybride pour les routes API via l'adaptateur Netlify. Une page `.astro` = une URL.
+- **TypeScript 5.5+** — mode strict, pas de `any`.
+- **Islands Architecture** — rendu serveur par défaut, React hydraté uniquement où l'interactivité est nécessaire (`client:load`, `client:idle`, `client:visible`).
 
-### Routing
+> L'ancienne stack `Vite direct + React Router + React Helmet` est **supprimée**. Les alias `vite.config` (`astro.config.mjs`) neutralisent `react-router-dom` et `react-helmet-async` (legacy non installés) — ne pas les réintroduire.
 
-- **React Router DOM 6.22.3** - Client-side routing with future flags enabled
-  - `v7_startTransition` - Smooth transitions
-  - `v7_relativeSplatPath` - Improved path resolution
+## Frontend
 
-### Styling
+- **React 18** — utilisé uniquement pour les îles hydratées (`src/components/islands/`).
+- **Tailwind CSS 3.4** — utility-first uniquement ; pas de CSS personnalisé hors `src/index.css`. Pas de dark mode.
+- **framer-motion 11** — animations via le hook `useMotionVariants` (désactivé sur touch/WKWebView). **Jamais** pour les animations continues (utiliser Tailwind `animate-spin`).
+- **Lucide React** — icônes.
+- **react-hot-toast** — notifications.
+- **date-fns 4** — utilitaires de dates.
 
-- **Tailwind CSS 3.4.1** - Utility-first CSS framework
-- **PostCSS 8.4.35** - CSS transformations
-- **Autoprefixer 10.4.18** - Vendor prefix automation
-- **@tailwindcss/typography 0.5.10** - Beautiful typographic defaults
-- **@tailwindcss/line-clamp 0.4.4** - Multi-line text truncation
+## Backend / Data
 
-### UI Components & Icons
+- **Pas d'ORM** (stack.yml: `orm: none`). SQL brut via `@supabase/supabase-js` (PostgREST) ou `pg`.
+- **Supabase / PostgreSQL 16** — base de données principale. Migrations dans `supabase/migrations/` (`001_init.sql` → `008_credits.sql`).
+- **BetterAuth 1.6** — authentification session-based, backend PostgreSQL. **Monocompte** (une seule praticienne ; le hook `beforeUserCreated` bloque toute inscription).
+- **Stripe** — Payment Links uniquement pour `appointment_mode = 'video'` (ADR-014). Avoirs internes plutôt que refunds (ADR-015).
+- **Google Calendar / Meet API** — créneaux + liens Meet (`googleapis`). `GOOGLE_CALENDAR_MOCK=true` en dev (créneaux fictifs le mercredi).
+- **Resend** — transport email prod (templates React Email). **Nodemailer → Mailpit** en dev local.
 
-- **Lucide React 0.344.0** - Beautiful open-source icon library
-- **Framer Motion 11.0.8** - Production-ready animation library
+## Build & Deploy
 
-### Forms & Communication
+- **Build :** `npm run build` (`astro build` → `dist/`).
+- **Dev server :** `npm run dev` — port **4321** (Astro), pas 5173 (Vite direct n'est plus utilisé).
+- **Adaptateur :** `@astrojs/netlify` — génère `_redirects` + edge functions pour les routes SSR.
+- **Plateforme :** Netlify (auto-déploiement depuis `main`).
+- **CI gate** (`.github/workflows/ci.yml`, PR #85) : `lint → test → build` bloquant ; `typecheck` advisory (issue #68 trace les ~20 erreurs résiduelles).
+- **Node :** 20 (`.nvmrc`, correspond à `netlify.toml`).
 
-- **@emailjs/browser 4.3.3** - Client-side email sending service
-- **React Hot Toast 2.4.1** - Notification/toast system
+## Tooling
 
-### SEO & Meta
+- **ESLint 9** — flat config (`eslint.config.js`).
+- **Vitest** — tests unitaires / intégration (`tests/unit/**`, env `node`).
+- **Playwright** — tests e2e (`e2e/*.spec.ts`).
+- **pa11y + Lighthouse** — audits accessibilité WCAG 2.1 AA (`npm run audit:a11y`). **Requis avant tout PR UI.**
+- **Astro Content Collections** — blog Markdown validé par Zod (`src/content.config.ts`).
 
-- **React Helmet Async 2.0.4** - Dynamic head management for SEO
+## Env vars (Astro `import.meta.env.*`)
 
-### Utilities
+Voir `docs/INFRA.md` (prod) et `docs/LOCAL_DEV.md` (local). Variables critiques : `DATABASE_URL`, `SUPABASE_*`, `BETTER_AUTH_*`, `STRIPE_*`, `RESEND_*`, `SMTP_*`, `GOOGLE_CALENDAR_*` / `GOOGLE_OAUTH_*`, `SITE_URL`.
 
-- **date-fns 4.1.0** - Modern date utility library
-- **html-react-parser 5.2.2** - HTML string to React component parser
+## Conventions clés
 
-## Development Tools
+- **Trailing slash obligatoire** sur toute URL côté client (ADR-013) — `fetch("/api/foo/")`, `window.location.href = "/mes-rdvs/"`.
+- **Langue :** code/types/commentaires en anglais ; texte utilisateur et emails en **français** ; commits en **français présent**.
+- **Statuts RDV :** `pending → confirmed | declined | rescheduled → payment_pending → payment_received | cancelled`. `payment_received` = « réglé » (Stripe **ou** avoir).
+- **Avoirs internes** (#63/#66) : pas de Stripe refund — émission via `credits`/`credit_usages`, RPC FIFO `consume_credits`/`restore_credits`. Admin-only.
 
-### Code Quality
+## Références
 
-- **ESLint 9.9.1** - JavaScript/TypeScript linting
-- **@eslint/js** - ESLint JavaScript configs
-- **eslint-plugin-react-hooks** - React Hooks linting rules
-- **eslint-plugin-react-refresh** - React Fast Refresh validation
-- **TypeScript ESLint 8.3.0** - TypeScript-specific linting
-
-### Build Optimization
-
-- **Terser 5.38.1** - JavaScript minification
-- **cssnano 6.0.5** - CSS minification and optimization
-
-### Accessibility Auditing
-
-- **pa11y 9.0.1** - Automated accessibility testing
-- **pa11y-ci 4.0.1** - CI/CD accessibility testing
-- **pa11y-reporter-html 2.0.0** - HTML report generation
-- **Lighthouse 12.8.2** - Performance and accessibility auditing
-
-### Type Definitions
-
-- **@types/react 18.3.5** - React TypeScript definitions
-- **@types/react-dom 18.3.0** - React DOM TypeScript definitions
-
-## Architecture Patterns
-
-### Component Organization
-
-- **Lazy Loading** - Routes loaded on demand for better performance
-- **Code Splitting** - Automatic via Vite and React.lazy()
-- **Suspense Boundaries** - Graceful loading states
-
-### State Management
-
-- **React Hooks** - useState, useEffect, custom hooks
-- **No external state library** - Props and context for simple state needs
-
-### Styling Approach
-
-- **Utility-First** - Tailwind CSS for rapid development
-- **Component-Scoped** - Styles defined per component
-- **Responsive-First** - Mobile-first breakpoint system
-
-### Type Safety
-
-- **Strict TypeScript** - Full type coverage across codebase
-- **Interface Definitions** - Clear type contracts in /src/types/
-
-## Build & Deployment
-
-### Build Process
-
-- **Bundler:** Vite with React plugin (@vitejs/plugin-react 4.3.1)
-- **Output:** Static files to `dist/` directory
-- **Optimization:** Tree-shaking, minification, code splitting
-
-### Development
-
-- **Dev Server:** Vite dev server with HMR
-- **Port:** Default (5173) or configured
-- **Preview:** `npm run preview` for production build testing
-
-### Scripts Available
-
-```json
-{
-  "dev": "vite",
-  "build": "vite build",
-  "lint": "eslint .",
-  "preview": "vite preview",
-  "generate-sitemap": "node generate-sitemap.js",
-  "audit:a11y": "node scripts/run-a11y-audit.mjs",
-  "audit:lighthouse": "lighthouse https://omf-therapie.fr ..."
-}
-```
-
-## Browser Support
-
-- Modern browsers with ES6+ support
-- Based on Vite's default targets
-- No legacy browser support needed
-
-## Performance Considerations
-
-- Route-based code splitting
-- Lazy loaded components
-- Optimized images and assets
-- CSS purging via Tailwind
-- Minified production builds
-
-## Accessibility Standards
-
-- WCAG 2.1 AA compliance target
-- Automated testing with pa11y
-- Lighthouse accessibility audits
-- Semantic HTML structure
-- ARIA attributes where needed
+- `CLAUDE.md` — instructions détaillées pour agents.
+- `AGENTS.md` — couche quick-reference (domaines, conventions critiques, gotchas).
+- `docs/architecture/index.md` — conception système + couches + domaines.
+- `docs/architecture/patterns.md` — patterns de code + AI Quick Reference.
+- `memory-bank/decisions.md` — ADRs (ADR-001 à ADR-016).

--- a/plan-seo-geo-omf-therapie.md
+++ b/plan-seo-geo-omf-therapie.md
@@ -1,6 +1,10 @@
 # Plan SEO / GEO — omf-therapie.fr
 
-> Site vitrine React SPA + React Router + Helmet, déployé sur Netlify.  
+> ⚠️ **Document de planification historique (pré-migration).** La description technique ci-dessous (« React SPA + React Router + Helmet ») reflète l'ancienne stack. Le site est désormais un **Astro 5 SSG + Islands** (juillet 2026) — les recommandations techniques de la section 6 (React Helmet, `_redirects`, `React.lazy`, sitemap manuel) sont **obsolètes** : la meta/JSON-LD est gérée via `src/utils/schema.ts` + `src/layouts/`, le sitemap est auto-généré par `@astrojs/sitemap` (filtré dans `astro.config.mjs`), et les redirects legacy sont dans `netlify.toml`. La **stratégie de contenu** (sections 1–5) reste pertinente.
+>
+> Pour la stack actuelle voir `memory-bank/technical-stack.md`, `docs/architecture/index.md`, `AGENTS.md`.
+>
+> Site vitrine ~~React SPA + React Router + Helmet~~ **Astro 5 SSG + Islands**, déployé sur Netlify.
 > Praticienne : Oriane Montabonnet, psychopraticienne à Montpellier.
 
 ---
@@ -85,6 +89,8 @@ Chaque article : lien en fin de page vers la page service correspondante + page 
 ## 6. Technique React / Helmet / Netlify
 
 ### 6.1 React Helmet — 1 set de balises par route
+
+> ⚠️ **Obsolète sous Astro.** Le `<Helmet>` React n'est plus utilisé. Les balises meta + JSON-LD sont désormais gérées côté serveur dans les layouts/pages `.astro` via `src/utils/schema.ts` et `<Layout>` / `<ServiceLayout>`. Cette section est conservée pour contexte historique.
 
 Dans chaque composant de page, déclarer un `<Helmet>` complet :
 
@@ -187,7 +193,7 @@ const schemaBlogPosting = {
 
 ## 8. Performance & Core Web Vitals
 
-- **Code splitting** : `React.lazy` + `Suspense` par route pour ne pas tout charger sur la home.
+- ~~**Code splitting** : `React.lazy` + `Suspense` par route~~ → sous Astro 5, le code splitting est automatique (une page `.astro` = un chunk statique pré-rendu ; React n'est hydraté que pour les îles).
 - **Images** : formats compressés (WebP de préférence), dimensions adaptées, `loading="lazy"` sur les visuels hors viewport initial.
 - **Suivi** : Google Search Console (Core Web Vitals) + Lighthouse / PageSpeed Insights.
 
@@ -215,6 +221,8 @@ const schemaBlogPosting = {
 **Recommandation : non à court terme (6–12 mois).**
 
 En appliquant les optimisations ci-dessus (prerender Netlify + Helmet + sitemap), la SPA React peut atteindre un niveau SEO satisfaisant pour un site vitrine de cette taille.
+
+> ✅ **Mise à jour juillet 2026** — La migration vers Astro 5 SSG (achevée en 2025) a rendu ces optimisations SPA caduques : le pré-rendu est désormais natif (SSG), la meta/JSON-LD est server-side dans les layouts, et le sitemap est auto-généré par `@astrojs/sitemap`. Le seuil « volume augmente > 20 pages » a été franchi (blog riche + pages services), confirmant le bien-fondé de la migration.
 
 **Un changement vers Astro ou Next.js (SSG) devient pertinent si :**
 - Le volume de contenu augmente significativement (>20 pages, blog riche).


### PR DESCRIPTION
## Résumé

Quatre volets de documentation en une seule branche, pour aligner toute la doc projet sur l'état actuel (post-PRs #85/#66/#65, stack Astro 5 SSG + Islands).

## 1. Synchronisation — PRs de la semaine (#85, #66, #65)

| Fichier | Changement |
|---------|------------|
| `CLAUDE.md` | Commandes `typecheck`/`test` + section CI (gate bloquant `lint → test → build`, `.nvmrc`, branch protection) + Deployment mis à jour |
| `memory-bank/architecture.md` | Statut `payment_received`, système d'avoirs (`credits`/`008_credits.sql`), diagramme booking (cancel/reschedule_paid/avoir), `lib/credits.ts`, emails (`AppointmentCancelled` + 6 autres), section CI, ADRs |
| `memory-bank/active-context.md` | Remplace le statut mai (stale) par l'activité de la semaine + #68 next |
| `memory-bank/decisions.md` | +ADR-015 (avoirs internes, pas de Stripe refund), +ADR-016 (CI bloquant, typecheck advisory) |
| `.github/copilot-instructions.md` | Composants admin (+`AppointmentsManager`), lib (+`credits.ts`), migrations 001→008 |
| `docs/LOCAL_DEV.md` | Section linting (+`typecheck` +`test` +CI note), troubleshooting Stripe/avoirs + caveat `db:reset` |

## 2. Structuration — `docs/` scaffold (11 nouveaux fichiers)

L'arborescence `docs/` manquait les sous-répertoires standards déclarés dans `.claude/stack.yml`. Création et peuplement avec contenu réel (zéro TODO) :

- `docs/architecture/{index,patterns,ubiquitous-language}.md` — ADR-001 (décomposition par domaine), couches Astro, patterns (slice, hydration, trailing slash, boundary, state machine), glossaire FR/EN 26 termes
- `docs/standards/{backend,frontend}-patterns.md, testing.md, code-review.md` — conventions détaillées par couche
- `docs/guides/{deployment,troubleshooting}.md` — Netlify + CI gate + migrations + gotchas
- `docs/processes/{dev-process,issue-management}.md` — branching, workflow dev-core, commits FR

Chaque doc standards/guides/processes inclut une section **AI Quick Reference** (6–10 règles impératives `ALWAYS`/`NEVER`/`PREFER`).

## 3. Nettoyage stale — références React SPA supprimées

La migration vers Astro 5 SSG (2025) rendait 3 docs trompeurs :

| Fichier | Changement |
|---------|------------|
| `memory-bank/technical-stack.md` | **Réécriture complète** : React Router / Vite direct / Helmet / port 5173 supprimés. Stack actuelle : Astro 5 + Islands + BetterAuth + Supabase + Stripe/avoirs + Resend + Vitest/Playwright/pa11y + CI |
| `memory-bank/conventions.md` | Bannière de révision (jan 2025 → juil 2026) ; § Testing : « no automated tests » → Vitest + Playwright + pa11y + CI ; § Performance : React.lazy marqué obsolète (Islands) |
| `plan-seo-geo-omf-therapie.md` | Bannière de dépréciation + 3 notes inline (Helmet, lazy routing, conclusion SPA). Stratégie de contenu conservée |

## 4. AGENTS.md

Ajoute `AGENTS.md` — couche quick-reference pour agents ZCode, par-dessus `CLAUDE.md` et `memory-bank/` : commandes, architecture boundaries, conventions critiques, domain concepts, env vars, gotchas, reading map pour zones sensibles.

## Vérifications

- ✅ Aucun code modifié (docs uniquement)
- ✅ ADR-001 non édité (immutable)
- ✅ Sources : `CLAUDE.md`, `memory-bank/*`, ADR-001, `AGENTS.md`, scan code (`package.json`, `src/`, `supabase/migrations/`)
- N/A lint/typecheck/test/build (pas de code)

## Lifecycle

| Phase | Artifact | Statut |
|-------|----------|--------|
| Intent | Documentation désynchronisée après PRs #85/#66/#65 | — |
| Implémentation | 4 commits sur `docs/doc-sync-week-29-juin-5-juillet` | Complete |