### PR TITLE
Ignore les majors npm dans Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,16 @@
 version: 2
-# Dependency update automation. Added in #95 alongside the safe-batch bump.
-# Groups keep dev/prod dependencies separate and bundle major-version bumps
-# into a single PR, so coordinated upgrades (e.g. React 19 + framer-motion 12)
-# land together instead of as split, mid-bump PRs.
+# Dependency update automation. Added in #95 alongside the safe-batch bump,
+# tightened to ignore semver-major npm bumps after the grouped major PRs
+# (#102 dev-deps, #103 prod-deps) failed at `npm ci` on peer-dep conflicts.
+#
+# Strategy:
+#  - npm: only patch + minor updates are proposed automatically (grouped dev/prod).
+#    Major bumps (astro 7, React 19, tailwindcss 4, TypeScript 7, eslint 10, ...)
+#    are blocked because they break peer-dep resolution and need coordinated
+#    migration work (see #95 deferred-majors list). Lift the ignore rule or run
+#    `@dependabot unignore` on a specific PR to upgrade a major deliberately.
+#  - github-actions: all updates (incl. majors) — action majors are low-risk
+#    runtime bumps that CI will reject if anything actually breaks.
 updates:
   # npm — application dependencies (src/) and devDependencies (tooling).
   - package-ecosystem: npm
@@ -16,6 +24,10 @@ updates:
         dependency-type: development
       production-dependencies:
         dependency-type: production
+    ignore:
+      # Block framework/tooling majors — they require coordinated migration
+      # (peer-dep conflicts, breaking API changes). Patch + minor still flow.
+      - update-types: ["version-update:semver-major"]
     commit-message:
       prefix: "chore(deps)"
 


### PR DESCRIPTION
## Contexte

Suite à #96 (safe-batch bump + config Dependabot), Dependabot a ouvert 4 PR cette semaine :

| PR | Contenu | État |
|----|---------|------|
| #100 | actions/setup-node 4→7 | ✅ mergé |
| #101 | actions/checkout 4→7 | ✅ mergé |
| #102 | dev-dependencies (10 updates, dont TS 7, eslint 10, tailwind 4) | ❌ fermé — `npm ci` ERESOLVE |
| #103 | production-dependencies (14 updates, dont astro 7, React 19, sentry 10) | ❌ fermé — `npm ci` ERESOLVE |

## Problème

Les PR npm groupaient **toutes** les mises à jour applicables, y compris les majors de framework que #95 avait explicitement différées. Celles-ci cassent l'installation :

- `typescript@7` vs `@astrojs/check` (peer `^5 || ^6`) → #102
- `astro@7` vs `@astrojs/tailwind` (peer `^3 || ^4 || ^5`) → #103

## Solution

Ajout de `ignore: [version-update:semver-major]` sur l'écosystème npm uniquement.

- **Patch + minor** → continuent de s'ouvrir en PR groupées (dev / prod) — c'est là que se trouvent les correctifs de sécurité et de bugs
- **Major** → gelée jusqu'à migration coordonnée (peer-deps + breaking changes). Pour en faire une, retirer la règle ou lancer `@dependabot unignore` sur une PR ciblée
- **github-actions** → non filtré. Les majors d'actions sont des bumps de runtime à faible risque que CI rejette si cassage réelle (#100 et #101 ont mergé en vert sans intervention)

Au prochain cycle (lundi), Dependabot rouvrira des PR npm plus petites et vertes contenant les patchs utiles actuellement piégés dans #102/#103 (stripe patch, ws, supabase-js, googleapis, autoprefixer, eslint-plugin-react-refresh…).

## Vérification

```bash
node -e "const y=require('yaml');const d=y.parse(require('fs').readFileSync('.github/dependabot.yml','utf8'));console.log(JSON.stringify(d.updates[0].ignore))"
# → [{"update-types":["version-update:semver-major"]}]
```

Fichier `dependabot.yml` seul — pas de code, pas de test à jouer. CI (`lint → test → build`) tournera pour valider l'absence de régression.