### PR TITLE
Corrige la validation Dependabot : dependency-name requis sur ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,11 @@ version: 2
 #    `@dependabot unignore` on a specific PR to upgrade a major deliberately.
 #  - github-actions: all updates (incl. majors) — action majors are low-risk
 #    runtime bumps that CI will reject if anything actually breaks.
+#
+# NOTE: the Dependabot schema requires `dependency-name` on every `ignore`
+# entry. The wildcard "*" applies the rule to every npm dependency, which is
+# what we want for a global semver-major block (an entry with only
+# `update-types` fails config validation — see #105).
 updates:
   # npm — application dependencies (src/) and devDependencies (tooling).
   - package-ecosystem: npm
@@ -27,7 +32,10 @@ updates:
     ignore:
       # Block framework/tooling majors — they require coordinated migration
       # (peer-dep conflicts, breaking API changes). Patch + minor still flow.
-      - update-types: ["version-update:semver-major"]
+      # `dependency-name: "*"` is required by the schema (matches every npm
+      # package); an entry with only `update-types` fails validation.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     commit-message:
       prefix: "chore(deps)"
 


### PR DESCRIPTION
## Contexte

La config Dependabot mergée en #104 échoue à la validation côté GitHub :

> The property '#/updates/0/ignore/0' did not contain a required property of 'dependency-name'

Le schéma Dependabot exige `dependency-name` sur **chaque** entrée `ignore`. #104 n'avait que `update-types`, ce qui est invalide.

## Correctif

Ajout du joker `dependency-name: "*"` sur l'entrée `ignore` de l'écosystème npm. Comportement identique à l'intention d'origine (bloc global des majors npm), mais **valide** selon le schéma.

```yaml
ignore:
  - dependency-name: "*"
    update-types: ["version-update:semver-major"]
```

## Documentation ajoutée

Note dans l'en-tête du fichier expliquant l'exigence du schéma et le recours au joker, pour éviter qu'un futur contributeur ne reproduise l'erreur.

## Référence

- [Dependabot options reference — ignore](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore)
- [Stack Overflow : global major-version ignore requires `dependency-name: "*"`](https://stackoverflow.com/questions/60649404/how-can-i-change-my-dependabot-config-to-exclude-major-versions)

## Test

- YAML valide (`yaml.safe_load` OK)
- La structure vérifie `ignore[0].dependency-name == "*"` et `ignore[0].update-types == ["version-update:semver-major"]`
- GitHub validera la config au push (déclencheur `pull_request` sur la CI)