### PR TITLE
Corrige l'attribution conversion Google Ads sur le parcours réservation

### DIFF
--- a/src/hooks/useBooking.ts
+++ b/src/hooks/useBooking.ts
@@ -7,6 +7,7 @@
 import { useCallback, useMemo, useState } from 'react';
 import { calculatePrice } from '../lib/pricing';
 import type { PricingResult } from '../lib/pricing';
+import { APPOINTMENT_ESTIMATED_VALUE, trackEvent } from '../lib/analytics';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -186,6 +187,18 @@ export function useBooking() {
         const data = await response.json() as { error?: string };
         throw new Error(data.error ?? 'Une erreur est survenue lors de l\'envoi.');
       }
+
+      // Conversion — fired exactly once, on successful submit. Marked as a
+      // conversion in the GA4 admin (generate_lead) and imported into Google
+      // Ads via the GA4↔Ads link. Distinct from the contact-form lead via
+      // `method: 'booking_form'`. step transitions to 'submitted' below.
+      trackEvent('generate_lead', {
+        currency: 'EUR',
+        value: APPOINTMENT_ESTIMATED_VALUE[state.appointment_type ?? 'individual'] ?? 65,
+        method: 'booking_form',
+        appointment_type: state.appointment_type ?? undefined,
+        appointment_mode: state.appointment_mode ?? undefined,
+      });
 
       setState(prev => ({ ...prev, step: 'submitted', isSubmitting: false }));
     } catch (err: unknown) {

--- a/src/pages/rdv/merci.astro
+++ b/src/pages/rdv/merci.astro
@@ -6,7 +6,7 @@
  * Affiche un message de succès + récapitulatif optionnel depuis les params URL.
  *
  * Params URL supportés (optionnels) :
- *   ?source=request-submitted|request-confirmed|payment-pending|payment-success
+ *   ?source=request-confirmed|payment-pending|payment-success
  *   ?paiement=en-attente (legacy alias)
  *   ?type=individual|couple|family
  *   ?mode=in-person|video
@@ -29,7 +29,6 @@ const paramName  = url.searchParams.get('name');
 const sourceParam = url.searchParams.get('source');
 const legacyPaiement = url.searchParams.get('paiement');
 const hasStripeSessionId = url.searchParams.has('session_id');
-const stripeSessionId = url.searchParams.get('session_id');
 const isMockPayment = url.searchParams.get('mock') === '1';
 const mockAppointmentId = url.searchParams.get('appointment_id');
 
@@ -58,16 +57,14 @@ if (paramDate) {
 const hasRecap = typeLabel || modeLabel || formattedDate;
 
 type MerciVariant =
-  | 'request-submitted'
   | 'request-confirmed'
   | 'payment-pending'
   | 'payment-success';
 
 const variant: MerciVariant =
-  sourceParam === 'request-confirmed' ? 'request-confirmed'
+  sourceParam === 'payment-success' || hasStripeSessionId || isMockPayment ? 'payment-success'
   : sourceParam === 'payment-pending' || legacyPaiement === 'en-attente' ? 'payment-pending'
-  : sourceParam === 'payment-success' || hasStripeSessionId || isMockPayment ? 'payment-success'
-  : 'request-submitted';
+  : 'request-confirmed';
 
 if (isMockPayment && mockAppointmentId) {
   try {
@@ -84,17 +81,13 @@ const pageTitle = variant === 'payment-success'
   ? 'Paiement reçu — OMF Thérapie'
   : variant === 'payment-pending'
     ? 'Paiement en attente — OMF Thérapie'
-    : variant === 'request-confirmed'
-      ? 'Rendez-vous confirmé — OMF Thérapie'
-      : 'Demande envoyée — OMF Thérapie';
+    : 'Rendez-vous confirmé — OMF Thérapie';
 
 const pageDescription = variant === 'payment-success'
   ? 'Votre paiement est confirmé. Votre rendez-vous est validé, vous recevrez votre confirmation complète par email.'
   : variant === 'payment-pending'
     ? 'Votre nouveau créneau est bien pris en compte. Finalisez le prépaiement pour confirmer votre séance vidéo.'
-    : variant === 'request-confirmed'
-      ? 'Votre nouveau créneau est confirmé.'
-      : 'Votre demande de rendez-vous a bien été reçue. Vous recevrez un email de confirmation dans les 24-48h.';
+    : 'Votre nouveau créneau est confirmé.';
 ---
 
 <Layout
@@ -134,9 +127,7 @@ const pageDescription = variant === 'payment-success'
             ? (paramName ? `Paiement confirmé, ${paramName}\u00a0!` : 'Paiement confirmé\u00a0!')
             : variant === 'payment-pending'
               ? (paramName ? `Créneau réservé, ${paramName}\u00a0!` : 'Créneau réservé\u00a0!')
-              : variant === 'request-confirmed'
-                ? (paramName ? `Merci, ${paramName}\u00a0!` : 'Rendez-vous confirmé\u00a0!')
-                : (paramName ? `Merci, ${paramName}\u00a0!` : 'Demande envoyée\u00a0!')
+              : (paramName ? `Merci, ${paramName}\u00a0!` : 'Rendez-vous confirmé\u00a0!')
           }
         </h1>
         <p class="text-sage-600 font-sans leading-relaxed">
@@ -152,18 +143,11 @@ const pageDescription = variant === 'payment-success'
               <br />
               Finalisez le <strong class="text-sage-800">prépaiement</strong> via l'email reçu.
             </>
-          ) : variant === 'request-confirmed' ? (
+          ) : (
             <>
               Votre rendez-vous a été confirmé.
               <br />
               Vous recevrez les détails par email.
-            </>
-          ) : (
-            <>
-              Votre demande de rendez-vous a bien été reçue.
-              <br />
-              Vous recevrez un e-mail de confirmation dans les{' '}
-              <strong class="text-sage-800">24–48&nbsp;h</strong>.
             </>
           )}
         </p>
@@ -226,7 +210,7 @@ const pageDescription = variant === 'payment-success'
                 Une fois payé, votre rendez-vous sera automatiquement confirmé.
               </li>
             </>
-          ) : variant === 'request-confirmed' ? (
+          ) : (
             <>
               <li class="flex items-start gap-2">
                 <span class="text-mint-500 mt-0.5 flex-shrink-0" aria-hidden="true">1.</span>
@@ -235,21 +219,6 @@ const pageDescription = variant === 'payment-success'
               <li class="flex items-start gap-2">
                 <span class="text-mint-500 mt-0.5 flex-shrink-0" aria-hidden="true">2.</span>
                 Vérifiez votre boîte mail pour les détails pratiques.
-              </li>
-            </>
-          ) : (
-            <>
-              <li class="flex items-start gap-2">
-                <span class="text-mint-500 mt-0.5 flex-shrink-0" aria-hidden="true">1.</span>
-                Vous recevrez un e-mail de confirmation de réception.
-              </li>
-              <li class="flex items-start gap-2">
-                <span class="text-mint-500 mt-0.5 flex-shrink-0" aria-hidden="true">2.</span>
-                La thérapeute examinera votre demande sous 24–48&nbsp;h.
-              </li>
-              <li class="flex items-start gap-2">
-                <span class="text-mint-500 mt-0.5 flex-shrink-0" aria-hidden="true">3.</span>
-                Vous recevrez un e-mail de confirmation ou de proposition de créneau alternatif.
               </li>
             </>
           )}
@@ -278,42 +247,4 @@ const pageDescription = variant === 'payment-success'
     </div>
   </main>
 
-  {import.meta.env.PROD && (
-  <script is:inline define:vars={{ variant, paramType, paramMode, stripeSessionId }}>
-    const VALUE_BY_TYPE = { individual: 65, couple: 90, family: 100 };
-    const estimatedValue = VALUE_BY_TYPE[paramType] ?? 65;
-    let eventsSent = false;
-
-    function sendGAEvents() {
-      if (typeof gtag === 'undefined' || eventsSent) return;
-      eventsSent = true;
-      if (variant === 'request-submitted') {
-        gtag('event', 'generate_lead', {
-          value: estimatedValue, currency: 'EUR',
-          appointment_type: paramType, appointment_mode: paramMode,
-        });
-      } else if (variant === 'payment-success') {
-        gtag('event', 'purchase', {
-          transaction_id: stripeSessionId ?? `rdv-${Date.now()}`,
-          value: estimatedValue, currency: 'EUR',
-          items: [{ item_id: paramType, item_name: `Thérapie ${paramType}`,
-            item_category: 'therapie', price: estimatedValue, quantity: 1 }],
-        });
-      } else if (variant === 'request-confirmed') {
-        gtag('event', 'appointment_confirmed', {
-          appointment_type: paramType, appointment_mode: paramMode,
-        });
-      }
-    }
-
-    // Fire conversion events the moment analytics consent is granted.
-    // __ckyAnalyticsReady is a Promise exposed by the Layout (registered
-    // before CookieYes). Awaiting it is race-free: it resolves once CookieYes
-    // reports the 'analytics' category as accepted, whether that happens
-    // before or after this script runs (returning vs. first-time visitor).
-    if (window.__ckyAnalyticsReady) {
-      window.__ckyAnalyticsReady.then(sendGAEvents);
-    }
-  </script>
-  )}
 </Layout>


### PR DESCRIPTION
## Contexte

Le suivi conversion Google Ads du parcours réservation était cassé à deux niveaux :

1. **Aucune conversion au moment du submit booking.** L'unique signal GA4 sur `/rendez-vous` était `booking_step_view` (déclenché à chaque changement d'étape, 4× par tentative + doublons back-and-forth). Le `generate_lead` prévu vivait uniquement sur `/rdv/merci/?source=request-submitted` — un variant **mort** : aucun code path ne redirige vers cette URL (le wizard passe à un step interne `submitted`, sans navigation).
2. **Attribution Ads impossible sur `purchase`.** Le flow paiement va : clic pub → submit → **patient quitte le site, reçoit email** → clic email → Stripe Checkout (autre domaine) → redirect `/rdv/merci/`. À l'arrivée, la session Ads d'origine est morte (gclid perdu) → Google Ads ne peut pas rapprocher le paiement du clic pub.

## Changements

**`src/hooks/useBooking.ts`** (+13)
- Ajoute un event GA4 `generate_lead` déclenché **exactement une fois** au succès du `POST /api/appointments/` (après `response.ok`, avant le passage au step `submitted`).
- Params : `currency: 'EUR'`, `value` = tarif estimé du type de RDV (`APPOINTMENT_ESTIMATED_VALUE`), `method: 'booking_form'` (distingue du formulaire de contact `contact_form`), `appointment_type`/`appointment_mode` pour le segmenting.
- Ce signal se déclenche pendant que la session Ads est encore vivante → attribution correcte.

**`src/pages/rdv/merci.astro`** (−77)
- Supprime le variant `request-submitted` (mort). `request-confirmed` devient le fallback pour les URLs nues/malformées. Aplatit les ternaires title/description/body/next-steps.
- Supprime le bloc `<script>` de conversion GA4 en entier. Les 3 events étaient :
  - `generate_lead` (variant mort) — jamais déclenché
  - `appointment_confirmed` (variant `request-confirmed`) — flow rétention, pas marketing
  - `purchase` (variant `payment-success`) — attribution Ads cassée par le passage via email/Stripe hors-session
- Supprime `stripeSessionId` et la dépendance à `window.__ckyAnalyticsReady` (n'étaient plus utilisés).

`generate_lead` (dans `useBooking.ts`) devient l'unique conversion GA4/Ads du parcours réservation.

## Décisions prises

- **Tracking server-side pour `purchase`** (capture gclid au submit + POST Google Ads API sur `stripe-webhook`) écarté : scope F-lite, ~1 jour, nécessite l'API Google Ads + refresh token — jugé hors proportion pour le besoin actuel.
- `booking_step_view` laissé tel quel selon demande (utile pour l'analyse funnel).
- Variant `request-submitted` fusionné dans `request-confirmed` plutôt que supprimé du fallback (la logique de sélection nécessite un default ; `request-confirmed` est le message le plus neutre pour un atterrissage bare sur `/rdv/merci/`).

## Action produit (côté admin, pas de code)

1. GA4 Admin → Conversions → marquer `generate_lead` comme conversion.
2. Google Ads → Outils → Conversions → importer depuis GA4.

## Tests

- `npm run lint` : 0 erreur (8 warnings préexistants dans `src/emails/_helpers.tsx`, hors scope).
- `npm run typecheck` : 0 erreur, 0 warning sur les fichiers modifiés.
- Pas de test unitaire existant pour `merci.astro` ou `useBooking.ts`.

## À vérifier avant merge

- `npm run audit:a11y` (dev server running) — le markup HTML est inchangé, mais les branches conditionnelles changent. URLs à valider : `/rdv/merci/`, `/?source=request-confirmed`, `/?source=payment-pending`, `/?source=payment-success`.

## Tier

S (2 fichiers, pas de décision d'architecture, pas de schéma).