### PR TITLE
fix(admin): RDV admin — 201 post-INSERT, traitement différé + sweep

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,12 +14,15 @@ npm run lint             # ESLint (eslint.config.js, flat config)
 npm run typecheck        # `astro check` — advisory in CI (see #68 for ~20 residual errors)
 npm run test             # Vitest (tests/unit/**, node env)
 npm run test:watch       # Vitest watch mode
+npm run test:low         # Vitest capped to 1 worker — use for local full-suite runs in WSL (see guard below)
 npm run format           # Prettier — write (singleQuote, arrowParens:avoid)
 npm run format:check     # Prettier — check only (advisory; not in CI gate)
 npm run audit:a11y       # Pa11y WCAG audit (needs dev server running) — REQUIRED before UI PRs
 npm run db:start         # Start Postgres + Mailpit via docker compose
 npm run db:reset         # ⚠️ Drops & re-creates schema, replays ONLY 001_init.sql
 ```
+
+> **WSL memory guard (2026-08-28 incident):** the dev VM has ~16 GB RAM; Vitest's default pool spawns a worker per core and `astro build` adds ~2 GB on top. Two concurrent full suites (e.g., parallel agents each running `npm run test`) OOM the VM and **crash WSL mid-task**. Rules — (1) subagents/parallel contexts run ONLY targeted test files: `npx vitest run tests/unit/<file>.test.ts --maxWorkers=1`; never the full suite, `build`, or `audit:*` inside an agent when others may run concurrently. (2) The lead runs full gates once, sequentially: `npm run test:low` → `lint` → `typecheck` → `build`. (3) Check `free -m` if a run dies unexpectedly — an OOM kill is an environment failure, not a code diagnostic. CI (GitHub runners) is unaffected.
 
 **Run `npm run audit:a11y` before any UI/visual PR** — accessibility (WCAG 2.1 AA) is a hard requirement, not a nice-to-have.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,9 +36,12 @@ npm run preview          # Preview production build locally
 npm run lint             # Run ESLint
 npm run typecheck        # Type-check via `astro check` (advisory in CI — see #68 for the 20 pre-existing errors)
 npm run test             # Vitest unit/integration tests
+npm run test:low         # Same suite, capped to 1 worker — WSL-safe for local full runs
 ```
 
 > **CI:** `.github/workflows/ci.yml` gates merges to `main` with `lint → test → build`. Typecheck runs as a non-blocking advisory until #68 clears the remaining type errors. After the workflow reports once on `main`, require `CI / build` in branch protection.
+
+> **WSL memory guard:** concurrent full test suites (default worker pool = one per core) plus a build can OOM the ~16 GB dev VM and crash WSL. In WSL, run the full suite with `npm run test:low`, run gates sequentially, and in parallel agent contexts run only targeted files (`npx vitest run <file> --maxWorkers=1`). See `aidd_docs/memory/testing.md` § WSL-safe validation for heap limits.
 
 ### Accessibility Audits
 ```bash

--- a/artifacts/frames/126-admin-appointments-504-rework-frame.mdx
+++ b/artifacts/frames/126-admin-appointments-504-rework-frame.mdx
@@ -1,0 +1,52 @@
+---
+title: "fix(admin): création RDV 504 — traitement post-INSERT + rattrapage automatique des invitations"
+issue: 126
+status: approved
+tier: F-lite
+date: 2026-08-28
+---
+
+## Problem
+
+Le `POST /api/admin/appointments/` enchaîne séquentiellement des étapes en base (session, validation, éligibilité, conflits, INSERT) puis des appels d'API externes (Google Calendar, Stripe pour la vidéo, Resend avec jusqu'à 3 tentatives, re-lecture finale) — le tout dans une seule fonction Netlify soumise au délai d'exécution (~10 s). Quand un service externe traîne, la passerelle renvoie un **504 à la modal admin** et tue la fonction en cours, à un point imprévisible de la chaîne.
+
+Incident production du 2026-08-28 : tentative 1 tuée *après* l'INSERT (RDV `confirmed` présentiel créé sans événement Google Calendar ni email patient — orphelin `1fd4e5f1-…`), tentative 2 tuée *avant* l'INSERT (rien en base). Le sweep `reconcile-confirmations` (#98) ne rattrape que les `payment_received` (`confirmation_sent_at IS NULL`) : les invitations (`confirmed` présentiel, `payment_pending` vidéo) n'ont **aucun filet** — un envoi perdu l'est définitivement.
+
+Impact observable : patient sans confirmation ni lien de paiement possible, créneau absent de l'agenda de la praticienne (risque de double réservation), praticienne tentée de retenter à l'aveugle.
+
+## Who
+
+- **Primaire :** la praticienne (admin) — crée des RDV manuels via la modal « Nouveau rendez-vous » ; subit les 504 et leurs effets partiels.
+- **Secondaire :** les patients — reçoivent (ou pas) invitation/lien de paiement ; l'équipe technique — doit identifier l'étape fautive dans les logs.
+
+## Constraints
+
+- Runtime : fonction Netlify synchrone (~10 s de budget) ; les étapes externes ne peuvent pas rester dans la request critique.
+- Patron d'idempotence L2 existant (`confirmation_sent_at`, migration 011) à étendre, pas réinventer ; le sweep `reconcile-confirmations` tourne déjà horairement.
+- Migration à appliquer manuellement (convention 002+), idempotente, avec backfill des RDV existants (sinon le sweep étendu re-spammerait l'historique).
+- Fire-and-forget **structuré** : pas de floating promise silencieuse — chaque étape loggée début/fin/durée/échec, rattrapable par le sweep.
+- Site en production pour une practicienne seule : pas de file d'attente externe (pas d'infra nouvelle — QLess/SQS hors scope).
+
+## Out of Scope
+
+- Refonte générale des helpers HTTP / validation zod (#84) et migration logger.* (#108) — ce frame n'aligne que les logs du endpoint concerné.
+- Le flux de réservation patient (`/api/appointments/`, `/rendez-vous`) — seul le parcours admin est touché.
+- Paiements/confirmation post-Stripe (webhook + sweep existant restent tels quels).
+- Augmentation du délai d'exécution Netlify (palliatif écarté, voir Alternative).
+
+## Premise Validity
+
+*(Valeurs par défaut — questions restées sans réponse à l'interview, révisables à l'approbation.)*
+
+**Success in 6 months :** zéro 504 sur `POST /api/admin/appointments/` dans les logs Netlify ; et aucun RDV à venir (créé < 48 h) ne reste `invitation_sent_at IS NULL` plus d'une heure après sa création (passage du sweep horaire). Vérifiable par requête SQL + logs.
+
+**Failure in 6 months :** l'incident du 28 août se reproduit à l'identique — un timeout laisse un RDV en base sans email ni agenda ET non rattrapé dans l'heure (une occurrence de `invitation_sent_at NULL > 48 h` sur un RDV à venir suffit à invalider la prémisse).
+
+**Simplest alternative :** lever le timeout de la fonction Netlify (+ fire-and-forget naïf sans sweep).
+**Why not simplest :** ça ne fait que repousser la limite — les étapes externes restent dans la fenêtre de la request, et tout échec d'envoi reste perdu à jamais puisqu'il n'existe aucun rattrapage des invitations. C'est exactement la défaillance observée.
+
+## Complexity
+
+**Tier: F-lite** — Scope clair, un seul domaine (flux de création admin) mais ~6 fichiers : endpoint API, migration SQL, extension du sweep cron, lib notifications, UI de la modal, tests. Pas de pattern inconnu : le patron L2 + sweep existe déjà (#98) et est réutilisé.
+
+Signals observés : un domaine métier unique ; patron existant à étendre ; pas d'architecture nouvelle ; périmètre fichier > 3 (exclut S) ; pas d'inconnues multi-domaines (exclut F-full).

--- a/artifacts/plans/126-admin-appointments-504-rework-plan.mdx
+++ b/artifacts/plans/126-admin-appointments-504-rework-plan.mdx
@@ -1,0 +1,182 @@
+---
+title: "Plan: Création RDV admin — post-INSERT + rattrapage invitations"
+issue: 126
+spec: artifacts/specs/126-admin-appointments-504-rework-spec.mdx
+complexity: 6/10
+tier: F-lite
+generated: 2026-08-28
+---
+
+## Summary
+
+Restructurer `POST /api/admin/appointments/` pour répondre 201 dès l'INSERT, exécuter agenda/Stripe/email en post-réponse via `waitUntil` avec logs par étape, et rattraper tout échec ≤ 1 h par une fonction programmée dédiée `reconcile-invitations` — après refactors lazy-init de `stripe.ts`/`google-calendar.ts` requis par le runtime cron.
+
+**Flux de données :** [Flux — création RDV admin #126](../visuals/126-admin-appointments-504-rework-data-flow.html)
+**Carte fichiers × fonctions :** [Fichiers × fonctions — #126](../visuals/126-admin-appointments-504-rework-file-map.html)
+
+*(Sidecars rédigés à la main — skill forge-chart non disponible dans cette session.)*
+
+## Bootstrap Context
+
+Patterns de référence à consulter avant implémentation :
+- `src/lib/resend.ts` — lazy-init des transports (précédent exact pour `stripe.ts`)
+- `src/lib/supabase.ts:37-42` — accès env `import.meta.env ?? process.env` (précédent pour `google-calendar.ts`)
+- `netlify/functions/reconcile-confirmations.ts` — squelette complet du sweep (monitor, deadline, poison-escape, DI sendFn, logs sans PII)
+- `supabase/migrations/011_confirmation_sent_at.sql` — patron migration L2 (backfill + index partiel + idempotence)
+- `src/pages/api/stripe-webhook.ts` — garde `WHERE … IS NULL` write-race
+
+## Agents
+
+| Agent | Instances | Tâches | Fichiers |
+|---|---|---|---|
+| backend-dev | A (T1,T3,T6,T7) · B (T11,T12) · C (T13) | 6 | endpoint, migrations, notifications, libs stripe/google, fonction cron |
+| frontend-dev | A (T8) | 1 | AdminCreateButton.tsx |
+| tester | A (T2,T4,T5,T9) · B (T10,T15) | 6 | tests/unit/* |
+| devops | A (T14) | 1 | netlify.toml |
+
+## Micro-Tasks
+
+### Slice V1 — Contrat L2 + migrations
+
+- **T1** [backend-dev-A · migrations · V1 · GREEN] Créer `supabase/migrations/012_credits_grants.sql` (copie depuis le worktree principal — hotfix prod 2026-08-28) et `supabase/migrations/013_invitation_sent_at.sql` (`ADD COLUMN IF NOT EXISTS invitation_sent_at TIMESTAMPTZ`, backfill `= now()` **sans filtre**, index partiel `IF NOT EXISTS … WHERE invitation_sent_at IS NULL AND deleted_at IS NULL` sur `created_at`). Ajouter `invitation_sent_at: string | null` à `src/types/appointment.ts`. *Vérif : `grep -c "IF NOT EXISTS" supabase/migrations/013_invitation_sent_at.sql` ≥ 2 ∧ `grep invitation_sent_at src/types/appointment.ts`.*
+- **T2** [tester-A · tests · V1 · RED] `tests/unit/admin-appointments-post.test.ts` — tests échouants : (a) POST pose `invitation_sent_at` après envoi email réussi (mock sendEmail) ; (b) statut `payment_received` (avoir) → pose AUSSI `confirmation_sent_at` ; (c) `send_email=false` → flag posé **à l'INSERT**, aucun appel sendEmail. *Vérif : `npm run test -- admin-appointments-post` → rouge sur (a)(c).*
+- **T3** [backend-dev-A · api · V1 · GREEN] `src/pages/api/admin/appointments/index.ts` : flag-setting post-email (structure encore synchrone) + `send_email=false` → `invitation_sent_at` dans le payload INSERT. Écritures de flag **non fatales** (log seul). *Vérif : tests T2 verts.*
+- **T4** [tester-A · tests · V1 · RED-GATE] `npm run test` → V1 vert complet. *Sentinelle : échec ici bloque V2.*
+
+### Slice V2 — Découplage post-réponse
+
+- **T5** [tester-A · tests · V2 · RED] Étendre `admin-appointments-post.test.ts` + créer `tests/unit/admin-appointment-side-effects.test.ts` : (a) 201 renvoyé sans qu'aucun mock externe (calendar/stripe/resend) ne soit sollicité ; (b) N2 : ordre S1→S2→S3, logs `step/appointmentId/ms/statut` ; (c) `send_email=false` → S1+S2 exécutés, S3 jamais ; (d) clé L1 `invite:{id}:patient` sur l'email ; (e) absence `locals.netlify` → fallback inline (non bloquant). *Vérif : rouge sur (a)(b).*
+- **T6** [backend-dev-A · lib · V2 · GREEN] `src/lib/notifications.ts` : extraire `processAppointmentSideEffects(appt, opts)` — agenda (skip Meet si `video_link` fourni) → Stripe (si vidéo + solde dû) → email (si `send_email`, templates PaymentRequest/AppointmentConfirmed, clé L1 `invite:{id}:patient`) → flags set-once (garde `WHERE … IS NULL`, `+confirmation_sent_at` si `payment_received`). DI : clients injectables (défaut = modules app). *Vérif : tests side-effects verts.*
+- **T7** [backend-dev-A · api · V2 · GREEN] POST : chemin critique réduit (INSERT → credits → invalidation cache → 201), dispatch `locals.netlify.context.waitUntil(processAppointmentSideEffects(...))` avec fallback inline best-effort non awaité si absent. *Vérif : T5(a) vert.*
+- **T8** [frontend-dev-A · ui · V2 · GREEN] `AdminCreateButton.tsx` : sur `res.status >= 500` ∨ erreur réseau → message « La création a peut-être abouti — vérifiez la liste des rendez-vous avant de retenter. » (les 4xx garde le `data.error` serveur). *Vérif : `npm run lint` ∧ grep message.*
+- **T9** [tester-A · tests · V2 · RED-GATE] `npm run test && npm run lint` → verts. *Sentinelle : bloque V3.*
+
+### Slice V3 — Backstop sweep + refactors runtime
+
+- **T10** [tester-B · tests · V3 · RED] `tests/unit/reconcile-invitations.test.ts` : éligibilité (statuses `confirmed|payment_pending`, flag NULL, `deleted_at` NULL, < 48 h, `scheduled_at > now()`, tri ancien d'abord, LIMIT) ; rattrapage par row S1→S2→S3 ; `GOOGLE_CALENDAR_MOCK` → skip agenda + log warn, reste exécuté ; poison-escape (4xx → flag posé) ; garde `WHERE invitation_sent_at IS NULL` sur le set-once ; clé L1 identique au POST. *Vérif : rouge.*
+- **T11** [backend-dev-B · lib-stripe · V3 · GREEN] `src/lib/stripe.ts` : lazy-init du client (miroir `resend.ts` — `import.meta.env.STRIPE_SECRET_KEY ?? process.env.STRIPE_SECRET_KEY` à la première utilisation, plus de construction au module-load). *Vérif : `grep -n "import.meta.env" src/lib/stripe.ts` → plus aucune lecture à la portée module hors fonction.*
+- **T12** [backend-dev-B · lib-google · V3 · GREEN] `src/lib/google-calendar.ts` : accesseurs env-agnostiques (`import.meta.env.X ?? process.env.X` — précédent `supabase.ts`) pour OAuth client/`GOOGLE_CALENDAR_ID`/`GOOGLE_CALENDAR_MOCK` ; seam DI acceptant un client/calendarId explicites (usage cron). *Vérif : idem + `npm run test` toujours vert.*
+- **T13** [backend-dev-C · sweep · V3 · GREEN] Créer `netlify/functions/reconcile-invitations.ts` (squelette `reconcile-confirmations.ts`) : schedule littéral `'20 * * * *'` + const `SCHEDULE` (verrou test), `Sentry.withMonitor('reconcile-invitations', …, { checkInMargin: 5, maxRuntime: 10 })` après `initSentry()`, `DEADLINE_MS = 8500`, `BATCH_LIMIT = 25`, clients DI depuis `process.env`, traitement par row via `processAppointmentSideEffects` (post T6/T11/T12 — **séquencement critique**), logs sans PII. *Vérif : tests T10 verts.*
+- **T14** [devops-A · config · V3 · GREEN] `netlify.toml` : documenter le bloc env vars de `reconcile-invitations` (`GOOGLE_CALENDAR_ID`, `GOOGLE_SERVICE_ACCOUNT_EMAIL`, `GOOGLE_PRIVATE_KEY`, `GOOGLE_CALENDAR_MOCK`, `STRIPE_SECRET_KEY`, `STRIPE_SUCCESS_URL` + existants) ; étendre `tests/unit/cron-schedule-source.test.ts` au littéral de la nouvelle fonction. *Vérif : test cron vert ∧ grep netlify.toml.*
+- **T15** [tester-B · tests · V3 · RED-GATE] `npm run test && npm run lint && npm run build` → verts (typecheck advisory toléré, #68). *Sentinelle finale.*
+
+## Wave Structure
+
+4 vagues utiles, max 4 agents ∥. Séquentiel vs ~60 % de parallélisation.
+
+| Wave | Trigger | Agents | Tasks |
+|------|---------|--------|-------|
+| 1 | start | 4 ∥ | backend-dev-A: T1 · tester-A: T2 · frontend-dev-A: T8 · backend-dev-B: T11→T12 |
+| 2 | Wave 1 done | 2 ∥ | backend-dev-A: T3 · tester-A: T4→T5 |
+| 3 | Wave 2 done | 2 ∥ | backend-dev-A: T6→T7 · tester-A: T9→(prêt V3) |
+| 4 | Wave 3 done | 3 ∥ | tester-B: T10 · backend-dev-C: T13 · devops-A: T14 |
+| 5 | Wave 4 done | 1 | tester-B: T15 |
+
+*(T8 n'a pas de dépendance backend — Wave 1. T11→T12 indépendants du POST — Wave 1. T13 exige T6+T11+T12 → Wave 4.)*
+
+### Budget — per task
+
+| Task | Items | Class | Est. ops | Split? |
+|------|-------|-------|----------|--------|
+| T1 | 3 | bounded | 6 | — |
+| T2 | 3 | judgmental | 8 | — |
+| T3 | 2 | judgmental | 6 | — |
+| T4/T9/T15 (gates) | 1 | trivial | 2 | — |
+| T5 | 5 | judgmental | 10 | — |
+| T6 | 4 | judgmental | 12 | — |
+| T7 | 2 | judgmental | 8 | — |
+| T8 | 1 | bounded | 3 | — |
+| T10 | 6 | judgmental | 12 | — |
+| T11 | 1 | bounded | 4 | — |
+| T12 | 1 | judgmental | 6 | — |
+| T13 | 1 | judgmental | 10 | — |
+| T14 | 2 | bounded | 4 | — |
+
+**Total estimé : ~91 ops** — aucun task > 50.
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|----------|-------|-------|----------|--------|
+| backend-dev-A | T1,T3,T6,T7 | 32 | migrations→api (1 fil V1/V2) | — |
+| backend-dev-B | T11,T12 | 10 | lib-runtime | — |
+| backend-dev-C | T13 | 10 | sweep | — |
+| tester-A | T2,T4,T5,T9 | 22 | tests | — (4 tasks, 1 sujet) |
+| tester-B | T10,T15 | 14 | tests | — |
+| frontend-dev-A | T8 | 3 | ui | — |
+| devops-A | T14 | 4 | config | — |
+
+## Task Seeding Blueprint
+
+<!-- T{n} | agent-instance | blockedBy | subject. Semer dans l'ordre des vagues ; dans une vague, ∥. -->
+
+### Wave 1 — no deps, 4 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T1 | backend-dev-A | — | migrations |
+| T2 | tester-A | — | tests |
+| T8 | frontend-dev-A | — | ui |
+| T11 | backend-dev-B | — | lib-stripe |
+
+### Wave 2 — after Wave 1, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T3 | backend-dev-A | T1,T2 | api |
+| T12 | backend-dev-B | T11 | lib-google |
+| T4 | tester-A | T3 | tests |
+
+### Wave 3 — after Wave 2, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T5 | tester-A | T4 | tests |
+| T6 | backend-dev-A | T5 | lib-notifications |
+
+### Wave 4 — after Wave 3, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T7 | backend-dev-A | T6 | api |
+| T9 | tester-A | T7 | tests-gate |
+| T10 | tester-B | T9 | tests |
+
+### Wave 5 — after Wave 4, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T13 | backend-dev-C | T6,T11,T12 | sweep |
+| T14 | devops-A | T13 | config |
+
+### Wave 6 — final
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T15 | tester-B | T13,T14 | tests-gate |
+
+## Consistency Report
+
+- Critères spec couverts : 8/8 (SC1→T5a/T7 · SC2→T6/T9 · SC3→T6/T10/T13 · SC4→T10/T13 · SC5→T1 · SC6→T6/T13/T14 · SC7→T8 · SC8→T1/T3 + runbook notes)
+- Breadboard : 13/13 IDs tracés (U1→T7, U2→T8, N1→T7, N2→T6/T13, S1-S3→T6, S4→T6, S5→T13, D1/D2→T1/T3/T6, D3/D4→T6)
+- Non couvert : néant. Exemptions : audit a11y non requis (pas de changement visuel de structure — message d'erreur textuel seul ; re-vérifier si le DOM change).
+
+## Task IDs
+
+<!-- Semées via la todo-list de session (adaptation harness : TodoWrite, pas de TaskCreate durable).
+     Au redémarrage de session, re-semer depuis le Task Seeding Blueprint ci-dessus (vagues 1→6). -->
+- T1: migrations 012/013 + type — backend-dev-A
+- T2: tests RED V1 (flags POST) — tester-A
+- T3: POST flag-setting + send_email=false — backend-dev-A
+- T4: RED-GATE V1 — tester-A
+- T5: tests RED V2 (201 sans externe, N2, fallback) — tester-A
+- T6: extraction processAppointmentSideEffects (N2) — backend-dev-A
+- T7: POST restructure waitUntil — backend-dev-A
+- T8: modal message ≥500/réseau — frontend-dev-A
+- T9: RED-GATE V2 — tester-A
+- T10: tests RED V3 (sweep invitations) — tester-B
+- T11: stripe.ts lazy-init — backend-dev-B
+- T12: google-calendar.ts env-agnostique — backend-dev-B
+- T13: fonction reconcile-invitations — backend-dev-C
+- T14: netlify.toml env cron + verrou schedule — devops-A
+- T15: RED-GATE final (test+lint+build) — tester-B

--- a/artifacts/specs/126-admin-appointments-504-rework-spec.mdx
+++ b/artifacts/specs/126-admin-appointments-504-rework-spec.mdx
@@ -102,3 +102,10 @@ Tests : chaque slice embarque ses tests unitaires (`tests/unit/` — sweep query
 - Env vars cron à documenter dans `netlify.toml` (bloc scheduled functions) pour `reconcile-invitations` : en plus de Supabase/Resend/AUTH — `GOOGLE_CALENDAR_ID`, `GOOGLE_SERVICE_ACCOUNT_EMAIL`, `GOOGLE_PRIVATE_KEY`, `GOOGLE_CALENDAR_MOCK`, `STRIPE_SECRET_KEY`, `STRIPE_SUCCESS_URL`.
 - Logs sweep sans PII (ids seulement), miroir `reconcile-confirmations`.
 - Ne pas reintroduire `react-router-dom`/`react-helmet-async` (aliases nullés) ; trailing slash sur tout fetch (`/api/admin/appointments/`).
+
+## Amendements (revue finale 2026-08-28, PR #127 — 4 warnings)
+
+- **§5 fenêtre du sweep : 48 h → 24 h** — bornée au TTL de déduplication Resend (~24 h) : au-delà, un re-jeu de l'email ne serait plus dédupliqué par la clé L1 (warning W3). Un échec d'écriture du flag après livraison email reste donc sans doublon patient.
+- **Sémantique des drapeaux L2 renforcée** : `invitation_sent_at` n'est posé que si TOUTES les étapes post-réponse sont ok/skipped (agenda, Stripe, email). Un échec d'étape — API ou persistance — laisse les flags NULL pour que le sweep complète le RDV (SC3, warning W1). Exception documentée : poison-escape 4xx (échec email permanent = stop global).
+- **Claim atomique (migration 014, `invitation_claimed_at`)** : bail de 10 min posé par le POST et par le sweep AVANT le pipeline — sérialise les démarrages simultanés waitUntil↔sweep (warning W2 : doubles events.insert / Payment Links), récupération automatique après crash. Jamais un marqueur de complétion.
+- **`GOOGLE_CALENDAR_MOCK=true`** : skip agenda SANS persistance d'eventId (fini les faux id `calendar-mock-*` que les passages suivants prenaient pour un événement réel) — warning W4.

--- a/artifacts/specs/126-admin-appointments-504-rework-spec.mdx
+++ b/artifacts/specs/126-admin-appointments-504-rework-spec.mdx
@@ -1,0 +1,104 @@
+---
+title: "Création RDV admin : traitement post-INSERT + rattrapage automatique des invitations"
+issue: 126
+status: approved
+tier: F-lite
+date: 2026-08-28
+---
+
+## Context
+
+Promu depuis le frame [126-admin-appointments-504-rework](../frames/126-admin-appointments-504-rework-frame.mdx) (approuvé). Incident déclencheur : production 2026-08-28 — `POST /api/admin/appointments/` tué en cours par le timeout Netlify (~10 s fonction synchrone), laissant un RDV `confirmed` sans événement Google Calendar ni email patient (`1fd4e5f1-…`), puis une seconde tentative sans rien en base. Le sweep `reconcile-confirmations` (#98) ne couvre que `payment_received` : les invitations n'ont aucun filet.
+
+Faits techniques vérifiés (worktree, adapter `@astrojs/netlify` 6.6.5, revue experte) :
+- Le runtime expose `locals.netlify.context.waitUntil(promise)` aux routes API (`dist/index.js:256`) — noop en dev, réel en prod. C'est le mécanisme du post-réponse fiable.
+- Les fonctions programmées Netlify ont un délai de **30 s** (pas 10) ; le sweep existant budgete 8,5 s (`DEADLINE_MS`).
+- **`src/lib/stripe.ts` et `src/lib/google-calendar.ts` lisent `import.meta.env` à la portée module** (clé Stripe au scope + constructeur qui throw à clé vide ; `GOOGLE_CALENDAR_MOCK` au scope, OAuth/Calendar ID en lecture directe). Ils **plantent au chargement** dans le runtime cron Node — le patron lazy-init/DI de `resend.ts` (précédent #98) doit leur être appliqué avant tout import par une fonction programmée.
+- Précédent d'accesseur env-agnostique : `src/lib/supabase.ts` lit `import.meta.env` avec fallback `process.env`.
+
+## Goal
+
+La création admin d'un RDV répond 201 dès l'INSERT commité, les side-effects externes (agenda Google, lien Stripe, email) s'exécutent en post-réponse avec logs par étape, et tout échec est rattrapé automatiquement ≤ 1 h par un sweep horaire dédié aux invitations. Tradeoff explicite : en cas d'échec du post-réponse, la praticienne voit un succès et l'email patient peut arriver avec ≤ 1 h de retard (aucun indicateur UI dans ce scope — badge « futur »).
+
+## Users
+
+- **Primaire** : la praticienne — crée des RDV via la modal « Nouveau rendez-vous » ; ne doit plus voir de 504 ni créer d'orphelins.
+- **Secondaire** : les patients (reçoivent systématiquement invitation/lien de paiement) ; l'équipe technique (identifie l'étape fautive dans les logs Netlify).
+
+## Expected Behavior
+
+1. **Chemin critique (synchrone, dans la request)** : garde admin → validation → éligibilité cabinet → conflits → tarification → solde d'avoir → `INSERT appointments` → `consume_credits` si avoir (échec → DELETE + 409, inchangé) → invalidation cache dispo → **201 avec le RDV**. Aucun appel d'API externe dans cette fenêtre.
+2. **Post-réponse (`waitUntil`)**, séquentiel par RDV : (a) événement Google Calendar — pas de génération Meet si `video_link` déjà fourni — → persister `google_calendar_event_id`/`video_link` ; (b) lien Stripe si vidéo et solde dû > 0 → persister `stripe_payment_link_*` ; (c) si `send_email` ≠ false : email patient — `PaymentRequest` (vidéo + solde dû) ou `AppointmentConfirmed` (présentiel, ou vidéo couverte par avoir) — avec **clé d'idempotence L1 déterministe `invite:{appointmentId}:patient`** (même clé produite par le sweep → aucun doublon Resend si les deux chemins s'exécutent) ; (d) poser `invitation_sent_at`, et `confirmation_sent_at` aussi si statut `payment_received` (évite le double envoi par le sweep de #98). Chaque étape logge `step`, `appointmentId`, durée ms, statut ok/error — idiome `console.*` actuel (#108 hors scope).
+3. **Échec post-réponse** (erreur ou fonction gelée) : les flags restent NULL — c'est le signal de rattrapage. Aucune erreur ne remonte à la praticienne : le RDV est créé. L'email peut alors arriver avec ≤ 1 h de retard (sweep).
+4. **`send_email = false`** : le post-réponse fait quand même agenda + lien Stripe (ce sont des invariants du RDV), mais **aucun email** ; `invitation_sent_at` est posé à `now()` dès la création (sémantique set-once « rien à envoyer ») → le sweep n'enverra jamais d'email non sollicité.
+5. **Sweep dédié** — NOUVELLE fonction programmée `netlify/functions/reconcile-invitations.ts` (fonction séparée de `reconcile-confirmations` : budget, cold start et monitor indépendants), schedule `'20 * * * *'` (décalé de `5 * * * *`), propre `Sentry.withMonitor` (`reconcile-invitations`). Rows : `status IN ('confirmed','payment_pending')` ∧ `invitation_sent_at IS NULL` ∧ `deleted_at IS NULL` ∧ `created_at > now() − 48 h` ∧ `scheduled_at > now()`, plus ancien d'abord, `LIMIT` borné. Par row : garantir agenda → garantir lien Stripe → envoyer l'email (même clé L1) → poser les flags (garde `WHERE invitation_sent_at IS NULL`). Budget deadline propre (8,5 s), poison-escape et isolation par row réutilisés. Clients Google/Stripe instanciés depuis `process.env` après les refactors lazy-init. `GOOGLE_CALENDAR_MOCK` : le cron lit `process.env.GOOGLE_CALENDAR_MOCK` (fallback `'false'`) ; si mock → **skip de la création d'agenda** avec log warn (les créneaux fictifs du mock sont dev-only), le reste du rattrapage continue.
+6. **Modal résiliente** : sur échec réseau ou statut ≥ 500, remplacer l'erreur brute par « La création a peut-être abouti — vérifiez la liste des rendez-vous avant de retenter. » Le rechargement sur succès est inchangé.
+7. **Statut `payment_received` créé par avoir** : traité par l'étape 2(d) — les deux flags posés ensemble ; le sweep #98 (inchangé) l'ignore donc.
+
+## Data Model & Consumers
+
+**Structure de données :** [Modèle — invitations RDV admin](../visuals/126-admin-appointments-504-rework-data-model.html)
+**Carte des consommateurs :** [Consommateurs — invitation_sent_at](../visuals/126-admin-appointments-504-rework-consumers.html)
+
+*(Sidecars rédigés à la main — skill forge-chart non disponible dans cette session ; à régénérer via forge si souhaité.)*
+
+| Champ | Mutation | Écrit par | Lu par | Quand |
+|---|---|---|---|---|
+| `appointments.invitation_sent_at` (NOUVEAU, TIMESTAMPTZ NULL) | set-once après email livré **ou dès la création si `send_email=false`**, jamais reset | POST post-réponse ; sweep invitations | sweep invitations (filtre) ; (futur, pointillé : badge UI admin) | création + sweep horaire |
+| `appointments.confirmation_sent_at` (existant, 011) | idem, pour statuts `payment_received` | POST post-réponse (cas avoir) ; webhook ; sweep #98 | sweep #98 | paiement |
+| `appointments.google_calendar_event_id` / `video_link` | upsert post-réponse | POST ; sweep invitations | email (lien visio) ; agenda praticienne | création |
+| `appointments.stripe_payment_link_id/url` | upsert post-réponse (vidéo + solde dû) | POST ; sweep invitations | email PaymentRequest | création |
+| `email_threads` (inchangé) | racine/upsert via `sendEmail` (thread `appointment:{id}:patient`) | POST (web) ; sweep = header `X-Thread-Key` seul (parité #98) | — | envoi |
+| `credits`/`credit_usages` | inchangé (chemin critique synchrone) | `consume_credits` RPC | — | création |
+
+**Migrations** (les deux idempotentes, applicables manuellement — convention 002+) :
+- `supabase/migrations/012_credits_grants.sql` — hotfix prod du 2026-08-28 (GRANT service_role sur `credits`/`credit_usages`, déjà appliqué en prod via SQL editor) : **versionné dans cette branche** pour pérenniser le fix.
+- `supabase/migrations/013_invitation_sent_at.sql` — `ADD COLUMN IF NOT EXISTS invitation_sent_at TIMESTAMPTZ` ; backfill `invitation_sent_at = now()` pour **tous** les RDV existants, **sans filtre `created_at`** (ferme aussi la fenêtre déploiement→migration) ; index partiel `WHERE invitation_sent_at IS NULL AND deleted_at IS NULL` sur `created_at` (miroir de `idx_appointments_confirmation_pending`).
+
+## Breadboard
+
+| ID | Élément | Handler → | Données |
+|---|---|---|---|
+| U1 | Bouton « Créer » (modal `AdminCreateButton`) | `handleSubmit` → N1 | payload inchangé (+ `send_email`) |
+| U2 | Zone d'erreur modal | message ≥500/réseau dédié | — |
+| N1 | `POST /api/admin/appointments/` — chemin critique | INSERT → dispatch N2 via `locals.netlify.context.waitUntil` (fallback : exécution inline best-effort si absent) → 201 | D1–D4 |
+| N2 | Processeur post-réponse (nouveau, `src/lib/notifications.ts` : `processAppointmentSideEffects`) | S1 → S2 → S3 (si `send_email`) → flags | D1–D4 |
+| S1 | `createCalendarEvent` (google-calendar, refactoré env-agnostique) | upsert D3 | — |
+| S2 | `createAppointmentPaymentLink` (stripe, refactoré lazy-init) | upsert D4 | — |
+| S3 | `sendEmail` (resend) + clé L1 `invite:{id}:patient` | S4 + D1 (+D2 si avoir) | — |
+| S4 | `email_threads` persist (inchangé) | via S3 (racine thread) | — |
+| S5 | Sweep `reconcile-invitations` (nouvelle fonction) | requête flags NULL → S1→S2→S3 → set-once flags | D1–D4 |
+| D1 | `appointments.invitation_sent_at` (nouveau) | set-once N2/S5 | migration 013 |
+| D2 | `appointments.confirmation_sent_at` (existant) | posé par N2 si `payment_received` (avoir) | sweep #98 |
+| D3 | `appointments.google_calendar_event_id` / `video_link` | upsert S1 | agenda praticienne + email visio |
+| D4 | `appointments.stripe_payment_link_id/url` | upsert S2 | email PaymentRequest |
+
+## Slices
+
+| # | Slice | Contenu | Demo indépendante |
+|---|---|---|---|
+| 1 | Contrat L2 + migrations | 012 (credits grants, versionné) + 013 (+backfill non filtré + index), type `Appointment.invitation_sent_at`, POST pose les flags après envoi (structure encore synchrone), 2(d) double-flag avoir, `send_email=false` → flag posé à la création sans email | Créer un RDV → flags non-NULL en base ; `send_email=false` → pas d'email, flag posé ; re-run migrations = no-op |
+| 2 | Découplage post-réponse | N2 extrait (S3+S4 inchangés), POST 201 après INSERT, wiring `waitUntil` + fallback, logs par étape, message modal U2 | Simuler un Google lent → réponse < 1 s, side-effects aboutissent, logs Netlify lisibles |
+| 3 | Backstop sweep + refactors runtime | Lazy-init `stripe.ts` + accesseur env-agnostique `google-calendar.ts` (précédent `supabase.ts`/`resend.ts`), nouvelle fonction `reconcile-invitations` (requête 48 h/futur, DI process.env, budget 8,5 s, poison-escape, L1 `invite:{id}:patient`, mock-skip agenda), doc env vars cron dans `netlify.toml`, tests concurrency | Tuer N2 (simu) → passage sweep → RDV complet (agenda+lien+email) sans doublon |
+
+Tests : chaque slice embarque ses tests unitaires (`tests/unit/` — sweep query eligibility, processeur (mocks S1–S3), fallback waitUntil, clé L1 déterministe) ; `npm run lint && npm run test` au vert avant PR.
+
+**Séquencement explicite (revue architecte)** : la fonction sweep n'importe N2/S1/S2 **qu'après** les refactors lazy-init du slice 3 — sinon le chargement module du runtime cron crashe. Entre le déploiement des slices 1–2 et celui du slice 3, un timeout laisse `invitation_sent_at NULL` **sans filet** — fenêtre acceptée (site mono-praticienne), notée au runbook.
+
+## Success Criteria
+
+- [ ] `POST /api/admin/appointments/` renvoie 201 après l'INSERT sans aucun appel d'API externe dans la fenêtre synchrone (prouvé par test : aucun mock externe sollicité avant la réponse).
+- [ ] Happy path : le patient reçoit l'email attendu (`PaymentRequest` ou `AppointmentConfirmed`) et `google_calendar_event_id` est non-NULL après le post-réponse.
+- [ ] Si le post-réponse échoue intégralement, un passage du sweep dédié rend le RDV complet (agenda + lien Stripe le cas échéant + email) et `invitation_sent_at` non-NULL — sans double envoi (clé L1 déterministe `invite:{appointmentId}:patient` partagée POST/sweep + garde `WHERE … IS NULL`).
+- [ ] Après un passage du sweep terminé sans erreur : aucun RDV à venir (créé < 48 h, `scheduled_at > now()`) ne reste `invitation_sent_at IS NULL` — y compris les créations `send_email=false` (flag posé à la création, aucun email jamais envoyé pour elles).
+- [ ] Migrations 012 et 013 idempotentes ; backfill 013 **sans filtre** couvrant tous les RDV existants et la fenêtre déploiement→migration ; applicables manuellement (convention 002+).
+- [ ] Chaque étape post-réponse produit un log identifiable (`step`, `appointmentId`, durée, statut) ; `reconcile-invitations` est une fonction programmée séparée avec son propre monitor Sentry (slug distinct) et son budget deadline propre.
+- [ ] Sur échec réseau/≥500, la modal affiche « La création a peut-être abouti — vérifiez la liste des rendez-vous avant de retenter. »
+- [ ] Aucun email de rattrapage aux RDV existants après déploiement (backfill testé sur données seedées) ; les écritures de flag en échec (colonne absente pré-migration) sont non fatales — runbook : déployer puis migrer est sûr, ne jamais reset les flags.
+
+## Notes d'implémentation (non normatives)
+
+- `waitUntil` : accès `locals.netlify.context.waitUntil` (adapter 6.6.5, `dist/index.js:256`) ; noop en dev (processus longévive — les promesses tournent quand même). Fallback prod si absent : exécution inline best-effort non awaitée + le sweep rattrape.
+- Env vars cron à documenter dans `netlify.toml` (bloc scheduled functions) pour `reconcile-invitations` : en plus de Supabase/Resend/AUTH — `GOOGLE_CALENDAR_ID`, `GOOGLE_SERVICE_ACCOUNT_EMAIL`, `GOOGLE_PRIVATE_KEY`, `GOOGLE_CALENDAR_MOCK`, `STRIPE_SECRET_KEY`, `STRIPE_SUCCESS_URL`.
+- Logs sweep sans PII (ids seulement), miroir `reconcile-confirmations`.
+- Ne pas reintroduire `react-router-dom`/`react-helmet-async` (aliases nullés) ; trailing slash sur tout fetch (`/api/admin/appointments/`).

--- a/artifacts/visuals/126-admin-appointments-504-rework-consumers.html
+++ b/artifacts/visuals/126-admin-appointments-504-rework-consumers.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="utf-8">
+<title>Consommateurs — invitation_sent_at (#126)</title>
+<style>
+  :root { color-scheme: dark; }
+  body { margin:0; padding:32px; background:#0d1117; color:#e6edf3; font:14px/1.5 -apple-system,"Segoe UI",sans-serif; }
+  h1 { font-size:18px; color:#7ee787; margin:0 0 4px; }
+  p.sub { color:#8b949e; margin:0 0 28px; font-size:13px; }
+  .hub { display:flex; align-items:center; justify-content:center; gap:0; flex-wrap:wrap; }
+  .hubcore { background:#0c2d5e; border:1px solid #388bfd; border-radius:14px; padding:18px 22px; text-align:center; box-shadow:0 0 22px rgba(56,139,253,.25); margin:0 8px; }
+  .hubcore h2 { margin:0; font-size:15px; color:#79c0ff; font-family:ui-monospace,monospace; }
+  .hubcore small { color:#8b949e; }
+  .arrow { color:#388bfd; font-size:20px; padding:0 4px; }
+  .cols { display:flex; gap:22px; justify-content:center; flex-wrap:wrap; margin-top:26px; }
+  .col h3 { font-size:12px; text-transform:uppercase; letter-spacing:.08em; color:#8b949e; margin:0 0 10px; text-align:center; }
+  .consumer { background:#161b22; border:1px solid #30363d; border-radius:10px; padding:12px 14px; width:270px; margin-bottom:12px; }
+  .consumer.futur { border-style:dashed; opacity:.75; }
+  .consumer b { font-size:13px; display:block; margin-bottom:4px; }
+  .consumer .f { font-family:ui-monospace,monospace; font-size:11px; color:#c9d1d9; }
+  .consumer .when { font-size:11px; color:#8b949e; margin-top:4px; }
+  .pill { float:right; font-size:10px; padding:1px 7px; border-radius:99px; background:#1f4d2a; color:#7ee787; }
+  .pill.f { background:#3d2d00; color:#d29922; }
+</style>
+</head>
+<body>
+<h1>Carte des consommateurs — appointments.invitation_sent_at</h1>
+<p class="sub">Hub central = le flag L2. Plein = ce changement · pointillé = futur.</p>
+
+<div class="hub">
+  <div class="hubcore"><h2>invitation_sent_at</h2><small>set-once · NULL = à rattraper</small></div>
+</div>
+
+<div class="cols">
+  <div class="col">
+    <h3>Écrivains</h3>
+    <div class="consumer">
+      <b>POST /api/admin/appointments/ <span class="pill">#126</span></b>
+      <span class="f">post-réponse (waitUntil) après email patient livré</span>
+      <div class="when">à la création (≤ qqs s après le 201)</div>
+    </div>
+    <div class="consumer">
+      <b>Sweep phase 2 — invitations <span class="pill">#126</span></b>
+      <span class="f">UPDATE … WHERE invitation_sent_at IS NULL (garde write-race)</span>
+      <div class="when">horaire H:05 · fenêtre 48 h · RDV à venir</div>
+    </div>
+    <div class="consumer">
+      <b>POST — cas avoir (payment_received) <span class="pill">#126</span></b>
+      <span class="f">pose AUSSI confirmation_sent_at (évite doublon phase 1)</span>
+      <div class="when">à la création</div>
+    </div>
+  </div>
+  <div class="col">
+    <h3>Lecteurs</h3>
+    <div class="consumer">
+      <b>Sweep phase 2 — sélection <span class="pill">#126</span></b>
+      <span class="f">filtre invitation_sent_at IS NULL + index partiel 013</span>
+      <div class="when">chaque passage horaire</div>
+    </div>
+    <div class="consumer">
+      <b>Sweep phase 1 — confirmations <span class="pill">#98</span></b>
+      <span class="f">lit confirmation_sent_at (inchangé) ; ignore confirmed/payment_pending</span>
+      <div class="when">chaque passage horaire</div>
+    </div>
+    <div class="consumer futur">
+      <b>UI admin /mes-rdvs <span class="pill f">futur</span></b>
+      <span class="f">badge « invitation en attente » si NULL &gt; 1 h</span>
+      <div class="when">pointillé — hors scope #126</div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/artifacts/visuals/126-admin-appointments-504-rework-data-flow.html
+++ b/artifacts/visuals/126-admin-appointments-504-rework-data-flow.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="utf-8">
+<title>Flux de données — #126</title>
+<style>
+  :root { color-scheme: dark; }
+  body { margin:0; padding:32px; background:#0d1117; color:#e6edf3; font:14px/1.5 -apple-system,"Segoe UI",sans-serif; }
+  h1 { font-size:18px; color:#7ee787; margin:0 0 4px; }
+  p.sub { color:#8b949e; margin:0 0 24px; font-size:13px; }
+  .zone { border:1px dashed #30363d; border-radius:12px; padding:16px 18px; margin-bottom:18px; }
+  .zone > h2 { font-size:12px; text-transform:uppercase; letter-spacing:.08em; color:#8b949e; margin:0 0 10px; }
+  .flow { display:flex; align-items:stretch; gap:10px; flex-wrap:wrap; }
+  .stage { background:#161b22; border:1px solid #30363d; border-radius:10px; padding:10px 14px; min-width:170px; }
+  .stage.crit { border-color:#7ee787; }
+  .stage.post { border-color:#388bfd; }
+  .stage.sweep { border-color:#d29922; }
+  .stage b { display:block; font-size:12px; margin-bottom:4px; }
+  .stage span { font-size:11px; color:#8b949e; font-family:ui-monospace,monospace; }
+  .arr { align-self:center; color:#388bfd; font-size:18px; }
+  .legend span { margin-right:16px; font-size:11px; color:#8b949e; }
+  .sw { display:inline-block; width:10px; height:10px; border-radius:3px; margin-right:5px; vertical-align:middle; }
+</style>
+</head>
+<body>
+<h1>Flux — création RDV admin #126</h1>
+<p class="sub">Trois zones : chemin critique (synchrone) · post-réponse (waitUntil) · backstop (cron dédié).</p>
+<p class="legend"><span><span class="sw" style="background:#7ee787"></span>synchrone &lt; 1 s</span><span><span class="sw" style="background:#388bfd"></span>post-réponse</span><span><span class="sw" style="background:#d29922"></span>sweep '20 * * * *'</span></p>
+
+<div class="zone">
+  <h2>Zone 1 — chemin critique (dans la request)</h2>
+  <div class="flow">
+    <div class="stage crit"><b>Modal U1</b><span>AdminCreateButton.tsx</span></div>
+    <div class="arr">→</div>
+    <div class="stage crit"><b>POST /api/admin/appointments/</b><span>auth · validation · conflits</span></div>
+    <div class="arr">→</div>
+    <div class="stage crit"><b>consume_credits</b><span>RPC FIFO (si avoir)</span></div>
+    <div class="arr">→</div>
+    <div class="stage crit"><b>INSERT appointments</b><span>+ invitation_sent_at si send_email=false</span></div>
+    <div class="arr">→</div>
+    <div class="stage crit"><b>201 JSON</b><span>réponse immédiate</span></div>
+  </div>
+</div>
+
+<div class="zone">
+  <h2>Zone 2 — post-réponse (locals.netlify.context.waitUntil · fallback inline)</h2>
+  <div class="flow">
+    <div class="stage post"><b>N2 dispatch</b><span>notifications.ts</span></div>
+    <div class="arr">→</div>
+    <div class="stage post"><b>S1 Google Calendar</b><span>google-calendar.ts (env-agnostique)</span></div>
+    <div class="arr">→</div>
+    <div class="stage post"><b>S2 Stripe link</b><span>stripe.ts (lazy-init) · si vidéo+solde dû</span></div>
+    <div class="arr">→</div>
+    <div class="stage post"><b>S3 Resend</b><span>L1 invite:{id}:patient · si send_email</span></div>
+    <div class="arr">→</div>
+    <div class="stage post"><b>Flags D1/D2</b><span>set-once · WHERE IS NULL</span></div>
+  </div>
+  <p style="font-size:11px;color:#8b949e;margin:8px 0 0">Chaque étape : log step/appointmentId/ms/statut. Échec → flags NULL → zone 3 rattrape.</p>
+</div>
+
+<div class="zone">
+  <h2>Zone 3 — backstop (netlify/functions/reconcile-invitations.ts · Sentry monitor)</h2>
+  <div class="flow">
+    <div class="stage sweep"><b>Sélection</b><span>confirmed|payment_pending · flag NULL · &lt;48h · futur</span></div>
+    <div class="arr">→</div>
+    <div class="stage sweep"><b>S1 → S2 → S3</b><span>mêmes libs refactorées · DI process.env</span></div>
+    <div class="arr">→</div>
+    <div class="stage sweep"><b>set-once D1</b><span>garde write-race · poison-escape</span></div>
+  </div>
+  <p style="font-size:11px;color:#8b949e;margin:8px 0 0">Budget 8,5 s propre · GOOGLE_CALENDAR_MOCK → skip agenda (warn) · parallèle au sweep #98 ('5 * * * *') sans budget partagé.</p>
+</div>
+</body>
+</html>

--- a/artifacts/visuals/126-admin-appointments-504-rework-data-model.html
+++ b/artifacts/visuals/126-admin-appointments-504-rework-data-model.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="utf-8">
+<title>Modèle — invitations RDV admin (#126)</title>
+<style>
+  :root { color-scheme: dark; }
+  body { margin:0; padding:32px; background:#0d1117; color:#e6edf3; font:14px/1.5 -apple-system,"Segoe UI",sans-serif; }
+  h1 { font-size:18px; color:#7ee787; margin:0 0 4px; }
+  p.sub { color:#8b949e; margin:0 0 28px; font-size:13px; }
+  .layer { margin-bottom:28px; }
+  .layer > h2 { font-size:12px; text-transform:uppercase; letter-spacing:.08em; color:#8b949e; border-left:3px solid #388bfd; padding-left:8px; margin:0 0 12px; }
+  .layer.side > h2 { border-color:#d29922; }
+  .layer.out > h2 { border-color:#7ee787; }
+  .node { background:#161b22; border:1px solid #30363d; border-radius:10px; padding:14px 16px; display:inline-block; vertical-align:top; margin:0 14px 14px 0; min-width:280px; }
+  .node.core { border-color:#388bfd; box-shadow:0 0 14px rgba(56,139,253,.15); }
+  .node.new { border-color:#7ee787; }
+  .node h3 { margin:0 0 8px; font-size:14px; }
+  .node .tag { float:right; font-size:10px; padding:1px 7px; border-radius:99px; margin-left:6px; }
+  .tag.new { background:#1f4d2a; color:#7ee787; }
+  .tag.frozen { background:#3d2d00; color:#d29922; }
+  .tag.mutable { background:#0c2d5e; color:#79c0ff; }
+  .field { font-family:ui-monospace,monospace; font-size:12px; padding:2px 0; color:#c9d1d9; }
+  .field em { color:#8b949e; font-style:normal; }
+  .field.new { color:#7ee787; }
+  .rel { font-family:ui-monospace,monospace; font-size:11px; color:#8b949e; margin-top:8px; border-top:1px dashed #30363d; padding-top:6px; }
+  .legend { margin-top:8px; font-size:11px; color:#8b949e; }
+  .legend span { margin-right:14px; }
+  .dot { display:inline-block; width:8px; height:8px; border-radius:50%; margin-right:5px; vertical-align:middle; }
+</style>
+</head>
+<body>
+<h1>Modèle de données — invitations RDV admin (#126)</h1>
+<p class="sub">Layered : cœur (muté par ce changement) ↓ tables liées (lecture/écriture chemin critique) ↓ sorties externes. <span class="dot" style="background:#7ee787"></span>nouveau · <span class="dot" style="background:#79c0ff"></span>mutable · <span class="dot" style="background:#d29922"></span>gelé (contrainte)</p>
+
+<div class="layer">
+  <h2>Cœur — appointments</h2>
+  <div class="node core">
+    <h3>appointments <span class="tag mutable">mutable</span></h3>
+    <div class="field new">invitation_sent_at&nbsp; TIMESTAMPTZ NULL <em>← NOUVEAU (013) — set-once, jamais reset</em></div>
+    <div class="field">confirmation_sent_at TIMESTAMPTZ NULL <em>(011, inchangé)</em></div>
+    <div class="field">google_calendar_event_id UUID NULL</div>
+    <div class="field">video_link TEXT NULL</div>
+    <div class="field">stripe_payment_link_id / _url TEXT NULL</div>
+    <div class="field">status, appointment_mode, final_price, credit_applied <em>(inchangés)</em></div>
+    <div class="rel">idx partiel (created_at) WHERE invitation_sent_at IS NULL AND deleted_at IS NULL — NOUVEAU</div>
+  </div>
+</div>
+
+<div class="layer side">
+  <h2>Chemin critique (synchrone, inchangé)</h2>
+  <div class="node">
+    <h3>credits <span class="tag frozen">RLS service_role</span></h3>
+    <div class="field">remaining, patient_email</div>
+    <div class="rel">consume_credits() RPC FIFO — AVANT la réponse 201</div>
+  </div>
+  <div class="node">
+    <h3>credit_usages <span class="tag frozen">cascade</span></h3>
+    <div class="field">credit_id, appointment_id, amount</div>
+    <div class="rel">FK appointments ON DELETE CASCADE</div>
+  </div>
+  <div class="node">
+    <h3>email_threads <span class="tag mutable">upsert</span></h3>
+    <div class="field">thread_key = appointment:{id}:patient</div>
+    <div class="rel">racine créée par l'envoi web (sweep = header seul)</div>
+  </div>
+</div>
+
+<div class="layer out">
+  <h2>Side-effects externes (post-réponse + backstop)</h2>
+  <div class="node">
+    <h3>Google Calendar <span class="tag mutable">via createCalendarEvent</span></h3>
+    <div class="field">event id → google_calendar_event_id</div>
+    <div class="field">Meet link → video_link (vidéo sans lien fourni)</div>
+  </div>
+  <div class="node">
+    <h3>Stripe <span class="tag mutable">via createAppointmentPaymentLink</span></h3>
+    <div class="field">payment link id/url — vidéo + solde dû &gt; 0</div>
+  </div>
+  <div class="node">
+    <h3>Resend <span class="tag mutable">Idempotency-Key L1</span></h3>
+    <div class="field">PaymentRequest | AppointmentConfirmed</div>
+    <div class="field">clé confirm:patient:{pi} si payment_intent ∃</div>
+  </div>
+</div>
+<p class="legend">Sémantique L2 : NULL = invitation non livrée (signal de rattrapage sweep) · non-NULL = livrée. Backfill 013 : tous les RDV existants → non-NULL.</p>
+</body>
+</html>

--- a/artifacts/visuals/126-admin-appointments-504-rework-file-map.html
+++ b/artifacts/visuals/126-admin-appointments-504-rework-file-map.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="utf-8">
+<title>Carte fichiers × fonctions — #126</title>
+<style>
+  :root { color-scheme: dark; }
+  body { margin:0; padding:32px; background:#0d1117; color:#e6edf3; font:14px/1.5 -apple-system,"Segoe UI",sans-serif; }
+  h1 { font-size:18px; color:#7ee787; margin:0 0 4px; }
+  p.sub { color:#8b949e; margin:0 0 24px; font-size:13px; }
+  .grid { display:flex; flex-wrap:wrap; gap:16px; }
+  .file { background:#161b22; border:1px solid #30363d; border-radius:10px; padding:12px 14px; width:300px; }
+  .file.new { border-color:#7ee787; }
+  .file.mod { border-color:#388bfd; }
+  .file h3 { margin:0 0 6px; font-size:12px; font-family:ui-monospace,monospace; word-break:break-all; }
+  .file .fn { font-size:11px; color:#c9d1d9; font-family:ui-monospace,monospace; padding:1px 0; }
+  .file .fn em { color:#8b949e; font-style:normal; }
+  .tag { float:right; font-size:10px; padding:1px 7px; border-radius:99px; margin-left:6px; }
+  .tag.new { background:#1f4d2a; color:#7ee787; }
+  .tag.mod { background:#0c2d5e; color:#79c0ff; }
+  .tag.test { background:#3d2d00; color:#d29922; }
+  .edge { font-size:11px; color:#8b949e; border-top:1px dashed #30363d; margin-top:6px; padding-top:5px; font-family:ui-monospace,monospace; }
+</style>
+</head>
+<body>
+<h1>Fichiers × fonctions — #126</h1>
+<p class="sub"><span class="tag new">nouveau</span> <span class="tag mod">modifié</span> <span class="tag test">test</span> — arêtes d'appel en pied de carte.</p>
+<div class="grid">
+  <div class="file new"><h3>supabase/migrations/012_credits_grants.sql <span class="tag new">new</span></h3><div class="fn">GRANT credits/credit_usages → service_role <em>(hotfix prod, versionné)</em></div></div>
+  <div class="file new"><h3>supabase/migrations/013_invitation_sent_at.sql <span class="tag new">new</span></h3><div class="fn">ADD COLUMN IF NOT EXISTS · backfill non filtré · index partiel IF NOT EXISTS</div></div>
+  <div class="file mod"><h3>src/types/appointment.ts <span class="tag mod">mod</span></h3><div class="fn">+ invitation_sent_at: string | null</div></div>
+  <div class="file mod"><h3>src/pages/api/admin/appointments/index.ts <span class="tag mod">mod</span></h3><div class="fn">POST — chemin critique seul · dispatch waitUntil · 201 précoce</div><div class="edge">→ notifications.processAppointmentSideEffects · locals.netlify.context.waitUntil</div></div>
+  <div class="file mod"><h3>src/lib/notifications.ts <span class="tag mod">mod</span></h3><div class="fn">+ processAppointmentSideEffects (N2) · clé L1 invite:{id}:patient · logs par étape · DI clients</div><div class="edge">→ google-calendar · stripe · resend</div></div>
+  <div class="file mod"><h3>src/lib/stripe.ts <span class="tag mod">mod</span></h3><div class="fn">lazy-init client (miroir resend.ts) · fallback process.env</div></div>
+  <div class="file mod"><h3>src/lib/google-calendar.ts <span class="tag mod">mod</span></h3><div class="fn">accesseurs env-agnostiques (précédent supabase.ts) · seam DI pour cron</div></div>
+  <div class="file new"><h3>netlify/functions/reconcile-invitations.ts <span class="tag new">new</span></h3><div class="fn">schedule '20 * * * *' (littéral) · Sentry.withMonitor('reconcile-invitations') · DEADLINE 8,5 s · poison-escape</div><div class="edge">→ notifications N2 · S1/S2/S3 via DI process.env</div></div>
+  <div class="file mod"><h3>netlify.toml <span class="tag mod">mod</span></h3><div class="fn">doc env vars cron : GOOGLE_*, STRIPE_*, GOOGLE_CALENDAR_MOCK</div></div>
+  <div class="file mod"><h3>src/components/admin/AdminCreateButton.tsx <span class="tag mod">mod</span></h3><div class="fn">U2 : message ≥500/réseau « la création a peut-être abouti… »</div></div>
+  <div class="file new"><h3>tests/unit/admin-appointment-side-effects.test.ts <span class="tag test">new</span></h3><div class="fn">N2 : ordre S1→S2→S3, send_email=false, flags set-once, clé L1</div></div>
+  <div class="file new"><h3>tests/unit/admin-appointments-post.test.ts <span class="tag test">new</span></h3><div class="fn">201 sans appel externe synchrone · fallback waitUntil</div></div>
+  <div class="file new"><h3>tests/unit/reconcile-invitations.test.ts <span class="tag test">new</span></h3><div class="fn">éligibilité requête · rattrapage · poison · mock-skip · garde IS NULL</div></div>
+  <div class="file mod"><h3>tests/unit/cron-schedule-source.test.ts <span class="tag test">mod</span></h3><div class="fn">+ verrou littéral schedule reconcile-invitations</div></div>
+</div>
+</body>
+</html>

--- a/netlify.toml
+++ b/netlify.toml
@@ -116,7 +116,8 @@
 #              STRIPE_SECRET_KEY (étape lien de paiement du pipeline délégué —
 #              RDV vidéo avec solde dû),
 #              GOOGLE_CALENDAR_ID + GOOGLE_OAUTH_CLIENT_ID/SECRET/REFRESH_TOKEN
-#              (étape agenda via le seam DI — cf. bloc Google ci-dessus),
+#              (étape agenda via le seam DI — vars OAuth du dashboard Netlify,
+#              lues via process.env au runtime, hors [build.environment]),
 #              GOOGLE_CALENDAR_MOCK (optionnel — 'true' = no-op agenda),
 #              PUBLIC_SENTRY_DSN (optionnel — instrumentation Sentry).
 #   Note : STRIPE_SUCCESS_URL n'est PAS lue dans ce runtime — le pipeline

--- a/netlify.toml
+++ b/netlify.toml
@@ -111,13 +111,17 @@
 #   `invitation_sent_at IS NULL` (créés < 48h, à venir).
 #   Requiert : SUPABASE_DATABASE_URL, SUPABASE_SERVICE_ROLE_KEY (écriture
 #              invitation_sent_at), RESEND_API_KEY, RESEND_FROM_EMAIL,
+#              BETTER_AUTH_SECRET (signature des liens .ics de l'email —
+#              validée au démarrage, abort si absente),
 #              STRIPE_SECRET_KEY (étape lien de paiement du pipeline délégué —
 #              RDV vidéo avec solde dû),
-#              STRIPE_SUCCESS_URL (URL de succès du Payment Link — NON lue dans
-#              ce runtime : le sweep ne passe pas successUrl au pipeline, qui
-#              retombe sur https://omf-therapie.fr/rdv/merci/),
+#              GOOGLE_CALENDAR_ID + GOOGLE_OAUTH_CLIENT_ID/SECRET/REFRESH_TOKEN
+#              (étape agenda via le seam DI — cf. bloc Google ci-dessus),
 #              GOOGLE_CALENDAR_MOCK (optionnel — 'true' = no-op agenda),
-#              PUBLIC_SENTRY_DSN (optionnel — instrumentation Sentry)
+#              PUBLIC_SENTRY_DSN (optionnel — instrumentation Sentry).
+#   Note : STRIPE_SUCCESS_URL n'est PAS lue dans ce runtime — le pipeline
+#   délégué retombe sur l'URL de succès codée en dur
+#   (https://omf-therapie.fr/rdv/merci/).
 
 # ---------------------------------------------------------------------------
 # Contextes de déploiement — variables non-sensibles par contexte

--- a/netlify.toml
+++ b/netlify.toml
@@ -103,6 +103,21 @@
 #              ADMIN_EMAIL (optionnel — sinon notification thérapeute ignorée),
 #              BETTER_AUTH_SECRET (signature du jeton .ics),
 #              BETTER_AUTH_URL ou SITE_URL (URL de base pour les liens)
+#
+# netlify/functions/reconcile-invitations.ts — sweep des invitations #126 (horaire :20)
+#   Backstop du pipeline post-réponse (waitUntil) : rejoue le pipeline partagé
+#   (`processAppointmentSideEffects`) pour les rendez-vous post-réponse
+#   (`confirmed`/`payment_pending`/`payment_received`) avec
+#   `invitation_sent_at IS NULL` (créés < 48h, à venir).
+#   Requiert : SUPABASE_DATABASE_URL, SUPABASE_SERVICE_ROLE_KEY (écriture
+#              invitation_sent_at), RESEND_API_KEY, RESEND_FROM_EMAIL,
+#              STRIPE_SECRET_KEY (étape lien de paiement du pipeline délégué —
+#              RDV vidéo avec solde dû),
+#              STRIPE_SUCCESS_URL (URL de succès du Payment Link — NON lue dans
+#              ce runtime : le sweep ne passe pas successUrl au pipeline, qui
+#              retombe sur https://omf-therapie.fr/rdv/merci/),
+#              GOOGLE_CALENDAR_MOCK (optionnel — 'true' = no-op agenda),
+#              PUBLIC_SENTRY_DSN (optionnel — instrumentation Sentry)
 
 # ---------------------------------------------------------------------------
 # Contextes de déploiement — variables non-sensibles par contexte

--- a/netlify.toml
+++ b/netlify.toml
@@ -111,6 +111,8 @@
 #   `invitation_sent_at IS NULL` (créés < 48h, à venir).
 #   Requiert : SUPABASE_DATABASE_URL, SUPABASE_SERVICE_ROLE_KEY (écriture
 #              invitation_sent_at), RESEND_API_KEY, RESEND_FROM_EMAIL,
+#              ADMIN_EMAIL (copie thérapeute en BCC des emails de
+#              rattrapage — parité avec sendEmail),
 #              BETTER_AUTH_SECRET (signature des liens .ics de l'email —
 #              validée au démarrage, abort si absente),
 #              STRIPE_SECRET_KEY (étape lien de paiement du pipeline délégué —

--- a/netlify/functions/reconcile-invitations.ts
+++ b/netlify/functions/reconcile-invitations.ts
@@ -196,6 +196,10 @@ async function reconcile(): Promise<void> {
   const resendApiKey = process.env.RESEND_API_KEY;
   const fromEmail =
     process.env.RESEND_FROM_EMAIL ?? 'OMF Thérapie <contact@omf-therapie.fr>';
+  // C2 : le jeton d'invitation .ics (email S3 des RDV confirmés/payés par
+  // avoir) est signé HMAC — `import.meta.env` est absent ici, le secret DOIT
+  // venir de process.env (parité reconcile-confirmations.ts).
+  const authSecret = process.env.BETTER_AUTH_SECRET;
 
   if (!supabaseUrl || !supabaseServiceRoleKey) {
     logger.error('reconcile-invitations: SUPABASE_DATABASE_URL or SUPABASE_SERVICE_ROLE_KEY missing — aborting');
@@ -203,6 +207,10 @@ async function reconcile(): Promise<void> {
   }
   if (!resendApiKey) {
     logger.error('reconcile-invitations: RESEND_API_KEY missing — aborting');
+    return;
+  }
+  if (!authSecret || authSecret.trim().length < 32) {
+    logger.error('reconcile-invitations: BETTER_AUTH_SECRET missing or too short — aborting');
     return;
   }
 
@@ -264,9 +272,19 @@ async function reconcile(): Promise<void> {
 
       await processAppointmentSideEffects(appt, {
         sendEmail: true,
-        amountDueCents: appt.status === 'payment_received' ? 0 : appt.final_price,
+        // C3 : solde dû = prix final − avoir déjà consommé. Sans cette
+        // déduction, un RDV payment_pending partiellement couvert par un
+        // avoir était re-facturé à plein tarif par le sweep (surfacturation).
+        // payment_received est déjà réglé → 0 (aucune re-facturation).
+        amountDueCents:
+          appt.status === 'payment_received'
+            ? 0
+            : Math.max(0, (appt.final_price ?? 0) - (appt.credit_applied ?? 0)),
         createCalendarEvent: calendarFn,
         sendFn: sendBundle.sendFn,
+        // C2 : secret HMAC explicite — createSecureLinkToken ne peut pas lire
+        // import.meta.env dans ce runtime Node.
+        signingSecret: authSecret,
         // The pipeline sets the L2 flags itself on success (set-once guard).
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         supabase: supabase as any,

--- a/netlify/functions/reconcile-invitations.ts
+++ b/netlify/functions/reconcile-invitations.ts
@@ -120,18 +120,36 @@ export const config: Config = {
  * capture récupérant la dernière erreur brute Resend. Le pipeline avalle les
  * erreurs email (runStep) — le sweep lit `state.lastError` pour classifier
  * poison (4xx permanent → échappatoire) vs retryable (5xx/429 → passage suivant).
+ *
+ * Parité transport avec `sendEmail` (src/lib/resend.ts) : ADMIN_EMAIL est
+ * ajouté en BCC de chaque email patient sauf s'il est déjà destinataire —
+ * le flux POST obtient ce BCC via sendEmail ; sans cette réplication, la
+ * thérapeute perdrait sa copie sur les emails de rattrapage.
  */
 function makeSendFnWithCapture(resend: Resend, fromEmail: string) {
   const state: { lastError: ResendApiError | null } = { lastError: null };
+  const adminEmail = process.env.ADMIN_EMAIL?.trim().toLowerCase();
   const sendFn = async (params: SendEmailParams): Promise<SendEmailResult> => {
     const { to, bcc, subject, react, replyTo, threadKey, idempotencyKey } =
       params;
     state.lastError = null;
+    const toList = (Array.isArray(to) ? to : [to]).map(email =>
+      email.trim().toLowerCase(),
+    );
+    const bccList = (bcc ? (Array.isArray(bcc) ? bcc : [bcc]) : []).map(email =>
+      email.trim(),
+    );
+    const adminAlreadyTargeted =
+      !!adminEmail &&
+      (toList.includes(adminEmail) ||
+        bccList.some(email => email.toLowerCase() === adminEmail));
+    const resolvedBcc =
+      adminEmail && !adminAlreadyTargeted ? [...bccList, adminEmail] : bccList;
     const { data, error } = await resend.emails.send(
       {
         from: fromEmail,
-        to: Array.isArray(to) ? to : [to],
-        ...(bcc ? { bcc: Array.isArray(bcc) ? bcc : [bcc] } : {}),
+        to: toList,
+        ...(resolvedBcc.length > 0 ? { bcc: resolvedBcc } : {}),
         subject,
         react,
         ...(replyTo ? { replyTo } : {}),

--- a/netlify/functions/reconcile-invitations.ts
+++ b/netlify/functions/reconcile-invitations.ts
@@ -7,11 +7,14 @@
  * flag (`invitation_sent_at`) is still NULL — i.e. the waitUntil pipeline
  * failed, was killed by the function timeout, or was interrupted by a deploy.
  *
- * Strategy: DELEGATION (not duplication). Each eligible row is re-run through
- * the shared pipeline `src/lib/notifications.ts` with a process.env-injected
- * `sendFn` (poison-escape capture, pattern #98). The pipeline sets the L2
- * flags itself on success; the sweep only intervenes on PERMANENT (non-
- * retryable) Resend errors to escape the retry loop (set-once flag update).
+ * Strategy: DELEGATION (not duplication). Each eligible row is claimed
+ * atomically (W2 — `claimInvitationProcessing`, 10 min lease on
+ * `invitation_claimed_at`, see 014_invitation_claim_at.sql) then re-run
+ * through the shared pipeline `src/lib/notifications.ts` with a
+ * process.env-injected `sendFn` (poison-escape capture, pattern #98). The
+ * pipeline sets the L2 flags itself on success; the sweep only intervenes on
+ * PERMANENT (non-retryable) Resend errors to escape the retry loop (set-once
+ * flag update).
  *
  * Runtime constraint: this cron runs in plain Node (`import.meta.env` is
  * absent). Possible only thanks to the lazy-init refactors of `stripe.ts`
@@ -37,8 +40,12 @@ import { Resend } from 'resend';
 import ws from 'ws';
 import type { Appointment } from '../../src/types/appointment';
 import type { SendEmailParams, SendEmailResult } from '../../src/lib/resend';
-import { isRetryableResendError, type ResendApiError } from '../../src/lib/resend-errors';
 import {
+  isRetryableResendError,
+  type ResendApiError,
+} from '../../src/lib/resend-errors';
+import {
+  claimInvitationProcessing,
   processAppointmentSideEffects,
   type ProcessSideEffectsOptions,
 } from '../../src/lib/notifications';
@@ -62,7 +69,7 @@ function initSentry(): void {
   Sentry.init({
     dsn,
     environment: BUILD_CONTEXT === 'production' ? 'production' : 'staging',
-    beforeSend: (event) => (shouldDropEvent(event) ? null : scrubPii(event)),
+    beforeSend: event => (shouldDropEvent(event) ? null : scrubPii(event)),
   });
 }
 
@@ -73,8 +80,17 @@ function initSentry(): void {
 /** Wall-clock budget per invocation (30s Netlify hard timeout, wide margin). */
 const DEADLINE_MS = 8500;
 
-/** Reconcile scope: appointments created within this window are eligible. */
-const CREATED_WITHIN_HOURS = 48;
+/**
+ * Reconcile scope: appointments created within this window are eligible.
+ *
+ * W3 review fix: bounded to the ~24h TTL of the Resend L1 idempotency key
+ * (`invite:{id}:patient`). Beyond that window a replayed pass would no longer
+ * be deduplicated by Resend and could RE-SEND the invitation (the exact
+ * scenario is: email delivered + flag write failed → row still selectable on
+ * a later pass). Past 24h, either the email was delivered (case covered) or
+ * it is in chronic failure, visible in the logs.
+ */
+const CREATED_WITHIN_HOURS = 24;
 
 /** Max rows processed per invocation (bounds work + respects the deadline). */
 const BATCH_LIMIT = 25;
@@ -108,7 +124,8 @@ export const config: Config = {
 function makeSendFnWithCapture(resend: Resend, fromEmail: string) {
   const state: { lastError: ResendApiError | null } = { lastError: null };
   const sendFn = async (params: SendEmailParams): Promise<SendEmailResult> => {
-    const { to, bcc, subject, react, replyTo, threadKey, idempotencyKey } = params;
+    const { to, bcc, subject, react, replyTo, threadKey, idempotencyKey } =
+      params;
     state.lastError = null;
     const { data, error } = await resend.emails.send(
       {
@@ -124,7 +141,10 @@ function makeSendFnWithCapture(resend: Resend, fromEmail: string) {
     );
     if (error) {
       state.lastError = error as ResendApiError;
-      return { success: false, error: (error as ResendApiError).message ?? 'Erreur Resend' };
+      return {
+        success: false,
+        error: (error as ResendApiError).message ?? 'Erreur Resend',
+      };
     }
     return { success: true, id: data?.id };
   };
@@ -140,16 +160,19 @@ type CalendarFn = NonNullable<ProcessSideEffectsOptions['createCalendarEvent']>;
 /** No-op calendar fn injected when GOOGLE_CALENDAR_MOCK=true (warns once). */
 function makeNoopCalendarEvent(): CalendarFn {
   let warned = false;
-  const fn = (async () => {
+  return async () => {
     if (!warned) {
       warned = true;
       console.warn(
         '[reconcile-invitations] GOOGLE_CALENDAR_MOCK=true — calendar step skipped (no-op)',
       );
     }
-    return { eventId: `calendar-mock-${Date.now()}`, meetLink: undefined };
-  }) as unknown as CalendarFn;
-  return fn;
+    // W4 : AUCUN eventId exploitable — S1 (processAppointmentSideEffects)
+    // traite ce résultat comme un skip SANS persistance. Un faux id
+    // `calendar-mock-*` persisté ferait croire aux passages suivants que
+    // l'événement Google existe déjà et verrouillerait le skip S1 à tort.
+    return { eventId: null, meetLink: undefined };
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -175,15 +198,11 @@ async function runReconcile(): Promise<void> {
 // in_progress porteur du monitor_config).
 async function handler(): Promise<void> {
   initSentry();
-  return Sentry.withMonitor(
-    'reconcile-invitations',
-    runReconcile,
-    {
-      schedule: { type: 'crontab', value: SCHEDULE },
-      checkInMargin: 5,
-      maxRuntime: 10,
-    },
-  );
+  return Sentry.withMonitor('reconcile-invitations', runReconcile, {
+    schedule: { type: 'crontab', value: SCHEDULE },
+    checkInMargin: 5,
+    maxRuntime: 10,
+  });
 }
 
 export default handler;
@@ -202,7 +221,9 @@ async function reconcile(): Promise<void> {
   const authSecret = process.env.BETTER_AUTH_SECRET;
 
   if (!supabaseUrl || !supabaseServiceRoleKey) {
-    logger.error('reconcile-invitations: SUPABASE_DATABASE_URL or SUPABASE_SERVICE_ROLE_KEY missing — aborting');
+    logger.error(
+      'reconcile-invitations: SUPABASE_DATABASE_URL or SUPABASE_SERVICE_ROLE_KEY missing — aborting',
+    );
     return;
   }
   if (!resendApiKey) {
@@ -210,7 +231,9 @@ async function reconcile(): Promise<void> {
     return;
   }
   if (!authSecret || authSecret.trim().length < 32) {
-    logger.error('reconcile-invitations: BETTER_AUTH_SECRET missing or too short — aborting');
+    logger.error(
+      'reconcile-invitations: BETTER_AUTH_SECRET missing or too short — aborting',
+    );
     return;
   }
 
@@ -230,7 +253,8 @@ async function reconcile(): Promise<void> {
     : createCalendarEvent;
 
   // Eligibility query (post-answer statuses, L2 flag still NULL, soft-delete
-  // guard, 48h creation window, upcoming only, oldest first, bounded batch).
+  // guard, 24h creation window — W3, bounded to the Resend L1 dedup TTL,
+  // upcoming only, oldest first, bounded batch).
   // NOTE — écart assumé vs spec §5 : `payment_received` est inclus (en plus de
   // 'confirmed' et 'payment_pending') car un RDV payé par avoir (SC3) est
   // inséré directement à payment_received et son email d'invitation peut
@@ -241,21 +265,37 @@ async function reconcile(): Promise<void> {
     .in('status', ['confirmed', 'payment_pending', 'payment_received'])
     .is('invitation_sent_at', null)
     .is('deleted_at', null)
-    .gt('created_at', new Date(Date.now() - CREATED_WITHIN_HOURS * 3_600_000).toISOString())
+    .gt(
+      'created_at',
+      new Date(Date.now() - CREATED_WITHIN_HOURS * 3_600_000).toISOString(),
+    )
     .gt('scheduled_at', new Date().toISOString())
     .order('created_at', { ascending: true })
     .limit(BATCH_LIMIT);
 
   if (fetchError) {
-    logger.error('reconcile-invitations: Supabase query failed', {}, fetchError);
+    logger.error(
+      'reconcile-invitations: Supabase query failed',
+      {},
+      fetchError,
+    );
     return;
   }
 
   const appointments = (rows ?? []) as Appointment[];
-  const counts = { found: appointments.length, reconciled: 0, failed: 0, deadlineHit: false };
+  const counts = {
+    found: appointments.length,
+    reconciled: 0,
+    failed: 0,
+    claimed: 0,
+    deadlineHit: false,
+  };
 
   if (appointments.length === 0) {
-    logger.info('reconcile-invitations: done (empty batch)', { ...counts, msElapsed: Date.now() - startedAt });
+    logger.info('reconcile-invitations: done (empty batch)', {
+      ...counts,
+      msElapsed: Date.now() - startedAt,
+    });
     return;
   }
 
@@ -268,6 +308,20 @@ async function reconcile(): Promise<void> {
 
     // Per-row isolation: a throwing row never blocks the rest of the batch.
     try {
+      // W2 — atomic claim (10 min lease) BEFORE delegating: if the admin POST
+      // waitUntil pipeline (or another worker/pass) already owns this row, do
+      // NOT run the pipeline — two concurrent pipelines would create duplicate
+      // Google events and duplicate Stripe Payment Links. Neither reconciled
+      // nor failed: counted as `claimed` (the owning worker owns the outcome).
+      const claimed = await claimInvitationProcessing(supabase, appt.id);
+      if (!claimed) {
+        logger.info('reconcile-invitations: row already claimed — skipping', {
+          appointmentId: appt.id,
+        });
+        counts.claimed += 1;
+        continue;
+      }
+
       sendBundle.state.lastError = null;
 
       await processAppointmentSideEffects(appt, {
@@ -306,23 +360,37 @@ async function reconcile(): Promise<void> {
           .eq('id', appt.id)
           .is('invitation_sent_at', null);
         if (escapeError) {
-          logger.error('reconcile-invitations: poison-escape UPDATE failed', { appointmentId: appt.id }, escapeError);
+          logger.error(
+            'reconcile-invitations: poison-escape UPDATE failed',
+            { appointmentId: appt.id },
+            escapeError,
+          );
         }
         counts.failed += 1;
       } else if (lastError) {
         // Retryable (5xx, 429, network) → leave the flag NULL; next pass retries.
-        logger.warn('reconcile-invitations: retryable email failure; will retry next sweep', {
-          appointmentId: appt.id,
-        });
+        logger.warn(
+          'reconcile-invitations: retryable email failure; will retry next sweep',
+          {
+            appointmentId: appt.id,
+          },
+        );
         counts.failed += 1;
       } else {
         counts.reconciled += 1;
       }
     } catch (err: unknown) {
-      logger.error('reconcile-invitations: unexpected error for row', { appointmentId: appt.id }, err);
+      logger.error(
+        'reconcile-invitations: unexpected error for row',
+        { appointmentId: appt.id },
+        err,
+      );
       counts.failed += 1;
     }
   }
 
-  logger.info('reconcile-invitations: done', { ...counts, msElapsed: Date.now() - startedAt });
+  logger.info('reconcile-invitations: done', {
+    ...counts,
+    msElapsed: Date.now() - startedAt,
+  });
 }

--- a/netlify/functions/reconcile-invitations.ts
+++ b/netlify/functions/reconcile-invitations.ts
@@ -1,0 +1,310 @@
+/**
+ * Netlify Scheduled Function — Reconciliation sweep for invitation side effects.
+ *
+ * Issue #126 (slice 3, T13): hourly backstop for the post-response pipeline
+ * (`processAppointmentSideEffects`, run via `waitUntil` in the admin POST).
+ * Catches `appointments` rows in a post-answer status whose invitation email
+ * flag (`invitation_sent_at`) is still NULL — i.e. the waitUntil pipeline
+ * failed, was killed by the function timeout, or was interrupted by a deploy.
+ *
+ * Strategy: DELEGATION (not duplication). Each eligible row is re-run through
+ * the shared pipeline `src/lib/notifications.ts` with a process.env-injected
+ * `sendFn` (poison-escape capture, pattern #98). The pipeline sets the L2
+ * flags itself on success; the sweep only intervenes on PERMANENT (non-
+ * retryable) Resend errors to escape the retry loop (set-once flag update).
+ *
+ * Runtime constraint: this cron runs in plain Node (`import.meta.env` is
+ * absent). Possible only thanks to the lazy-init refactors of `stripe.ts`
+ * (T11), `google-calendar.ts` (T12), `resend.ts` (#98) and the env-agnostic
+ * `supabase.ts`. NEVER read `import.meta.env` here.
+ *
+ * ---------------------------------------------------------------------------
+ * Observability — Sentry.withMonitor (patterns #75/#99/#113).
+ * ---------------------------------------------------------------------------
+ *
+ * ---------------------------------------------------------------------------
+ * Required env vars (configure in Netlify dashboard — NEVER inline secrets):
+ *   SUPABASE_DATABASE_URL / SUPABASE_SERVICE_ROLE_KEY — Supabase access
+ *   RESEND_API_KEY / RESEND_FROM_EMAIL                 — invitation emails
+ *   GOOGLE_CALENDAR_MOCK (optional)                    — 'true' = no-op calendar
+ *   PUBLIC_SENTRY_DSN (optional)                       — Sentry instrumentation
+ */
+
+import type { Config } from '@netlify/functions';
+import * as Sentry from '@sentry/node';
+import { createClient } from '@supabase/supabase-js';
+import { Resend } from 'resend';
+import ws from 'ws';
+import type { Appointment } from '../../src/types/appointment';
+import type { SendEmailParams, SendEmailResult } from '../../src/lib/resend';
+import { isRetryableResendError, type ResendApiError } from '../../src/lib/resend-errors';
+import {
+  processAppointmentSideEffects,
+  type ProcessSideEffectsOptions,
+} from '../../src/lib/notifications';
+import { createCalendarEvent } from '../../src/lib/google-calendar';
+import { scrubPii, shouldDropEvent, captureAndFlush } from './_lib/sentry';
+import { BUILD_CONTEXT } from './_lib/build-env';
+import { logger } from './_lib/logger';
+
+/**
+ * Sentry init PER-INVOCATION (not the `initialized`-guarded `_lib/sentry`
+ * version). Rationale: the withMonitor `in_progress` check-in — the only one
+ * carrying monitor_config (#113) — requires an initialized client at every
+ * invocation. In a warm container the shared cross-invocation guard would be
+ * a no-op optimization, but re-initializing is cheap and guarantees the
+ * monitor config is never dropped. Reuses the shared PII scrubber + noise
+ * filter (parity with the other crons).
+ */
+function initSentry(): void {
+  const dsn = process.env.PUBLIC_SENTRY_DSN;
+  if (!dsn) return;
+  Sentry.init({
+    dsn,
+    environment: BUILD_CONTEXT === 'production' ? 'production' : 'staging',
+    beforeSend: (event) => (shouldDropEvent(event) ? null : scrubPii(event)),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Wall-clock budget per invocation (30s Netlify hard timeout, wide margin). */
+const DEADLINE_MS = 8500;
+
+/** Reconcile scope: appointments created within this window are eligible. */
+const CREATED_WITHIN_HOURS = 48;
+
+/** Max rows processed per invocation (bounds work + respects the deadline). */
+const BATCH_LIMIT = 25;
+
+/** Schedule partagée entre la config Netlify et le monitor Sentry. */
+const SCHEDULE = '20 * * * *' as const;
+
+export const config: Config = {
+  /**
+   * Chaque heure à H:20 (décalé du sweep #98 à H:05 pour éviter la contention).
+   *
+   * ⚠️  NE PAS remplacer par la const SCHEDULE ci-dessus — l'extracteur statique
+   * de Netlify ne résout QUE les littéraux (régression #113/#114). Le littéral
+   * DOIT rester inline ici ; la synchronisation SCHEDULE ↔ littéral est
+   * verrouillée par tests.
+   */
+  schedule: '20 * * * *',
+  // No schedule_timezone → Netlify defaults to UTC (matches Sentry monitor).
+};
+
+// ---------------------------------------------------------------------------
+// sendFn with capture (poison-escape pattern #98 — makeSendFnWithCapture)
+// ---------------------------------------------------------------------------
+
+/**
+ * Crée un `sendFn` (client Resend instancié depuis process.env) + un état de
+ * capture récupérant la dernière erreur brute Resend. Le pipeline avalle les
+ * erreurs email (runStep) — le sweep lit `state.lastError` pour classifier
+ * poison (4xx permanent → échappatoire) vs retryable (5xx/429 → passage suivant).
+ */
+function makeSendFnWithCapture(resend: Resend, fromEmail: string) {
+  const state: { lastError: ResendApiError | null } = { lastError: null };
+  const sendFn = async (params: SendEmailParams): Promise<SendEmailResult> => {
+    const { to, bcc, subject, react, replyTo, threadKey, idempotencyKey } = params;
+    state.lastError = null;
+    const { data, error } = await resend.emails.send(
+      {
+        from: fromEmail,
+        to: Array.isArray(to) ? to : [to],
+        ...(bcc ? { bcc: Array.isArray(bcc) ? bcc : [bcc] } : {}),
+        subject,
+        react,
+        ...(replyTo ? { replyTo } : {}),
+        ...(threadKey ? { headers: { 'X-Thread-Key': threadKey } } : {}),
+      },
+      idempotencyKey ? { idempotencyKey } : undefined,
+    );
+    if (error) {
+      state.lastError = error as ResendApiError;
+      return { success: false, error: (error as ResendApiError).message ?? 'Erreur Resend' };
+    }
+    return { success: true, id: data?.id };
+  };
+  return { sendFn, state };
+}
+
+// ---------------------------------------------------------------------------
+// Calendar DI — no-op when GOOGLE_CALENDAR_MOCK=true (dev-only skip)
+// ---------------------------------------------------------------------------
+
+type CalendarFn = NonNullable<ProcessSideEffectsOptions['createCalendarEvent']>;
+
+/** No-op calendar fn injected when GOOGLE_CALENDAR_MOCK=true (warns once). */
+function makeNoopCalendarEvent(): CalendarFn {
+  let warned = false;
+  const fn = (async () => {
+    if (!warned) {
+      warned = true;
+      console.warn(
+        '[reconcile-invitations] GOOGLE_CALENDAR_MOCK=true — calendar step skipped (no-op)',
+      );
+    }
+    return { eventId: `calendar-mock-${Date.now()}`, meetLink: undefined };
+  }) as unknown as CalendarFn;
+  return fn;
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+async function runReconcile(): Promise<void> {
+  try {
+    await reconcile();
+  } catch (err) {
+    await captureAndFlush(err);
+    throw err;
+  } finally {
+    if (process.env.PUBLIC_SENTRY_DSN) {
+      await Sentry.flush(2000);
+    }
+  }
+}
+
+// CRITIQUE (#75) : withMonitor retourne T, pas une fonction — on l'enveloppe
+// dans une vraie fonction handler invoquable par le bootstrap Netlify.
+// CRITIQUE (#113) : initSentry() DOIT précéder withMonitor (check-in
+// in_progress porteur du monitor_config).
+async function handler(): Promise<void> {
+  initSentry();
+  return Sentry.withMonitor(
+    'reconcile-invitations',
+    runReconcile,
+    {
+      schedule: { type: 'crontab', value: SCHEDULE },
+      checkInMargin: 5,
+      maxRuntime: 10,
+    },
+  );
+}
+
+export default handler;
+
+async function reconcile(): Promise<void> {
+  const startedAt = Date.now();
+
+  const supabaseUrl = process.env.SUPABASE_DATABASE_URL;
+  const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const resendApiKey = process.env.RESEND_API_KEY;
+  const fromEmail =
+    process.env.RESEND_FROM_EMAIL ?? 'OMF Thérapie <contact@omf-therapie.fr>';
+
+  if (!supabaseUrl || !supabaseServiceRoleKey) {
+    logger.error('reconcile-invitations: SUPABASE_DATABASE_URL or SUPABASE_SERVICE_ROLE_KEY missing — aborting');
+    return;
+  }
+  if (!resendApiKey) {
+    logger.error('reconcile-invitations: RESEND_API_KEY missing — aborting');
+    return;
+  }
+
+  // Clients from process.env ONLY (import.meta.env is absent in the cron runtime).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const supabase = createClient<any>(supabaseUrl, supabaseServiceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+    realtime: { transport: ws },
+  });
+  const resend = new Resend(resendApiKey);
+  const sendBundle = makeSendFnWithCapture(resend, fromEmail);
+
+  // Calendar DI: real module unless GOOGLE_CALENDAR_MOCK==='true' (default false).
+  const isCalendarMock = process.env.GOOGLE_CALENDAR_MOCK === 'true';
+  const calendarFn: CalendarFn = isCalendarMock
+    ? makeNoopCalendarEvent()
+    : createCalendarEvent;
+
+  // Eligibility query (post-answer statuses, L2 flag still NULL, soft-delete
+  // guard, 48h creation window, upcoming only, oldest first, bounded batch).
+  // NOTE — écart assumé vs spec §5 : `payment_received` est inclus (en plus de
+  // 'confirmed' et 'payment_pending') car un RDV payé par avoir (SC3) est
+  // inséré directement à payment_received et son email d'invitation peut
+  // tout aussi bien échouer.
+  const { data: rows, error: fetchError } = await supabase
+    .from('appointments')
+    .select('*')
+    .in('status', ['confirmed', 'payment_pending', 'payment_received'])
+    .is('invitation_sent_at', null)
+    .is('deleted_at', null)
+    .gt('created_at', new Date(Date.now() - CREATED_WITHIN_HOURS * 3_600_000).toISOString())
+    .gt('scheduled_at', new Date().toISOString())
+    .order('created_at', { ascending: true })
+    .limit(BATCH_LIMIT);
+
+  if (fetchError) {
+    logger.error('reconcile-invitations: Supabase query failed', {}, fetchError);
+    return;
+  }
+
+  const appointments = (rows ?? []) as Appointment[];
+  const counts = { found: appointments.length, reconciled: 0, failed: 0, deadlineHit: false };
+
+  if (appointments.length === 0) {
+    logger.info('reconcile-invitations: done (empty batch)', { ...counts, msElapsed: Date.now() - startedAt });
+    return;
+  }
+
+  for (const appt of appointments) {
+    // Deadline guard — remaining rows drain on the next hourly pass.
+    if (Date.now() - startedAt > DEADLINE_MS) {
+      counts.deadlineHit = true;
+      break;
+    }
+
+    // Per-row isolation: a throwing row never blocks the rest of the batch.
+    try {
+      sendBundle.state.lastError = null;
+
+      await processAppointmentSideEffects(appt, {
+        sendEmail: true,
+        amountDueCents: appt.status === 'payment_received' ? 0 : appt.final_price,
+        createCalendarEvent: calendarFn,
+        sendFn: sendBundle.sendFn,
+        // The pipeline sets the L2 flags itself on success (set-once guard).
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        supabase: supabase as any,
+      });
+
+      const lastError = sendBundle.state.lastError;
+      if (lastError && !isRetryableResendError(lastError)) {
+        // Poison-escape: permanent 4xx on the patient email → the sweep itself
+        // sets invitation_sent_at (set-once) to stop the hourly retry loop.
+        // Log sans PII : appointment ID seulement, jamais patient_email.
+        logger.error(
+          'reconcile-invitations: poison row — permanent Resend error, escaping retry loop',
+          { appointmentId: appt.id },
+          lastError,
+        );
+        const { error: escapeError } = await supabase
+          .from('appointments')
+          .update({ invitation_sent_at: new Date().toISOString() })
+          .eq('id', appt.id)
+          .is('invitation_sent_at', null);
+        if (escapeError) {
+          logger.error('reconcile-invitations: poison-escape UPDATE failed', { appointmentId: appt.id }, escapeError);
+        }
+        counts.failed += 1;
+      } else if (lastError) {
+        // Retryable (5xx, 429, network) → leave the flag NULL; next pass retries.
+        logger.warn('reconcile-invitations: retryable email failure; will retry next sweep', {
+          appointmentId: appt.id,
+        });
+        counts.failed += 1;
+      } else {
+        counts.reconciled += 1;
+      }
+    } catch (err: unknown) {
+      logger.error('reconcile-invitations: unexpected error for row', { appointmentId: appt.id }, err);
+      counts.failed += 1;
+    }
+  }
+
+  logger.info('reconcile-invitations: done', { ...counts, msElapsed: Date.now() - startedAt });
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "eslint .",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:low": "node scripts/generate-build-env.mjs && vitest run --pool=threads --maxWorkers=1 --no-file-parallelism",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "typecheck": "astro check",

--- a/src/components/admin/AdminCreateButton.tsx
+++ b/src/components/admin/AdminCreateButton.tsx
@@ -621,7 +621,10 @@ function AdminCreateModal({ onClose, prefillData }: { onClose: () => void; prefi
 
           {/* ── Erreur ── */}
           {error && (
-            <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 font-sans">
+            <div
+              role="alert"
+              className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 font-sans"
+            >
               {error}
             </div>
           )}

--- a/src/components/admin/AdminCreateButton.tsx
+++ b/src/components/admin/AdminCreateButton.tsx
@@ -60,6 +60,10 @@ const DURATIONS: { value: AppointmentDuration | 'custom'; label: string }[] = [
   { value: 'custom' as const, label: 'Personnalisée…' },
 ];
 
+// 5xx ou erreur réseau : le traitement serveur a peut-être abouti malgré l'échec apparent.
+const UNCERTAIN_RESULT_MESSAGE =
+  "La création a peut-être abouti — vérifiez la liste des rendez-vous avant de retenter.";
+
 const INITIAL_STATE: FormState = {
   patient_name: "",
   patient_email: "",
@@ -309,6 +313,9 @@ function AdminCreateModal({ onClose, prefillData }: { onClose: () => void; prefi
       });
 
       if (!res.ok) {
+        // 5xx (504/502…) : le traitement serveur peut continuer en arrière-plan —
+        // la ligne est peut-être créée. On invite à vérifier avant de retenter.
+        if (res.status >= 500) throw new Error(UNCERTAIN_RESULT_MESSAGE);
         const data = await res.json().catch(() => ({}));
         throw new Error(data.error ?? `Erreur ${res.status}`);
       }
@@ -316,7 +323,12 @@ function AdminCreateModal({ onClose, prefillData }: { onClose: () => void; prefi
       // Succès : recharger la page pour afficher le nouveau RDV
       window.location.reload();
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Une erreur est survenue");
+      // Erreur réseau (fetch rejeté) : même incertitude — la requête a peut-être abouti.
+      setError(
+        err instanceof TypeError ? UNCERTAIN_RESULT_MESSAGE
+          : err instanceof Error ? err.message
+          : "Une erreur est survenue",
+      );
     } finally {
       setLoading(false);
     }

--- a/src/lib/google-calendar.ts
+++ b/src/lib/google-calendar.ts
@@ -108,10 +108,56 @@ export type AppointmentMode = 'in-person' | 'video';
 export type AppointmentDuration = 60 | 90;
 
 // ---------------------------------------------------------------------------
+// Env access — lazy & runtime-agnostic (issue #126 / T12)
+// ---------------------------------------------------------------------------
+
+/**
+ * Reads an env var at FIRST USE (never at module load) with an Astro → Node
+ * fallback. Netlify scheduled functions (pure Node runtime) have no Vite env
+ * object — a module-scope read would crash at import time, so every
+ * env access in this file must go through this helper (or an explicit DI value).
+ */
+function readEnv(key: string): string | undefined {
+  const fromMeta = (import.meta as { env?: Record<string, string | undefined> }).env?.[key];
+  if (fromMeta !== undefined) return fromMeta;
+  return process.env[key];
+}
+
+// ---------------------------------------------------------------------------
 // Mock mode
 // ---------------------------------------------------------------------------
 
-const MOCK_MODE = import.meta.env.GOOGLE_CALENDAR_MOCK === 'true';
+/** Mock flag read lazily — identical behavior, just no module-scope env read. */
+function isMockMode(): boolean {
+  return readEnv('GOOGLE_CALENDAR_MOCK') === 'true';
+}
+
+// ---------------------------------------------------------------------------
+// DI seam (issue #126 / T12)
+// ---------------------------------------------------------------------------
+
+/**
+ * Dependency-injection seam for the future `reconcile-invitations` cron
+ * (Netlify scheduled function, pure Node runtime). The cron builds its own
+ * calendar client from `process.env` and passes it here; all existing callers
+ * keep the previous behavior (client built from env on first use).
+ */
+export interface CalendarClientOptions {
+  /** Explicit googleapis calendar client — defaults to building one from env. */
+  calendar?: calendar_v3.Calendar;
+  /** Explicit calendar id — defaults to GOOGLE_CALENDAR_ID from env. */
+  calendarId?: string;
+}
+
+async function resolveCalendarId(explicit?: string): Promise<string> {
+  const calendarId = explicit ?? readEnv('GOOGLE_CALENDAR_ID');
+  if (!calendarId) {
+    throw new GoogleCalendarError(
+      'Configuration manquante : GOOGLE_CALENDAR_ID non défini.',
+    );
+  }
+  return calendarId;
+}
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -133,11 +179,11 @@ const MIN_NOTICE_MS = 24 * 60 * 60 * 1000;
  * Falls back to bootstrapping from env vars on first run.
  */
 async function getPersistedOAuthClient(): Promise<Auth.OAuth2Client | null> {
-  const clientId = import.meta.env.GOOGLE_OAUTH_CLIENT_ID;
-  const clientSecret = import.meta.env.GOOGLE_OAUTH_CLIENT_SECRET;
+  const clientId = readEnv('GOOGLE_OAUTH_CLIENT_ID');
+  const clientSecret = readEnv('GOOGLE_OAUTH_CLIENT_SECRET');
   if (!clientId || !clientSecret) return null;
 
-  const redirectUri = import.meta.env.GOOGLE_OAUTH_REDIRECT_URI ?? 'https://developers.google.com/oauthplayground';
+  const redirectUri = readEnv('GOOGLE_OAUTH_REDIRECT_URI') ?? 'https://developers.google.com/oauthplayground';
   const oauth2Client = new google.auth.OAuth2(clientId, clientSecret, redirectUri);
 
   // 1. Load persisted tokens from DB
@@ -149,7 +195,7 @@ async function getPersistedOAuthClient(): Promise<Auth.OAuth2Client | null> {
 
   if (!tokens) {
     // 2. Bootstrap from env vars on first run
-    const refreshToken = import.meta.env.GOOGLE_OAUTH_REFRESH_TOKEN;
+    const refreshToken = readEnv('GOOGLE_OAUTH_REFRESH_TOKEN');
     if (!refreshToken) return null;
 
     tokens = {
@@ -185,8 +231,8 @@ async function getPersistedOAuthClient(): Promise<Auth.OAuth2Client | null> {
       const errData = (err as { response?: { data?: { error?: string } } })?.response?.data;
       if (errData?.error === 'invalid_grant') {
         // AC-3: alert admin — fire and forget (don't block the throw)
-        const adminEmail = import.meta.env.ADMIN_EMAIL as string | undefined;
-        const siteUrl = import.meta.env.SITE_URL ?? 'https://omf-therapie.fr';
+        const adminEmail = readEnv('ADMIN_EMAIL');
+        const siteUrl = readEnv('SITE_URL') ?? 'https://omf-therapie.fr';
         if (adminEmail) {
           const { createElement } = await import('react');
           const { default: CalendarAuthAlert } = await import('../emails/CalendarAuthAlert');
@@ -498,8 +544,9 @@ export async function getAvailableSlots(
   duration: AppointmentDuration,
   mode: AppointmentMode,
   dbBusyPeriods: Array<{ start: string; end: string }> = [],
+  options: CalendarClientOptions = {},
 ): Promise<TimeSlot[]> {
-  if (MOCK_MODE) {
+  if (isMockMode()) {
     console.log('[calendar-mock] getAvailableSlots called — generating slots via shared algorithm');
 
     // Mock = pas de Google Calendar : on réutilise le même moteur de génération
@@ -528,10 +575,7 @@ export async function getAvailableSlots(
     });
   }
 
-  const calendarId = import.meta.env.GOOGLE_CALENDAR_ID;
-  if (!calendarId) {
-    throw new Error('Configuration manquante : GOOGLE_CALENDAR_ID non défini.');
-  }
+  const calendarId = await resolveCalendarId(options.calendarId);
 
   const candidates = await generateCandidateSlots(startDate, endDate, duration, mode);
 
@@ -539,8 +583,7 @@ export async function getAvailableSlots(
     return [];
   }
 
-  const auth = await resolveCalendarAuth();
-  const calendar = google.calendar({ version: 'v3', auth });
+  const calendar = options.calendar ?? google.calendar({ version: 'v3', auth: await resolveCalendarAuth() });
 
   // Une seule requête Freebusy pour toute la plage
   let busyPeriods: Array<{ start: string; end: string }> = [];
@@ -682,18 +725,17 @@ async function pollMeetLink(
 export async function updateCalendarEvent(
   eventId: string,
   patch: { start?: Date; end?: Date; summary?: string },
+  options: CalendarClientOptions = {},
 ): Promise<void> {
-  if (MOCK_MODE) {
+  if (isMockMode()) {
     console.log(`[calendar-mock] Updating event ${eventId}:`, patch);
     return;
   }
 
-  const calendarId = import.meta.env.GOOGLE_CALENDAR_ID;
-  if (!calendarId) throw new GoogleCalendarError('GOOGLE_CALENDAR_ID non défini.');
+  const calendarId = await resolveCalendarId(options.calendarId);
 
   await withCalendarRetry(async () => {
-    const auth = await resolveCalendarAuth();
-    const calendar = google.calendar({ version: 'v3', auth });
+    const calendar = options.calendar ?? google.calendar({ version: 'v3', auth: await resolveCalendarAuth() });
     const body: calendar_v3.Schema$Event = {};
     if (patch.start) body.start = { dateTime: patch.start.toISOString(), timeZone: TIMEZONE };
     if (patch.end) body.end = { dateTime: patch.end.toISOString(), timeZone: TIMEZONE };
@@ -710,18 +752,19 @@ export async function updateCalendarEvent(
 /**
  * Deletes a Google Calendar event (e.g., on decline or cancellation).
  */
-export async function deleteCalendarEvent(eventId: string): Promise<void> {
-  if (MOCK_MODE) {
+export async function deleteCalendarEvent(
+  eventId: string,
+  options: CalendarClientOptions = {},
+): Promise<void> {
+  if (isMockMode()) {
     console.log(`[calendar-mock] Deleting event ${eventId}`);
     return;
   }
 
-  const calendarId = import.meta.env.GOOGLE_CALENDAR_ID;
-  if (!calendarId) throw new GoogleCalendarError('GOOGLE_CALENDAR_ID non défini.');
+  const calendarId = await resolveCalendarId(options.calendarId);
 
   await withCalendarRetry(async () => {
-    const auth = await resolveCalendarAuth();
-    const calendar = google.calendar({ version: 'v3', auth });
+    const calendar = options.calendar ?? google.calendar({ version: 'v3', auth: await resolveCalendarAuth() });
     await calendar.events.delete({
       calendarId,
       eventId,
@@ -736,8 +779,9 @@ export async function deleteCalendarEvent(eventId: string): Promise<void> {
  */
 export async function createCalendarEvent(
   params: CreateEventParams,
+  options: CalendarClientOptions = {},
 ): Promise<CreateEventResult> {
-  if (MOCK_MODE) {
+  if (isMockMode()) {
     console.log(`[calendar-mock] Creating event: ${params.title} at ${params.start}`);
     const { withMeet, appointmentId } = params;
     const eventId = `mock-event-${Date.now()}`;
@@ -749,10 +793,7 @@ export async function createCalendarEvent(
     };
   }
 
-  const calendarId = import.meta.env.GOOGLE_CALENDAR_ID;
-  if (!calendarId) {
-    throw new Error('Configuration manquante : GOOGLE_CALENDAR_ID non défini.');
-  }
+  const calendarId = await resolveCalendarId(options.calendarId);
 
   const attendees = params.attendeeEmail
     ? [{ email: params.attendeeEmail }]
@@ -813,14 +854,15 @@ export async function createCalendarEvent(
   };
 
   // Use OAuth for all event types (Meet and in-person).
-  const oauthAuth = await getPersistedOAuthClient();
-  if (!oauthAuth) {
-    throw new GoogleCalendarError(
-      'OAuth non configuré : impossible de créer le rendez-vous dans l\'agenda.',
-    );
-  }
-
-  const oauthCalendar = google.calendar({ version: 'v3', auth: oauthAuth });
+  const oauthCalendar = options.calendar ?? await (async () => {
+    const oauthAuth = await getPersistedOAuthClient();
+    if (!oauthAuth) {
+      throw new GoogleCalendarError(
+        'OAuth non configuré : impossible de créer le rendez-vous dans l\'agenda.',
+      );
+    }
+    return google.calendar({ version: 'v3', auth: oauthAuth });
+  })();
   try {
     return await upsertEvent(
       oauthCalendar,

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -39,9 +39,13 @@ import {
   therapistConfirmationKey,
 } from './idempotency-keys';
 import { getTypeLabel, getModeLabel } from './pricing';
+import { createCalendarEvent } from './google-calendar';
+import { createAppointmentPaymentLink } from './stripe';
+import { supabaseAdmin } from './supabase';
 import AppointmentConfirmed from '../emails/AppointmentConfirmed';
 import PaymentReceivedNotification from '../emails/PaymentReceivedNotification';
-import type { Appointment } from '../types/appointment';
+import PaymentRequest from '../emails/PaymentRequest';
+import type { Appointment, AppointmentType } from '../types/appointment';
 
 export interface SendConfirmationsResult {
   patientEmailSent: boolean;
@@ -209,4 +213,273 @@ export async function buildAndSendConfirmationEmails(
     : false;
 
   return { patientEmailSent, therapistEmailSent };
+}
+
+// ---------------------------------------------------------------------------
+// Issue #126 / T6 — pipeline de side-effects post-réponse
+// ---------------------------------------------------------------------------
+
+/**
+ * Rendez-vous inséré (ligne `appointments` + contexte d'exécution) tel que
+ * renvoyé par le POST /api/admin/appointments/.
+ * Structurellement compatible avec `Appointment` (champs utilisés seulement).
+ */
+export interface SideEffectsAppointment {
+  id: string;
+  status: string;
+  appointment_type: string;
+  appointment_mode: 'video' | 'in-person';
+  duration: number;
+  scheduled_at: string;
+  patient_name: string;
+  patient_email: string;
+  final_price: number;
+  video_link?: string | null;
+  google_calendar_event_id?: string | null;
+}
+
+/** Chaîne d'update Supabase minimale (DI test-friendly, set-once via `.is`). */
+interface SupabaseUpdateChain extends PromiseLike<{ data: unknown; error: unknown }> {
+  eq: (column: string, value: unknown) => SupabaseUpdateChain;
+  is: (column: string, value: unknown) => SupabaseUpdateChain;
+}
+
+/** Client Supabase minimal requis pour les écritures L2. */
+type SupabaseLike = {
+  from: (table: string) => { update: (payload: Record<string, unknown>) => SupabaseUpdateChain };
+};
+
+export interface ProcessSideEffectsOptions {
+  /** S3 : envoyer l'email patient (condition `send_email` du POST). */
+  sendEmail: boolean;
+  /** S2 : solde dû en centimes (final_price - credit_applied). */
+  amountDueCents: number;
+  /** URL de succès Stripe (S2). */
+  successUrl?: string;
+  /** Base des liens sécurisés .ics (DI, comme BuildAndSendOptions). */
+  baseUrl?: string;
+  /** Email admin (réservé — le POST actuel n'envoie pas de notification thérapeute ici). */
+  adminEmail?: string;
+  /** DI — défaut : module app. */
+  createCalendarEvent?: typeof createCalendarEvent;
+  createAppointmentPaymentLink?: typeof createAppointmentPaymentLink;
+  sendFn?: typeof sendEmail;
+  /** Client Supabase pour les écritures L2 — défaut : `supabaseAdmin`. */
+  supabase?: SupabaseLike;
+}
+
+type StepName = 'calendar' | 'stripe' | 'email' | 'flags';
+type StepStatus = 'ok' | 'skipped' | 'error';
+
+/**
+ * Exécute une étape du pipeline avec isolation + observabilité :
+ * durée mesurée, log structuré unique `[side-effects]`, erreur avalée
+ * (le pipeline continue — le cron de rattrapage repasse sur les flags NULL).
+ */
+async function runStep<T>(
+  step: StepName,
+  appointmentId: string,
+  fn: () => Promise<T>,
+): Promise<{ status: StepStatus; value?: T }> {
+  const start = Date.now();
+  try {
+    const value = await fn();
+    console.info('[side-effects]', { step, appointmentId, ms: Date.now() - start, status: 'ok' });
+    return { status: 'ok', value };
+  } catch (err) {
+    console.error('[side-effects] step failed:', step, appointmentId, err);
+    console.info('[side-effects]', { step, appointmentId, ms: Date.now() - start, status: 'error' });
+    return { status: 'error' };
+  }
+}
+
+function logSkipped(step: StepName, appointmentId: string): void {
+  console.info('[side-effects]', { step, appointmentId, ms: 0, status: 'skipped' });
+}
+
+/**
+ * Pipeline agenda → Stripe → email + drapeaux L2, extrait du
+ * POST /api/admin/appointments/ (issue #126). Conçu pour être exécuté
+ * POST-RÉPONSE via `waitUntil` (T7) ET par le futur cron de rattrapage :
+ *
+ * - S1 calendar : événement standard TOUJOURS créé (`withMeet:false` si un
+ *   `video_link` existe déjà) ; persistance de l'event id (+ meet link).
+ * - S2 stripe   : uniquement `mode vidéo && amountDueCents > 0`.
+ * - S3 email    : uniquement `opts.sendEmail` ; clé d'idempotence Resend L1
+ *   `invite:{id}:patient`. Réutilise la composition d'emails du POST.
+ * - flags L2    : un SEUL update set-once `.is('invitation_sent_at', null)` ;
+ *   `confirmation_sent_at` posé dans le MÊME update quand
+ *   `status === 'payment_received'`.
+ *
+ * Chaque étape est isolée : une erreur est loguée (`status:'error'`) et le
+ * pipeline CONTINUE. Ne jette jamais.
+ */
+export async function processAppointmentSideEffects(
+  appt: SideEffectsAppointment,
+  opts: ProcessSideEffectsOptions,
+): Promise<void> {
+  const db = opts.supabase ?? (supabaseAdmin as unknown as SupabaseLike);
+  const calendarFn = opts.createCalendarEvent ?? createCalendarEvent;
+  const paymentLinkFn = opts.createAppointmentPaymentLink ?? createAppointmentPaymentLink;
+  const send = opts.sendFn ?? sendEmail;
+  const isVideo = appt.appointment_mode === 'video';
+  const baseUrl = opts.baseUrl ?? 'https://omf-therapie.fr';
+
+  // --- S1 : événement agenda (standard ; pas de Meet si video_link déjà fourni)
+  let resolvedVideoLink: string | undefined = appt.video_link ?? undefined;
+
+  if (appt.google_calendar_event_id) {
+    logSkipped('calendar', appt.id);
+  } else {
+    const cal = await runStep('calendar', appt.id, async () => {
+      const start = new Date(appt.scheduled_at);
+      const end = new Date(start.getTime() + appt.duration * 60 * 1000);
+      const modeLabel = isVideo ? 'Téléconsultation' : 'Présentiel';
+      const calResult = await calendarFn({
+        title: `${isVideo ? '🎥 ' : ''}${appt.patient_name} — séance ${modeLabel.toLowerCase()} (${appt.duration} min)`,
+        start: start.toISOString(),
+        end: end.toISOString(),
+        description: [
+          `Patient: ${appt.patient_name}`,
+          `Email: ${appt.patient_email}`,
+          `Mode: ${modeLabel}`,
+          `Durée: ${appt.duration} min`,
+          ...(resolvedVideoLink ? [`Lien visio: ${resolvedVideoLink}`] : []),
+        ].join('\n'),
+        location: isVideo ? 'Téléconsultation' : CABINET_ADDRESS,
+        attendeeEmail: appt.patient_email,
+        withMeet: isVideo && !resolvedVideoLink,
+        appointmentId: `${appt.id}-admin-${isVideo ? 'video' : 'inperson'}`,
+        colorId: isVideo ? '11' : '2',
+      });
+      // Persistance technique (update simple, distinct du set-once final).
+      const calendarUpdate: Record<string, string> = { google_calendar_event_id: calResult.eventId };
+      if (isVideo && calResult.meetLink) calendarUpdate.video_link = calResult.meetLink;
+      await db.from('appointments').update(calendarUpdate).eq('id', appt.id);
+      return calResult;
+    });
+    if (cal.status === 'ok' && cal.value && isVideo && cal.value.meetLink) {
+      resolvedVideoLink = cal.value.meetLink;
+    }
+  }
+
+  // --- S2 : lien de paiement Stripe (solde dû, vidéo uniquement)
+  let paymentLinkUrl: string | undefined;
+  if (!(isVideo && opts.amountDueCents > 0)) {
+    logSkipped('stripe', appt.id);
+  } else {
+    const stripe = await runStep('stripe', appt.id, async () => {
+      const paymentLink = await paymentLinkFn({
+        appointmentId: appt.id,
+        patientEmail: appt.patient_email,
+        patientName: appt.patient_name,
+        amount: opts.amountDueCents,
+        description: `Séance de thérapie — ${new Date(appt.scheduled_at).toLocaleDateString('fr-FR')}`,
+        successUrl: opts.successUrl ?? `${baseUrl}/rdv/merci/`,
+      });
+      await db.from('appointments')
+        .update({ stripe_payment_link_id: paymentLink.id, stripe_payment_link_url: paymentLink.url })
+        .eq('id', appt.id);
+      return paymentLink;
+    });
+    if (stripe.status === 'ok' && stripe.value) paymentLinkUrl = stripe.value.url;
+  }
+
+  // --- S3 : email patient (demande de prépaiement OU confirmation)
+  let emailDelivered = true; // sendEmail:false → flags quand même posés
+  if (!opts.sendEmail) {
+    emailDelivered = true;
+    logSkipped('email', appt.id);
+  } else {
+    const email = await runStep('email', appt.id, async () => {
+      const threadKey = `appointment:${appt.id}:patient`;
+      const idempotencyKey = `invite:${appt.id}:patient`;
+      const dateFr = new Date(appt.scheduled_at).toLocaleDateString('fr-FR');
+
+      let params: SendEmailParams;
+      if (isVideo && opts.amountDueCents > 0) {
+        if (!paymentLinkUrl) throw new Error('stripe payment link unavailable for PaymentRequest email');
+        params = {
+          to: appt.patient_email,
+          threadKey,
+          subject: buildAppointmentConversationSubject(`Prépaiement de votre séance — ${dateFr}`, appt.id),
+          react: createElement(PaymentRequest, {
+            patientName: appt.patient_name,
+            scheduledAt: appt.scheduled_at,
+            appointmentType: appt.appointment_type as AppointmentType,
+            duration: appt.duration,
+            finalPrice: opts.amountDueCents,
+            stripePaymentUrl: paymentLinkUrl,
+          }),
+          idempotencyKey,
+        };
+      } else {
+        // Avoir couvrant tout (payment_received) OU présentiel (confirmed).
+        const start = new Date(appt.scheduled_at);
+        const end = new Date(start.getTime() + appt.duration * 60 * 1000);
+        const calendarEvent = {
+          uid: appt.id,
+          summary: 'Séance de thérapie — OMF Therapie',
+          description: `Patient: ${appt.patient_name}\nMode: ${isVideo ? 'Téléconsultation' : 'Présentiel'}`,
+          location: appt.appointment_mode === 'in-person' ? CABINET_ADDRESS : (resolvedVideoLink ?? undefined),
+          url: resolvedVideoLink ?? undefined,
+          start,
+          end,
+          organizerName: 'Oriane Montabonnet — OMF Thérapie',
+          organizerEmail: 'contact@omf-therapie.fr',
+        };
+        const googleCalendarLink = generateGoogleCalendarLink(calendarEvent);
+        const outlookCalendarLink = generateOutlookCalendarLink(calendarEvent);
+        const inviteToken = createSecureLinkToken({
+          appointmentId: appt.id,
+          purpose: 'ics-invite',
+          expiresInSeconds: 60 * 60 * 24 * 180,
+          nonce: appt.scheduled_at,
+        });
+        const appleCalendarLink = generateAppleCalendarInviteLink(baseUrl, appt.id, inviteToken);
+        params = {
+          to: appt.patient_email,
+          threadKey,
+          subject: buildAppointmentConversationSubject(`Votre rendez-vous est confirmé — ${dateFr}`, appt.id),
+          react: createElement(AppointmentConfirmed, {
+            patientName: appt.patient_name,
+            appointmentType: appt.appointment_type as AppointmentType,
+            appointmentMode: appt.appointment_mode,
+            scheduledAt: appt.scheduled_at,
+            duration: appt.duration,
+            finalPrice: appt.final_price,
+            ...(isVideo ? { videoLink: resolvedVideoLink } : { cabinetAddress: CABINET_ADDRESS }),
+            googleCalendarLink,
+            appleCalendarLink,
+            outlookCalendarLink,
+          }),
+          idempotencyKey,
+        };
+      }
+
+      const emailResult = await send(params);
+      if (!emailResult.success) {
+        throw new Error(`email send failed: ${JSON.stringify(emailResult.error)}`);
+      }
+      return emailResult;
+    });
+    emailDelivered = email.status === 'ok';
+  }
+
+  // --- L2 : drapeaux set-once (un seul update)
+  if (!emailDelivered) {
+    // Échec d'envoi : on laisse invitation_sent_at NULL — le cron rattrapera.
+    logSkipped('flags', appt.id);
+    return;
+  }
+  await runStep('flags', appt.id, async () => {
+    const now = new Date().toISOString();
+    const payload: Record<string, string> = { invitation_sent_at: now };
+    if (appt.status === 'payment_received') payload.confirmation_sent_at = now;
+    const { error } = await db.from('appointments')
+      .update(payload)
+      .eq('id', appt.id)
+      .is('invitation_sent_at', null);
+    if (error) throw error;
+  });
 }

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -39,7 +39,11 @@ import {
   therapistConfirmationKey,
 } from './idempotency-keys';
 import { getTypeLabel, getModeLabel } from './pricing';
-import { createCalendarEvent } from './google-calendar';
+import {
+  createCalendarEvent,
+  type CreateEventParams,
+  type CalendarClientOptions,
+} from './google-calendar';
 import { createAppointmentPaymentLink } from './stripe';
 import { supabaseAdmin } from './supabase';
 import AppointmentConfirmed from '../emails/AppointmentConfirmed';
@@ -91,7 +95,10 @@ export function buildICSEvent(appt: Appointment) {
     uid: appt.id,
     summary: `Séance OMF Thérapie — ${typeLabel}`,
     description: `${typeLabel} (${modeLabel}) · ${appt.duration} min`,
-    location: appt.appointment_mode === 'in-person' ? CABINET_ADDRESS : (appt.video_link ?? undefined),
+    location:
+      appt.appointment_mode === 'in-person'
+        ? CABINET_ADDRESS
+        : (appt.video_link ?? undefined),
     url: appt.video_link ?? undefined,
     start,
     end,
@@ -135,7 +142,9 @@ export async function buildAndSendConfirmationEmails(
   const therapistIdempotencyKey = therapistConfirmationKey(pi);
 
   // 1. Construire l'événement ICS + les liens calendrier (lift verbatim du webhook ~325-336)
-  const apptForIcs = videoLink ? { ...appointment, video_link: videoLink } : appointment;
+  const apptForIcs = videoLink
+    ? { ...appointment, video_link: videoLink }
+    : appointment;
   const icsEvent = buildICSEvent(apptForIcs);
   const googleCalendarLink = generateGoogleCalendarLink(icsEvent);
   const outlookCalendarLink = generateOutlookCalendarLink(icsEvent);
@@ -149,7 +158,11 @@ export async function buildAndSendConfirmationEmails(
     nonce: appointment.scheduled_at,
     ...(options.signingSecret ? { secret: options.signingSecret } : {}),
   });
-  const appleCalendarLink = generateAppleCalendarInviteLink(baseUrl, appointment.id, inviteToken);
+  const appleCalendarLink = generateAppleCalendarInviteLink(
+    baseUrl,
+    appointment.id,
+    inviteToken,
+  );
 
   // 2. Email patient — construction verbatim de l'objet + props (webhook ~339-361)
   const patientEmailParams: SendEmailParams = {
@@ -157,7 +170,10 @@ export async function buildAndSendConfirmationEmails(
     threadKey: `appointment:${appointment.id}:patient`,
     subject: buildAppointmentConversationSubject(
       `Votre rendez-vous est confirmé — ${new Intl.DateTimeFormat('fr-FR', {
-        day: 'numeric', month: 'long', year: 'numeric', timeZone: 'Europe/Paris',
+        day: 'numeric',
+        month: 'long',
+        year: 'numeric',
+        timeZone: 'Europe/Paris',
       }).format(new Date(appointment.scheduled_at))}`,
       appointment.id,
     ),
@@ -243,15 +259,38 @@ export interface SideEffectsAppointment {
   stripe_payment_link_url?: string | null;
 }
 
-/** Chaîne d'update Supabase minimale (DI test-friendly, set-once via `.is`). */
-interface SupabaseUpdateChain extends PromiseLike<{ data: unknown; error: unknown }> {
+/**
+ * Résultat de l'étape S1 élargi (W4) : un `calendarFn` injecté peut résoudre
+ * SANS eventId exploitable (ex. no-op mock du sweep) — S1 traite alors l'étape
+ * comme un skip SANS persistance (aucun update `google_calendar_event_id`).
+ */
+export interface CalendarStepResult {
+  eventId?: string | null;
+  meetLink?: string;
+}
+
+/** calendarFn injectable (DI) — accepte les résultats sans eventId (W4). */
+export type CalendarFn = (
+  params: CreateEventParams,
+  options?: CalendarClientOptions,
+) => Promise<CalendarStepResult>;
+
+/** Chaîne d'update Supabase minimale (DI test-friendly, set-once via `.is`, bail via `.or`). */
+interface SupabaseUpdateChain extends PromiseLike<{
+  data: unknown;
+  error: unknown;
+}> {
   eq: (column: string, value: unknown) => SupabaseUpdateChain;
   is: (column: string, value: unknown) => SupabaseUpdateChain;
+  or: (filter: string) => SupabaseUpdateChain;
+  select: (...columns: string[]) => SupabaseUpdateChain;
 }
 
 /** Client Supabase minimal requis pour les écritures L2. */
 type SupabaseLike = {
-  from: (table: string) => { update: (payload: Record<string, unknown>) => SupabaseUpdateChain };
+  from: (table: string) => {
+    update: (payload: Record<string, unknown>) => SupabaseUpdateChain;
+  };
 };
 
 export interface ProcessSideEffectsOptions {
@@ -273,8 +312,8 @@ export interface ProcessSideEffectsOptions {
    * email S3 de chaque ligne.
    */
   signingSecret?: string;
-  /** DI — défaut : module app. */
-  createCalendarEvent?: typeof createCalendarEvent;
+  /** DI — défaut : module app. Accepte les résultats sans eventId (W4). */
+  createCalendarEvent?: CalendarFn;
   createAppointmentPaymentLink?: typeof createAppointmentPaymentLink;
   sendFn?: typeof sendEmail;
   /** Client Supabase pour les écritures L2 — défaut : `supabaseAdmin`. */
@@ -288,26 +327,94 @@ type StepStatus = 'ok' | 'skipped' | 'error';
  * Exécute une étape du pipeline avec isolation + observabilité :
  * durée mesurée, log structuré unique `[side-effects]`, erreur avalée
  * (le pipeline continue — le cron de rattrapage repasse sur les flags NULL).
+ *
+ * W4 : `isSkipped` permet à une étape qui RÉSOUT sans produire d'effet
+ * exploitable (ex. calendarFn no-op sans eventId) de se loguer `skipped`
+ * plutôt que `ok` — sans lever ni persister quoi que ce soit.
  */
 async function runStep<T>(
   step: StepName,
   appointmentId: string,
   fn: () => Promise<T>,
+  isSkipped?: (value: T) => boolean,
 ): Promise<{ status: StepStatus; value?: T }> {
   const start = Date.now();
   try {
     const value = await fn();
-    console.info('[side-effects]', { step, appointmentId, ms: Date.now() - start, status: 'ok' });
-    return { status: 'ok', value };
+    const status: StepStatus = isSkipped?.(value) ? 'skipped' : 'ok';
+    console.info('[side-effects]', {
+      step,
+      appointmentId,
+      ms: Date.now() - start,
+      status,
+    });
+    return { status, value };
   } catch (err) {
     console.error('[side-effects] step failed:', step, appointmentId, err);
-    console.info('[side-effects]', { step, appointmentId, ms: Date.now() - start, status: 'error' });
+    console.info('[side-effects]', {
+      step,
+      appointmentId,
+      ms: Date.now() - start,
+      status: 'error',
+    });
     return { status: 'error' };
   }
 }
 
 function logSkipped(step: StepName, appointmentId: string): void {
-  console.info('[side-effects]', { step, appointmentId, ms: 0, status: 'skipped' });
+  console.info('[side-effects]', {
+    step,
+    appointmentId,
+    ms: 0,
+    status: 'skipped',
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Issue #126 / W2 — bail atomique waitUntil ↔ sweep
+// ---------------------------------------------------------------------------
+
+/** Bail par défaut : 10 min (le claim est un LEASE, pas un marqueur de complétion). */
+const DEFAULT_CLAIM_LEASE_MS = 10 * 60_000;
+
+/**
+ * Claim atomique d'une ligne `appointments` AVANT d'exécuter le pipeline de
+ * side-effects (W2). Sans ce bail, le POST (`waitUntil`) et le sweep
+ * `reconcile-invitations` peuvent démarrer le pipeline simultanément sur un
+ * drapeau NULL → deux `events.insert` Google, deux Payment Links Stripe (la
+ * garde set-once finale ne déduplique que l'email/flag — trop tard).
+ *
+ * L'update conditionnel est atomique côté Postgres :
+ *   SET invitation_claimed_at = now()
+ *   WHERE id = $1
+ *     AND (invitation_claimed_at IS NULL OR invitation_claimed_at < now() − lease)
+ * Une ligne retournée = claim obtenu ; zéro ligne = déjà claimé (bail vivant).
+ *
+ * Fail-closed : en cas d'erreur DB on retourne false — sans certitude
+ * d'exclusivité on ne démarre PAS le pipeline (mieux vaut ne rien faire que
+ * doubler un effet externe ; le sweep repassera à la prochaine heure).
+ *
+ * ⚠️ `invitation_claimed_at` n'est JAMAIS un marqueur de complétion — la
+ * complétion reste `invitation_sent_at` (013). Voir 014_invitation_claim_at.sql.
+ */
+export async function claimInvitationProcessing(
+  supabase: SupabaseLike,
+  appointmentId: string,
+  opts: { leaseMs?: number } = {},
+): Promise<boolean> {
+  const leaseMs = opts.leaseMs ?? DEFAULT_CLAIM_LEASE_MS;
+  const cutoff = new Date(Date.now() - leaseMs).toISOString();
+  const { data, error } = await supabase
+    .from('appointments')
+    .update({ invitation_claimed_at: new Date().toISOString() })
+    .eq('id', appointmentId)
+    .or(`invitation_claimed_at.is.null,invitation_claimed_at.lt.${cutoff}`)
+    .select('id');
+  if (error) {
+    console.error('[side-effects] claim failed:', { appointmentId });
+    return false;
+  }
+  return Array.isArray(data) && data.length > 0;
 }
 
 /**
@@ -317,6 +424,8 @@ function logSkipped(step: StepName, appointmentId: string): void {
  *
  * - S1 calendar : événement standard TOUJOURS créé (`withMeet:false` si un
  *   `video_link` existe déjà) ; persistance de l'event id (+ meet link).
+ *   W4 : un résultat SANS eventId exploitable (ex. no-op mock du sweep) est
+ *   un skip SANS persistance — le pipeline continue normalement.
  * - S2 stripe   : uniquement `mode vidéo && amountDueCents > 0` ; idempotent —
  *   un `stripe_payment_link_url` déjà présent est réutilisé (skip), jamais de
  *   second lien.
@@ -324,70 +433,89 @@ function logSkipped(step: StepName, appointmentId: string): void {
  *   `invite:{id}:patient`. Réutilise la composition d'emails du POST.
  * - flags L2    : un SEUL update set-once `.is('invitation_sent_at', null)` ;
  *   `confirmation_sent_at` posé dans le MÊME update quand
- *   `status === 'payment_received'`. SKIPPÉ si l'email a échoué OU si une
- *   écriture de persistance S1/S2 a échoué (C7) — drapeaux laissés NULL pour
- *   que le cron de rattrapage repasse.
+ *   `status === 'payment_received'`. W1 : écrit SEULEMENT si TOUTES les étapes
+ *   S1/S2/S3 sont ok ou skipped — TOUTE erreur d'étape (API OU persistance)
+ *   laisse les drapeaux NULL pour que le cron de rattrapage repasse (les
+ *   gardes de skip S1/S2 empêchent les doublons d'effets externes au re-jeu ;
+ *   l'email re-joué est dédupliqué par la clé L1 Resend).
  *
  * Chaque étape est isolée : une erreur est loguée (`status:'error'`) et le
  * pipeline CONTINUE. Ne jette jamais.
+ *
+ * @returns `{ flagsSet }` — true uniquement si l'update set-once des drapeaux
+ *          a résolu. Les appelants actuels (POST waitUntil, sweep) ignorent
+ *          la valeur (le sweep classifie via sa capture Resend), mais les
+ *          tests et futurs appelants peuvent l'observer.
  */
 export async function processAppointmentSideEffects(
   appt: SideEffectsAppointment,
   opts: ProcessSideEffectsOptions,
-): Promise<void> {
+): Promise<{ flagsSet: boolean }> {
   const db = opts.supabase ?? (supabaseAdmin as unknown as SupabaseLike);
   const calendarFn = opts.createCalendarEvent ?? createCalendarEvent;
-  const paymentLinkFn = opts.createAppointmentPaymentLink ?? createAppointmentPaymentLink;
+  const paymentLinkFn =
+    opts.createAppointmentPaymentLink ?? createAppointmentPaymentLink;
   const send = opts.sendFn ?? sendEmail;
   const isVideo = appt.appointment_mode === 'video';
   const baseUrl = opts.baseUrl ?? 'https://omf-therapie.fr';
 
   // --- S1 : événement agenda (standard ; pas de Meet si video_link déjà fourni)
   let resolvedVideoLink: string | undefined = appt.video_link ?? undefined;
-  // C7 : un échec de PERSISTANCE (update event id / lien Stripe) doit laisser
-  // les drapeaux L2 à NULL — le cron de rattrapage repassera. Distinct d'un
-  // échec d'API (calendarFn/paymentLinkFn) où l'email prime sur les flags.
-  let persistFailed = false;
+  // W1 : accumulateur d'échecs par étape (API OU persistance). Les drapeaux L2
+  // ne sont écrits qu'en l'absence de TOUT échec — sinon invitation_sent_at
+  // reste NULL et le sweep rattrape la ligne (SC3).
+  const stepFailed = { calendar: false, stripe: false, email: false };
 
   if (appt.google_calendar_event_id) {
     logSkipped('calendar', appt.id);
   } else {
-    const cal = await runStep('calendar', appt.id, async () => {
-      const start = new Date(appt.scheduled_at);
-      const end = new Date(start.getTime() + appt.duration * 60 * 1000);
-      const modeLabel = isVideo ? 'Téléconsultation' : 'Présentiel';
-      const calResult = await calendarFn({
-        title: `${isVideo ? '🎥 ' : ''}${appt.patient_name} — séance ${modeLabel.toLowerCase()} (${appt.duration} min)`,
-        start: start.toISOString(),
-        end: end.toISOString(),
-        description: [
-          `Patient: ${appt.patient_name}`,
-          `Email: ${appt.patient_email}`,
-          `Mode: ${modeLabel}`,
-          `Durée: ${appt.duration} min`,
-          ...(resolvedVideoLink ? [`Lien visio: ${resolvedVideoLink}`] : []),
-        ].join('\n'),
-        location: isVideo ? 'Téléconsultation' : CABINET_ADDRESS,
-        attendeeEmail: appt.patient_email,
-        withMeet: isVideo && !resolvedVideoLink,
-        appointmentId: `${appt.id}-admin-${isVideo ? 'video' : 'inperson'}`,
-        colorId: isVideo ? '11' : '2',
-      });
-      // Persistance technique (update simple, distinct du set-once final).
-      // C7 : une erreur d'update est THROWN → statut `error` observable pour
-      // l'étape (sinon l'event id était perdu silencieusement et les flags
-      // finissaient posés — le RDV ne serait jamais rattrapé).
-      const calendarUpdate: Record<string, string> = { google_calendar_event_id: calResult.eventId };
-      if (isVideo && calResult.meetLink) calendarUpdate.video_link = calResult.meetLink;
-      const { error: calendarUpdateError } = await db.from('appointments')
-        .update(calendarUpdate)
-        .eq('id', appt.id);
-      if (calendarUpdateError) {
-        persistFailed = true;
-        throw calendarUpdateError;
-      }
-      return calResult;
-    });
+    const cal = await runStep(
+      'calendar',
+      appt.id,
+      async () => {
+        const start = new Date(appt.scheduled_at);
+        const end = new Date(start.getTime() + appt.duration * 60 * 1000);
+        const modeLabel = isVideo ? 'Téléconsultation' : 'Présentiel';
+        const calResult = await calendarFn({
+          title: `${isVideo ? '🎥 ' : ''}${appt.patient_name} — séance ${modeLabel.toLowerCase()} (${appt.duration} min)`,
+          start: start.toISOString(),
+          end: end.toISOString(),
+          description: [
+            `Patient: ${appt.patient_name}`,
+            `Email: ${appt.patient_email}`,
+            `Mode: ${modeLabel}`,
+            `Durée: ${appt.duration} min`,
+            ...(resolvedVideoLink ? [`Lien visio: ${resolvedVideoLink}`] : []),
+          ].join('\n'),
+          location: isVideo ? 'Téléconsultation' : CABINET_ADDRESS,
+          attendeeEmail: appt.patient_email,
+          withMeet: isVideo && !resolvedVideoLink,
+          appointmentId: `${appt.id}-admin-${isVideo ? 'video' : 'inperson'}`,
+          colorId: isVideo ? '11' : '2',
+        });
+        // W4 : résultat sans eventId exploitable (ex. no-op mock) → skip SANS
+        // persistance. Un faux id persisté ferait croire aux passages suivants
+        // que l'événement Google existe déjà (skip S1 définitif erroné).
+        if (!calResult.eventId) return calResult;
+        // Persistance technique (update simple, distinct du set-once final).
+        // C7 : une erreur d'update est THROWN → statut `error` observable pour
+        // l'étape (sinon l'event id était perdu silencieusement et les flags
+        // finissaient posés — le RDV ne serait jamais rattrapé).
+        const calendarUpdate: Record<string, string> = {
+          google_calendar_event_id: calResult.eventId,
+        };
+        if (isVideo && calResult.meetLink)
+          calendarUpdate.video_link = calResult.meetLink;
+        const { error: calendarUpdateError } = await db
+          .from('appointments')
+          .update(calendarUpdate)
+          .eq('id', appt.id);
+        if (calendarUpdateError) throw calendarUpdateError;
+        return calResult;
+      },
+      value => !value.eventId,
+    );
+    if (cal.status === 'error') stepFailed.calendar = true;
     if (cal.status === 'ok' && cal.value && isVideo && cal.value.meetLink) {
       resolvedVideoLink = cal.value.meetLink;
     }
@@ -415,22 +543,24 @@ export async function processAppointmentSideEffects(
       });
       // C7 : idem S1 — l'erreur de persistance est observable, le sweep
       // rattrape (le lien Stripe orphelin reste payable mais non référencé).
-      const { error: stripeUpdateError } = await db.from('appointments')
-        .update({ stripe_payment_link_id: paymentLink.id, stripe_payment_link_url: paymentLink.url })
+      const { error: stripeUpdateError } = await db
+        .from('appointments')
+        .update({
+          stripe_payment_link_id: paymentLink.id,
+          stripe_payment_link_url: paymentLink.url,
+        })
         .eq('id', appt.id);
-      if (stripeUpdateError) {
-        persistFailed = true;
-        throw stripeUpdateError;
-      }
+      if (stripeUpdateError) throw stripeUpdateError;
       return paymentLink;
     });
-    if (stripe.status === 'ok' && stripe.value) paymentLinkUrl = stripe.value.url;
+    if (stripe.status === 'error') stepFailed.stripe = true;
+    if (stripe.status === 'ok' && stripe.value)
+      paymentLinkUrl = stripe.value.url;
   }
 
   // --- S3 : email patient (demande de prépaiement OU confirmation)
-  let emailDelivered = true; // sendEmail:false → flags quand même posés
   if (!opts.sendEmail) {
-    emailDelivered = true;
+    // Email non requis (send_email:false) — pas un échec : les flags seront posés.
     logSkipped('email', appt.id);
   } else {
     const email = await runStep('email', appt.id, async () => {
@@ -440,11 +570,17 @@ export async function processAppointmentSideEffects(
 
       let params: SendEmailParams;
       if (isVideo && opts.amountDueCents > 0) {
-        if (!paymentLinkUrl) throw new Error('stripe payment link unavailable for PaymentRequest email');
+        if (!paymentLinkUrl)
+          throw new Error(
+            'stripe payment link unavailable for PaymentRequest email',
+          );
         params = {
           to: appt.patient_email,
           threadKey,
-          subject: buildAppointmentConversationSubject(`Prépaiement de votre séance — ${dateFr}`, appt.id),
+          subject: buildAppointmentConversationSubject(
+            `Prépaiement de votre séance — ${dateFr}`,
+            appt.id,
+          ),
           react: createElement(PaymentRequest, {
             patientName: appt.patient_name,
             scheduledAt: appt.scheduled_at,
@@ -463,7 +599,10 @@ export async function processAppointmentSideEffects(
           uid: appt.id,
           summary: 'Séance de thérapie — OMF Therapie',
           description: `Patient: ${appt.patient_name}\nMode: ${isVideo ? 'Téléconsultation' : 'Présentiel'}`,
-          location: appt.appointment_mode === 'in-person' ? CABINET_ADDRESS : (resolvedVideoLink ?? undefined),
+          location:
+            appt.appointment_mode === 'in-person'
+              ? CABINET_ADDRESS
+              : (resolvedVideoLink ?? undefined),
           url: resolvedVideoLink ?? undefined,
           start,
           end,
@@ -482,11 +621,18 @@ export async function processAppointmentSideEffects(
           // (import.meta.env absent) et purge l'étape email de chaque ligne.
           ...(opts.signingSecret ? { secret: opts.signingSecret } : {}),
         });
-        const appleCalendarLink = generateAppleCalendarInviteLink(baseUrl, appt.id, inviteToken);
+        const appleCalendarLink = generateAppleCalendarInviteLink(
+          baseUrl,
+          appt.id,
+          inviteToken,
+        );
         params = {
           to: appt.patient_email,
           threadKey,
-          subject: buildAppointmentConversationSubject(`Votre rendez-vous est confirmé — ${dateFr}`, appt.id),
+          subject: buildAppointmentConversationSubject(
+            `Votre rendez-vous est confirmé — ${dateFr}`,
+            appt.id,
+          ),
           react: createElement(AppointmentConfirmed, {
             patientName: appt.patient_name,
             appointmentType: appt.appointment_type as AppointmentType,
@@ -494,7 +640,9 @@ export async function processAppointmentSideEffects(
             scheduledAt: appt.scheduled_at,
             duration: appt.duration,
             finalPrice: appt.final_price,
-            ...(isVideo ? { videoLink: resolvedVideoLink } : { cabinetAddress: CABINET_ADDRESS }),
+            ...(isVideo
+              ? { videoLink: resolvedVideoLink }
+              : { cabinetAddress: CABINET_ADDRESS }),
             googleCalendarLink,
             appleCalendarLink,
             outlookCalendarLink,
@@ -505,28 +653,33 @@ export async function processAppointmentSideEffects(
 
       const emailResult = await send(params);
       if (!emailResult.success) {
-        throw new Error(`email send failed: ${JSON.stringify(emailResult.error)}`);
+        throw new Error(
+          `email send failed: ${JSON.stringify(emailResult.error)}`,
+        );
       }
       return emailResult;
     });
-    emailDelivered = email.status === 'ok';
+    stepFailed.email = email.status !== 'ok';
   }
 
-  // --- L2 : drapeaux set-once (un seul update)
-  if (!emailDelivered || persistFailed) {
-    // Échec d'envoi OU de persistance (C7) : on laisse invitation_sent_at
-    // NULL — le cron rattrapera.
+  // --- L2 : drapeaux set-once (un seul update) — uniquement si TOUT est ok/skipped
+  if (stepFailed.calendar || stepFailed.stripe || stepFailed.email) {
+    // W1 : au moins une étape a échoué (API OU persistance) — on laisse
+    // invitation_sent_at NULL ; le sweep rattrapera la ligne (l'échec email
+    // permanent est géré par le poison-escape du sweep, inchangé).
     logSkipped('flags', appt.id);
-    return;
+    return { flagsSet: false };
   }
-  await runStep('flags', appt.id, async () => {
+  const flags = await runStep('flags', appt.id, async () => {
     const now = new Date().toISOString();
     const payload: Record<string, string> = { invitation_sent_at: now };
     if (appt.status === 'payment_received') payload.confirmation_sent_at = now;
-    const { error } = await db.from('appointments')
+    const { error } = await db
+      .from('appointments')
       .update(payload)
       .eq('id', appt.id)
       .is('invitation_sent_at', null);
     if (error) throw error;
   });
+  return { flagsSet: flags.status === 'ok' };
 }

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -234,8 +234,13 @@ export interface SideEffectsAppointment {
   patient_name: string;
   patient_email: string;
   final_price: number;
+  /** Avoir déjà consommé sur ce RDV (centimes) — l'appelant déduit le solde dû. */
+  credit_applied?: number | null;
   video_link?: string | null;
   google_calendar_event_id?: string | null;
+  /** Lien Stripe déjà existant (idempotence S2 — jamais de second lien). */
+  stripe_payment_link_id?: string | null;
+  stripe_payment_link_url?: string | null;
 }
 
 /** Chaîne d'update Supabase minimale (DI test-friendly, set-once via `.is`). */
@@ -260,6 +265,14 @@ export interface ProcessSideEffectsOptions {
   baseUrl?: string;
   /** Email admin (réservé — le POST actuel n'envoie pas de notification thérapeute ici). */
   adminEmail?: string;
+  /**
+   * Secret HMAC pour signer le jeton d'invitation .ics (DI — parité exacte
+   * avec `BuildAndSendOptions.signingSecret`). Le sweep Netlify (runtime Node,
+   * `import.meta.env` absent) DOIT passer `process.env.BETTER_AUTH_SECRET`
+   * explicitement, sans quoi `createSecureLinkToken` lève en purgeant l'étape
+   * email S3 de chaque ligne.
+   */
+  signingSecret?: string;
   /** DI — défaut : module app. */
   createCalendarEvent?: typeof createCalendarEvent;
   createAppointmentPaymentLink?: typeof createAppointmentPaymentLink;
@@ -304,12 +317,16 @@ function logSkipped(step: StepName, appointmentId: string): void {
  *
  * - S1 calendar : événement standard TOUJOURS créé (`withMeet:false` si un
  *   `video_link` existe déjà) ; persistance de l'event id (+ meet link).
- * - S2 stripe   : uniquement `mode vidéo && amountDueCents > 0`.
+ * - S2 stripe   : uniquement `mode vidéo && amountDueCents > 0` ; idempotent —
+ *   un `stripe_payment_link_url` déjà présent est réutilisé (skip), jamais de
+ *   second lien.
  * - S3 email    : uniquement `opts.sendEmail` ; clé d'idempotence Resend L1
  *   `invite:{id}:patient`. Réutilise la composition d'emails du POST.
  * - flags L2    : un SEUL update set-once `.is('invitation_sent_at', null)` ;
  *   `confirmation_sent_at` posé dans le MÊME update quand
- *   `status === 'payment_received'`.
+ *   `status === 'payment_received'`. SKIPPÉ si l'email a échoué OU si une
+ *   écriture de persistance S1/S2 a échoué (C7) — drapeaux laissés NULL pour
+ *   que le cron de rattrapage repasse.
  *
  * Chaque étape est isolée : une erreur est loguée (`status:'error'`) et le
  * pipeline CONTINUE. Ne jette jamais.
@@ -327,6 +344,10 @@ export async function processAppointmentSideEffects(
 
   // --- S1 : événement agenda (standard ; pas de Meet si video_link déjà fourni)
   let resolvedVideoLink: string | undefined = appt.video_link ?? undefined;
+  // C7 : un échec de PERSISTANCE (update event id / lien Stripe) doit laisser
+  // les drapeaux L2 à NULL — le cron de rattrapage repassera. Distinct d'un
+  // échec d'API (calendarFn/paymentLinkFn) où l'email prime sur les flags.
+  let persistFailed = false;
 
   if (appt.google_calendar_event_id) {
     logSkipped('calendar', appt.id);
@@ -353,9 +374,18 @@ export async function processAppointmentSideEffects(
         colorId: isVideo ? '11' : '2',
       });
       // Persistance technique (update simple, distinct du set-once final).
+      // C7 : une erreur d'update est THROWN → statut `error` observable pour
+      // l'étape (sinon l'event id était perdu silencieusement et les flags
+      // finissaient posés — le RDV ne serait jamais rattrapé).
       const calendarUpdate: Record<string, string> = { google_calendar_event_id: calResult.eventId };
       if (isVideo && calResult.meetLink) calendarUpdate.video_link = calResult.meetLink;
-      await db.from('appointments').update(calendarUpdate).eq('id', appt.id);
+      const { error: calendarUpdateError } = await db.from('appointments')
+        .update(calendarUpdate)
+        .eq('id', appt.id);
+      if (calendarUpdateError) {
+        persistFailed = true;
+        throw calendarUpdateError;
+      }
       return calResult;
     });
     if (cal.status === 'ok' && cal.value && isVideo && cal.value.meetLink) {
@@ -365,7 +395,13 @@ export async function processAppointmentSideEffects(
 
   // --- S2 : lien de paiement Stripe (solde dû, vidéo uniquement)
   let paymentLinkUrl: string | undefined;
-  if (!(isVideo && opts.amountDueCents > 0)) {
+  if (appt.stripe_payment_link_url) {
+    // Idempotence (miroir exact de la garde S1 sur google_calendar_event_id) :
+    // un lien déjà présent est RÉUTILISÉ pour l'email S3 — jamais de second
+    // lien (cascade Stripe + sur-facturation du patient).
+    paymentLinkUrl = appt.stripe_payment_link_url;
+    logSkipped('stripe', appt.id);
+  } else if (!(isVideo && opts.amountDueCents > 0)) {
     logSkipped('stripe', appt.id);
   } else {
     const stripe = await runStep('stripe', appt.id, async () => {
@@ -377,9 +413,15 @@ export async function processAppointmentSideEffects(
         description: `Séance de thérapie — ${new Date(appt.scheduled_at).toLocaleDateString('fr-FR')}`,
         successUrl: opts.successUrl ?? `${baseUrl}/rdv/merci/`,
       });
-      await db.from('appointments')
+      // C7 : idem S1 — l'erreur de persistance est observable, le sweep
+      // rattrape (le lien Stripe orphelin reste payable mais non référencé).
+      const { error: stripeUpdateError } = await db.from('appointments')
         .update({ stripe_payment_link_id: paymentLink.id, stripe_payment_link_url: paymentLink.url })
         .eq('id', appt.id);
+      if (stripeUpdateError) {
+        persistFailed = true;
+        throw stripeUpdateError;
+      }
       return paymentLink;
     });
     if (stripe.status === 'ok' && stripe.value) paymentLinkUrl = stripe.value.url;
@@ -435,6 +477,10 @@ export async function processAppointmentSideEffects(
           purpose: 'ics-invite',
           expiresInSeconds: 60 * 60 * 24 * 180,
           nonce: appt.scheduled_at,
+          // C2 : DI du secret (parité buildAndSendConfirmationEmails). Sans
+          // cette seam, createSecureLinkToken lève en runtime Node pur
+          // (import.meta.env absent) et purge l'étape email de chaque ligne.
+          ...(opts.signingSecret ? { secret: opts.signingSecret } : {}),
         });
         const appleCalendarLink = generateAppleCalendarInviteLink(baseUrl, appt.id, inviteToken);
         params = {
@@ -467,8 +513,9 @@ export async function processAppointmentSideEffects(
   }
 
   // --- L2 : drapeaux set-once (un seul update)
-  if (!emailDelivered) {
-    // Échec d'envoi : on laisse invitation_sent_at NULL — le cron rattrapera.
+  if (!emailDelivered || persistFailed) {
+    // Échec d'envoi OU de persistance (C7) : on laisse invitation_sent_at
+    // NULL — le cron rattrapera.
     logSkipped('flags', appt.id);
     return;
   }

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -15,8 +15,12 @@ import Stripe from 'stripe';
 // ---------------------------------------------------------------------------
 
 function getStripeKey(): string {
+  // Guarded access (mirror of `readEnv` in google-calendar.ts): the optional
+  // chaining keeps this importable in runtimes where `import.meta.env` is
+  // undefined (Netlify scheduled functions — plain Node bundle, cf. #98/#126).
   return (
-    (import.meta.env.STRIPE_SECRET_KEY as string | undefined) ??
+    (import.meta as { env?: Record<string, string | undefined> }).env
+      ?.STRIPE_SECRET_KEY ??
     process.env.STRIPE_SECRET_KEY ??
     ''
   );

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -7,28 +7,52 @@
 
 import Stripe from 'stripe';
 
-const stripeKey = import.meta.env.STRIPE_SECRET_KEY ?? '';
+// ---------------------------------------------------------------------------
+// Lazy initialization — this module must be importable from runtimes where
+// `import.meta.env` is undefined (Netlify Functions Node.js, cf. resend.ts #98).
+// The Stripe client and mock flag resolve on first use, not on module load.
+// `process.env` is the only env source available in the cron runtime.
+// ---------------------------------------------------------------------------
 
-if (!stripeKey) {
-  console.warn('[stripe] ⚠️  STRIPE_SECRET_KEY est absent. Les paiements Stripe échoueront.');
+function getStripeKey(): string {
+  return (
+    (import.meta.env.STRIPE_SECRET_KEY as string | undefined) ??
+    process.env.STRIPE_SECRET_KEY ??
+    ''
+  );
 }
 
-/** True when running in dev/test with placeholder Stripe keys */
-export const isStripeMock = !stripeKey || stripeKey === 'sk_test_placeholder' || stripeKey.startsWith('sk_test_placeholder');
+let cachedStripe: Stripe | null | undefined;
 
-/** Instance Stripe singleton */
-export const stripe: Stripe = new Stripe(stripeKey, {
-  // Explicitly pin the API version literal to the live account's pinned version
-  // (Dashboard → Developers → API version). stripe@22 bundles the
-  // "2026-06-24.dahlia" types; our account is still on "2024-12-18.acacia".
-  // Stripe pins requests to the account version regardless of this value, so
-  // the literal documents intent; the @ts-expect-error bridges the SDK-type
-  // drift and self-invalidates if the literal ever matches LatestApiVersion.
-  // To upgrade: bump the account version first, verify response shapes, then
-  // set this literal to match (the @ts-expect-error will drop automatically).
-  // @ts-expect-error — account version differs from bundled LatestApiVersion
-  apiVersion: '2024-12-18.acacia',
-});
+/** Instance Stripe (lazy) — null si STRIPE_SECRET_KEY est absente */
+export function getStripe(): Stripe | null {
+  if (cachedStripe !== undefined) return cachedStripe;
+  const stripeKey = getStripeKey();
+  cachedStripe = stripeKey
+    ? new Stripe(stripeKey, {
+        // Explicitly pin the API version literal to the live account's pinned version
+        // (Dashboard → Developers → API version). stripe@22 bundles the
+        // "2026-06-24.dahlia" types; our account is still on "2024-12-18.acacia".
+        // Stripe pins requests to the account version regardless of this value, so
+        // the literal documents intent; the @ts-expect-error bridges the SDK-type
+        // drift and self-invalidates if the literal ever matches LatestApiVersion.
+        // To upgrade: bump the account version first, verify response shapes, then
+        // set this literal to match (the @ts-expect-error will drop automatically).
+        // @ts-expect-error — account version differs from bundled LatestApiVersion
+        apiVersion: '2024-12-18.acacia',
+      })
+    : null;
+  if (!cachedStripe) {
+    console.warn('[stripe] ⚠️  STRIPE_SECRET_KEY est absent. Les paiements Stripe échoueront.');
+  }
+  return cachedStripe;
+}
+
+/** True when running in dev/test with placeholder (or missing) Stripe keys */
+export function isStripeMock(): boolean {
+  const stripeKey = getStripeKey();
+  return !stripeKey || stripeKey === 'sk_test_placeholder' || stripeKey.startsWith('sk_test_placeholder');
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -93,7 +117,7 @@ export async function createAppointmentPaymentLink(
   const redirectUrl = buildStripeSuccessUrl(successUrl);
 
   // Dev/test bypass: return a mock payment link when Stripe key is placeholder
-  if (isStripeMock) {
+  if (isStripeMock()) {
     console.warn('[stripe] 🔧 Mode dev — lien de paiement simulé (clé Stripe placeholder)');
     const mockUrl = withQueryParam(
       withQueryParam(redirectUrl, 'mock', '1'),
@@ -106,8 +130,13 @@ export async function createAppointmentPaymentLink(
     };
   }
 
+  const client = getStripe();
+  if (!client) {
+    throw new Error('Stripe client non initialisé — STRIPE_SECRET_KEY manquante');
+  }
+
   // 1. Créer un prix one-time
-  const price = await stripe.prices.create({
+  const price = await client.prices.create({
     unit_amount: amount,
     currency: 'eur',
     product_data: {
@@ -116,7 +145,7 @@ export async function createAppointmentPaymentLink(
   });
 
   // 2. Créer le Payment Link
-  const paymentLink = await stripe.paymentLinks.create({
+  const paymentLink = await client.paymentLinks.create({
     line_items: [{ price: price.id, quantity: 1 }],
     after_completion: {
       type: 'redirect',

--- a/src/pages/api/admin/appointments/index.ts
+++ b/src/pages/api/admin/appointments/index.ts
@@ -67,11 +67,14 @@ export const POST: APIRoute = async ({ request, locals }) => {
     patient_reason,
     override_first_session,
     is_solidarity,
-    send_email: shouldSendEmail = true,
+    send_email: rawSendEmail,
     video_link,
     override_price,
     use_credit,
   } = body;
+
+  // send_email optionnel (défaut : envoi) — normalisé en booléen strict
+  const shouldSendEmail = rawSendEmail === undefined ? true : rawSendEmail === true;
 
   // 3. Validation
   if (!patient_name || typeof patient_name !== 'string' || patient_name.trim().length < 2)

--- a/src/pages/api/admin/appointments/index.ts
+++ b/src/pages/api/admin/appointments/index.ts
@@ -200,9 +200,20 @@ export const POST: APIRoute = async ({ request, locals }) => {
       final_price: finalPriceCents,
       credit_applied: creditApplied,
       video_link: isVideo ? (video_link ?? null) : null,
-      // send_email:false → aucun email ne partira jamais : on pose le flag L2
-      // dès l'insert pour que le futur sweep ne tente pas d'envoi de rattrapage.
-      ...(shouldSendEmail ? {} : { invitation_sent_at: new Date().toISOString() }),
+      // send_email:false → aucun email ne partira jamais : on pose le(s) flag(s)
+      // L2 dès l'insert pour que les sweeps (#126/#98) ne tentent pas d'envoi de
+      // rattrapage. Statut initial payment_received (avoir couvrant tout) :
+      // l'invitation EST la confirmation — le pipeline aval ne repassera pas
+      // (son set-once est gardé `.is('invitation_sent_at', null)`, déjà posé),
+      // donc les DEUX drapeaux partent dans le payload INSERT (C6).
+      ...(shouldSendEmail
+        ? {}
+        : initialStatus === 'payment_received'
+          ? {
+              invitation_sent_at: new Date().toISOString(),
+              confirmation_sent_at: new Date().toISOString(),
+            }
+          : { invitation_sent_at: new Date().toISOString() }),
     })
     .select()
     .single();

--- a/src/pages/api/admin/appointments/index.ts
+++ b/src/pages/api/admin/appointments/index.ts
@@ -10,7 +10,10 @@ import { hasAppointmentConflict } from '../../../../lib/appointment-conflicts';
 import type { AppointmentType } from '../../../../types/appointment';
 import { invalidateAvailabilityCache } from '../../../../lib/calendar-cache.js';
 import { isCabinetEligibleSlot } from '../../../../lib/appointment-eligibility';
-import { processAppointmentSideEffects } from '../../../../lib/notifications';
+import {
+  claimInvitationProcessing,
+  processAppointmentSideEffects,
+} from '../../../../lib/notifications';
 
 // ---------------------------------------------------------------------------
 // Validation helpers
@@ -22,7 +25,11 @@ const PHONE_RE = /^(?:\+33|0033|0)[1-9](?:[0-9]{8})$/;
 const VALID_TYPES = new Set<string>(['individual', 'couple', 'family']);
 const VALID_MODES = new Set<string>(['in-person', 'video']);
 
-function errorResponse(status: number, message: string, field?: string): Response {
+function errorResponse(
+  status: number,
+  message: string,
+  field?: string,
+): Response {
   return new Response(JSON.stringify({ error: message, field }), {
     status,
     headers: { 'Content-Type': 'application/json' },
@@ -74,16 +81,33 @@ export const POST: APIRoute = async ({ request, locals }) => {
   } = body;
 
   // send_email optionnel (défaut : envoi) — normalisé en booléen strict
-  const shouldSendEmail = rawSendEmail === undefined ? true : rawSendEmail === true;
+  const shouldSendEmail =
+    rawSendEmail === undefined ? true : rawSendEmail === true;
 
   // 3. Validation
-  if (!patient_name || typeof patient_name !== 'string' || patient_name.trim().length < 2)
-    return errorResponse(400, 'Nom requis (2 caractères minimum)', 'patient_name');
+  if (
+    !patient_name ||
+    typeof patient_name !== 'string' ||
+    patient_name.trim().length < 2
+  )
+    return errorResponse(
+      400,
+      'Nom requis (2 caractères minimum)',
+      'patient_name',
+    );
 
-  if (!patient_email || typeof patient_email !== 'string' || !EMAIL_RE.test(patient_email))
+  if (
+    !patient_email ||
+    typeof patient_email !== 'string' ||
+    !EMAIL_RE.test(patient_email)
+  )
     return errorResponse(400, 'Email invalide', 'patient_email');
 
-  if (patient_phone && (typeof patient_phone !== 'string' || !PHONE_RE.test(patient_phone.replace(/\s/g, ''))))
+  if (
+    patient_phone &&
+    (typeof patient_phone !== 'string' ||
+      !PHONE_RE.test(patient_phone.replace(/\s/g, '')))
+  )
     return errorResponse(400, 'Numéro de téléphone invalide', 'patient_phone');
 
   if (!appointment_type || !VALID_TYPES.has(appointment_type as string))
@@ -92,52 +116,99 @@ export const POST: APIRoute = async ({ request, locals }) => {
   if (!appointment_mode || !VALID_MODES.has(appointment_mode as string))
     return errorResponse(400, 'Mode de séance invalide', 'appointment_mode');
 
-  if (!duration || !Number.isInteger(Number(duration)) || Number(duration) < 15 || Number(duration) > 240)
-    return errorResponse(400, 'Durée invalide (entre 15 et 240 minutes)', 'duration');
+  if (
+    !duration ||
+    !Number.isInteger(Number(duration)) ||
+    Number(duration) < 15 ||
+    Number(duration) > 240
+  )
+    return errorResponse(
+      400,
+      'Durée invalide (entre 15 et 240 minutes)',
+      'duration',
+    );
 
   const GRID_DURATIONS = new Set([60, 90]);
   if (!GRID_DURATIONS.has(Number(duration)) && override_price === undefined)
-    return errorResponse(400, 'Durée personnalisée : le tarif manuel est obligatoire', 'override_price');
+    return errorResponse(
+      400,
+      'Durée personnalisée : le tarif manuel est obligatoire',
+      'override_price',
+    );
 
-  if (!scheduled_at || typeof scheduled_at !== 'string' || isNaN(Date.parse(scheduled_at)))
+  if (
+    !scheduled_at ||
+    typeof scheduled_at !== 'string' ||
+    isNaN(Date.parse(scheduled_at))
+  )
     return errorResponse(400, 'Date de séance invalide', 'scheduled_at');
 
   if (appointment_mode === 'video' && video_link) {
-    if (typeof video_link !== 'string') return errorResponse(400, 'Lien vidéo invalide', 'video_link');
+    if (typeof video_link !== 'string')
+      return errorResponse(400, 'Lien vidéo invalide', 'video_link');
     try {
       const parsed = new URL(video_link as string);
       if (parsed.protocol !== 'https:')
-        return errorResponse(400, 'Lien vidéo invalide (HTTPS requis)', 'video_link');
+        return errorResponse(
+          400,
+          'Lien vidéo invalide (HTTPS requis)',
+          'video_link',
+        );
     } catch {
       return errorResponse(400, 'Lien vidéo invalide', 'video_link');
     }
   }
 
-  if (override_price !== undefined && (
-    !Number.isInteger(Number(override_price)) ||
-    Number(override_price) < 0 ||
-    Number(override_price) > 500
-  ))
-    return errorResponse(400, 'Tarif manuel invalide (entre 0 et 500€)', 'override_price');
+  if (
+    override_price !== undefined &&
+    (!Number.isInteger(Number(override_price)) ||
+      Number(override_price) < 0 ||
+      Number(override_price) > 500)
+  )
+    return errorResponse(
+      400,
+      'Tarif manuel invalide (entre 0 et 500€)',
+      'override_price',
+    );
 
   const scheduledDate = new Date(scheduled_at);
   if (scheduledDate.getTime() < Date.now())
-    return errorResponse(400, 'La date de séance doit être dans le futur', 'scheduled_at');
+    return errorResponse(
+      400,
+      'La date de séance doit être dans le futur',
+      'scheduled_at',
+    );
 
-  if (appointment_mode === 'in-person' && !(await isCabinetEligibleSlot(scheduled_at)))
-    return errorResponse(400, 'Les rendez-vous en présentiel ne sont pas disponibles sur ce créneau.', 'scheduled_at');
+  if (
+    appointment_mode === 'in-person' &&
+    !(await isCabinetEligibleSlot(scheduled_at))
+  )
+    return errorResponse(
+      400,
+      'Les rendez-vous en présentiel ne sont pas disponibles sur ce créneau.',
+      'scheduled_at',
+    );
 
   try {
-    const slotEnd = new Date(scheduledDate.getTime() + Number(duration) * 60 * 1000);
+    const slotEnd = new Date(
+      scheduledDate.getTime() + Number(duration) * 60 * 1000,
+    );
     const hasConflict = await hasAppointmentConflict({
       slotStartIso: scheduledDate.toISOString(),
       slotEndIso: slotEnd.toISOString(),
     });
     if (hasConflict) {
-      return errorResponse(409, 'Ce créneau n\'est plus disponible. Veuillez sélectionner un autre horaire.', 'scheduled_at');
+      return errorResponse(
+        409,
+        "Ce créneau n'est plus disponible. Veuillez sélectionner un autre horaire.",
+        'scheduled_at',
+      );
     }
   } catch (conflictError) {
-    console.error('[admin/appointments] Erreur vérification doublon:', conflictError);
+    console.error(
+      '[admin/appointments] Erreur vérification doublon:',
+      conflictError,
+    );
     return errorResponse(500, 'Erreur lors de la vérification du créneau');
   }
 
@@ -149,10 +220,12 @@ export const POST: APIRoute = async ({ request, locals }) => {
     .in('status', ['confirmed', 'completed'])
     .limit(1);
 
-  const autoDetectedFirstSession = !existingAppointments || existingAppointments.length === 0;
-  const isFirstSession = typeof override_first_session === 'boolean'
-    ? override_first_session
-    : autoDetectedFirstSession;
+  const autoDetectedFirstSession =
+    !existingAppointments || existingAppointments.length === 0;
+  const isFirstSession =
+    typeof override_first_session === 'boolean'
+      ? override_first_session
+      : autoDetectedFirstSession;
   const pricing = calculatePrice(
     appointment_type as AppointmentType,
     Number(duration),
@@ -167,7 +240,9 @@ export const POST: APIRoute = async ({ request, locals }) => {
   let creditApplied = 0;
 
   if (use_credit === true) {
-    const balance = await getAvailableCredit((patient_email as string).toLowerCase());
+    const balance = await getAvailableCredit(
+      (patient_email as string).toLowerCase(),
+    );
     if (balance > 0) {
       creditApplied = Math.min(balance, finalPriceCents);
     }
@@ -176,7 +251,9 @@ export const POST: APIRoute = async ({ request, locals }) => {
 
   // 6. Statut initial
   const initialStatus: string = isVideo
-    ? (amountDueCents === 0 ? 'payment_received' : 'payment_pending')
+    ? amountDueCents === 0
+      ? 'payment_received'
+      : 'payment_pending'
     : 'confirmed';
 
   // 7. Insertion en base
@@ -185,7 +262,9 @@ export const POST: APIRoute = async ({ request, locals }) => {
     .insert({
       patient_name: (patient_name as string).trim(),
       patient_email: (patient_email as string).toLowerCase(),
-      patient_phone: patient_phone ? (patient_phone as string).replace(/\s/g, '') : '',
+      patient_phone: patient_phone
+        ? (patient_phone as string).replace(/\s/g, '')
+        : '',
       patient_postal_code: '',
       patient_city: '',
       appointment_type,
@@ -232,9 +311,18 @@ export const POST: APIRoute = async ({ request, locals }) => {
         appointment.id,
       );
     } catch (creditErr) {
-      console.error('[admin/appointments] Erreur consommation avoir:', creditErr);
-      await supabaseAdmin.from('appointments').delete().eq('id', appointment.id);
-      return errorResponse(409, 'Avoir insuffisant ou erreur lors de la consommation de l\'avoir.');
+      console.error(
+        '[admin/appointments] Erreur consommation avoir:',
+        creditErr,
+      );
+      await supabaseAdmin
+        .from('appointments')
+        .delete()
+        .eq('id', appointment.id);
+      return errorResponse(
+        409,
+        "Avoir insuffisant ou erreur lors de la consommation de l'avoir.",
+      );
     }
   }
 
@@ -249,26 +337,53 @@ export const POST: APIRoute = async ({ request, locals }) => {
   // précède son premier await) et ne doit pas s'exécuter avant que la réponse
   // 201 soit construite et retournée. `setImmediate` (runtime Node/Netlify) est
   // FIFO avec les autres immediates ; fallback `setTimeout` ailleurs.
-  const schedule = typeof setImmediate === 'function' ? setImmediate : setTimeout;
+  const schedule =
+    typeof setImmediate === 'function' ? setImmediate : setTimeout;
   // `status` est le statut INSÉRÉ (payment_received/… ) : il pilote le drapeau
   // confirmation_sent_at côté pipeline. Fallback défensif si la ligne retournée
   // ne portait pas la colonne.
-  const apptForSideEffects = { ...appointment, status: appointment.status ?? initialStatus };
-  const sideEffects: Promise<void> = new Promise((resolve) => {
+  const apptForSideEffects = {
+    ...appointment,
+    status: appointment.status ?? initialStatus,
+  };
+  const sideEffects: Promise<void> = new Promise(resolve => {
     schedule(() => {
-      void processAppointmentSideEffects(apptForSideEffects, {
-        sendEmail: shouldSendEmail,
-        amountDueCents,
-        successUrl: import.meta.env.STRIPE_SUCCESS_URL
-          ?? `${new URL(request.url).origin}/rdv/merci/?source=payment-success`,
-        baseUrl: import.meta.env.BETTER_AUTH_URL ?? new URL(request.url).origin,
-      }).then(resolve, resolve);
+      // W2 — bail atomique (lease 10 min) AVANT le pipeline : si le sweep
+      // `reconcile-invitations` (ou un autre worker) traite déjà cette ligne,
+      // on NE démarre PAS — deux pipelines simultanés créeraient un doublon
+      // events.insert Google + Payment Link Stripe. Échec du claim (erreur
+      // DB) = fail-closed : le sweep horaire rattrapera la ligne.
+      void claimInvitationProcessing(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        supabaseAdmin as any,
+        appointment.id,
+      )
+        .then(claimed => {
+          if (!claimed) {
+            console.info('[side-effects] dispatch skipped — already claimed', {
+              appointmentId: appointment.id,
+            });
+            return;
+          }
+          return processAppointmentSideEffects(apptForSideEffects, {
+            sendEmail: shouldSendEmail,
+            amountDueCents,
+            successUrl:
+              import.meta.env.STRIPE_SUCCESS_URL ??
+              `${new URL(request.url).origin}/rdv/merci/?source=payment-success`,
+            baseUrl:
+              import.meta.env.BETTER_AUTH_URL ?? new URL(request.url).origin,
+          });
+        })
+        .then(resolve, resolve);
     });
   });
 
   // waitUntil : promesse capturée par le runtime Netlify, exécutée APRÈS la
   // réponse. `locals` n'est pas typé pour `netlify` — accès optionnel sûr.
-  const netlifyLocals = (locals as { netlify?: { context?: { waitUntil?: unknown } } } | undefined)?.netlify;
+  const netlifyLocals = (
+    locals as { netlify?: { context?: { waitUntil?: unknown } } } | undefined
+  )?.netlify;
   const waitUntil = netlifyLocals?.context?.waitUntil;
   if (typeof waitUntil === 'function') {
     (waitUntil as (p: Promise<unknown>) => void)(sideEffects);

--- a/src/pages/api/admin/appointments/index.ts
+++ b/src/pages/api/admin/appointments/index.ts
@@ -1,23 +1,16 @@
 export const prerender = false;
 
 import type { APIRoute } from 'astro';
-import { createElement } from 'react';
 import { auth } from '../../../../lib/auth';
 import { isAdminSession } from '../../../../lib/authz';
 import { supabaseAdmin } from '../../../../lib/supabase';
 import { calculatePrice } from '../../../../lib/pricing';
 import { getAvailableCredit, consumeCredits } from '../../../../lib/credits';
-import { sendEmail, buildAppointmentConversationSubject } from '../../../../lib/resend';
-import { createAppointmentPaymentLink } from '../../../../lib/stripe';
-import { generateGoogleCalendarLink, generateOutlookCalendarLink, generateAppleCalendarInviteLink, CABINET_ADDRESS } from '../../../../lib/ics';
-import { createSecureLinkToken } from '../../../../lib/secure-links';
-import { createCalendarEvent } from '../../../../lib/google-calendar';
 import { hasAppointmentConflict } from '../../../../lib/appointment-conflicts';
-import AppointmentConfirmed from '../../../../emails/AppointmentConfirmed';
-import PaymentRequest from '../../../../emails/PaymentRequest';
 import type { AppointmentType } from '../../../../types/appointment';
 import { invalidateAvailabilityCache } from '../../../../lib/calendar-cache.js';
 import { isCabinetEligibleSlot } from '../../../../lib/appointment-eligibility';
+import { processAppointmentSideEffects } from '../../../../lib/notifications';
 
 // ---------------------------------------------------------------------------
 // Validation helpers
@@ -37,34 +30,15 @@ function errorResponse(status: number, message: string, field?: string): Respons
 }
 
 // ---------------------------------------------------------------------------
-// L2 flag helpers (issue #126) — set-once, never reset, non-fatal
-// ---------------------------------------------------------------------------
-
-/**
- * Mark the invitation email as delivered. `WHERE invitation_sent_at IS NULL`
- * keeps the write set-once (a future cron sweep relies on NULL = "to retry").
- * Failure is logged and swallowed: a flag write must never fail a creation.
- */
-async function markInvitationSent(appointmentId: string, extra?: Record<string, string>): Promise<void> {
-  try {
-    const { error } = await supabaseAdmin
-      .from('appointments')
-      .update({ invitation_sent_at: new Date().toISOString(), ...extra })
-      .eq('id', appointmentId)
-      .is('invitation_sent_at', null);
-    if (error) {
-      console.error('[admin/appointments] invitation_sent_at write failed:', error);
-    }
-  } catch (flagErr) {
-    console.error('[admin/appointments] invitation_sent_at write failed:', flagErr);
-  }
-}
-
-// ---------------------------------------------------------------------------
 // POST — création manuelle d'un rendez-vous par l'admin
 // ---------------------------------------------------------------------------
 
-export const POST: APIRoute = async ({ request }) => {
+// Issue #126 : les fonctions synchrones Netlify sont tuées à ~10s (504).
+// Le chemin critique ne fait AUCUN appel réseau externe (Google/Stripe/Resend) :
+// agenda, lien de paiement et email partent post-réponse via
+// `locals.netlify.context.waitUntil` (adaptateur @astrojs/netlify), avec un
+// repli inline best-effort (non attendu) hors runtime Netlify.
+export const POST: APIRoute = async ({ request, locals }) => {
   // 1. Auth guard — admin seulement
   const session = await auth.api.getSession({ headers: request.headers });
   if (!session?.user) {
@@ -165,8 +139,6 @@ export const POST: APIRoute = async ({ request }) => {
   }
 
   // 4. Calcul tarifaire
-  // Pour une création manuelle, on calcule toujours la remise nouveau client si applicable.
-  // L'admin peut activer le tarif solidaire via is_solidarity.
   const { data: existingAppointments } = await supabaseAdmin
     .from('appointments')
     .select('id')
@@ -175,7 +147,6 @@ export const POST: APIRoute = async ({ request }) => {
     .limit(1);
 
   const autoDetectedFirstSession = !existingAppointments || existingAppointments.length === 0;
-  // override_first_session allows admin to manually force/disable first-session discount
   const isFirstSession = typeof override_first_session === 'boolean'
     ? override_first_session
     : autoDetectedFirstSession;
@@ -187,12 +158,7 @@ export const POST: APIRoute = async ({ request }) => {
     override_price !== undefined ? Number(override_price) : undefined,
   );
 
-  // 5. Avoir (avoir interne) — déduction admin-only
-  // ----------------------------------------------------------------
-  // Si l'admin coche « utiliser l'avoir » et qu'un avoir est disponible pour
-  // cet email, on consomme en FIFO le montant plafonné à final_price.
-  // montant dû = final_price - credit_applied. Si 0 → pas de paiement Stripe,
-  // statut payment_received (video) / confirmed (in-person).
+  // 5. Avoir (avoir interne) — montant dû = final_price − crédit consommé
   const isVideo = appointment_mode === 'video';
   const finalPriceCents = pricing.finalPrice * 100;
   let creditApplied = 0;
@@ -206,8 +172,6 @@ export const POST: APIRoute = async ({ request }) => {
   const amountDueCents = Math.max(0, finalPriceCents - creditApplied);
 
   // 6. Statut initial
-  // in-person → confirmed directement (jamais de paiement en ligne)
-  // video → payment_pending (lien Stripe) SAUF si montant dû = 0 → payment_received
   const initialStatus: string = isVideo
     ? (amountDueCents === 0 ? 'payment_received' : 'payment_pending')
     : 'confirmed';
@@ -245,7 +209,7 @@ export const POST: APIRoute = async ({ request }) => {
     return errorResponse(500, 'Erreur lors de la création du rendez-vous');
   }
 
-  // 8. Consommer l'avoir (atomique, FIFO) — après l'insert (besoin de l'id).
+  // 8. Consommer l'avoir (atomique, FIFO) — échec → rollback INSERT + 409.
   if (creditApplied > 0) {
     try {
       await consumeCredits(
@@ -254,7 +218,6 @@ export const POST: APIRoute = async ({ request }) => {
         appointment.id,
       );
     } catch (creditErr) {
-      // Échec consommation : on annule le RDV (cohérence — pas de credit_applied sans usage).
       console.error('[admin/appointments] Erreur consommation avoir:', creditErr);
       await supabaseAdmin.from('appointments').delete().eq('id', appointment.id);
       return errorResponse(409, 'Avoir insuffisant ou erreur lors de la consommation de l\'avoir.');
@@ -263,209 +226,46 @@ export const POST: APIRoute = async ({ request }) => {
 
   await invalidateAvailabilityCache().catch(console.error);
 
-  let resolvedVideoLink: string | undefined = appointment.video_link ?? undefined;
+  // 9. Side-effects post-réponse (issue #126) : agenda → Stripe → email +
+  // drapeaux L2. Le pipeline ne jette jamais ; chaque étape est isolée et
+  // observable (`[side-effects]` logs), le cron de rattrapage repasse sur les
+  // flags NULL.
+  // Le démarrage du pipeline est différé d'un macrotask : le préfixe de
+  // `processAppointmentSideEffects` est synchrone (l'appel à createCalendarEvent
+  // précède son premier await) et ne doit pas s'exécuter avant que la réponse
+  // 201 soit construite et retournée. `setImmediate` (runtime Node/Netlify) est
+  // FIFO avec les autres immediates ; fallback `setTimeout` ailleurs.
+  const schedule = typeof setImmediate === 'function' ? setImmediate : setTimeout;
+  // `status` est le statut INSÉRÉ (payment_received/… ) : il pilote le drapeau
+  // confirmation_sent_at côté pipeline. Fallback défensif si la ligne retournée
+  // ne portait pas la colonne.
+  const apptForSideEffects = { ...appointment, status: appointment.status ?? initialStatus };
+  const sideEffects: Promise<void> = new Promise((resolve) => {
+    schedule(() => {
+      void processAppointmentSideEffects(apptForSideEffects, {
+        sendEmail: shouldSendEmail,
+        amountDueCents,
+        successUrl: import.meta.env.STRIPE_SUCCESS_URL
+          ?? `${new URL(request.url).origin}/rdv/merci/?source=payment-success`,
+        baseUrl: import.meta.env.BETTER_AUTH_URL ?? new URL(request.url).origin,
+      }).then(resolve, resolve);
+    });
+  });
 
-  if (!appointment.google_calendar_event_id) {
-    try {
-      const start = new Date(appointment.scheduled_at);
-      const end = new Date(start.getTime() + appointment.duration * 60 * 1000);
-      const modeLabel = isVideo ? 'Téléconsultation' : 'Présentiel';
-      const calResult = await createCalendarEvent({
-        title: `${isVideo ? '🎥 ' : ''}${appointment.patient_name} — séance ${modeLabel.toLowerCase()} (${appointment.duration} min)`,
-        start: start.toISOString(),
-        end: end.toISOString(),
-        description: [
-          `Patient: ${appointment.patient_name}`,
-          `Email: ${appointment.patient_email}`,
-          `Mode: ${modeLabel}`,
-          `Durée: ${appointment.duration} min`,
-          ...(resolvedVideoLink ? [`Lien visio: ${resolvedVideoLink}`] : []),
-        ].join('\n'),
-        location: isVideo ? 'Téléconsultation' : CABINET_ADDRESS,
-        attendeeEmail: appointment.patient_email,
-        withMeet: isVideo && !resolvedVideoLink,
-        appointmentId: `${appointment.id}-admin-${isVideo ? 'video' : 'inperson'}`,
-        colorId: isVideo ? '11' : '2',
-      });
-      const calendarUpdate: Record<string, string> = { google_calendar_event_id: calResult.eventId };
-      if (isVideo && calResult.meetLink) calendarUpdate.video_link = calResult.meetLink;
-      await supabaseAdmin.from('appointments').update(calendarUpdate).eq('id', appointment.id);
-      if (isVideo && calResult.meetLink) resolvedVideoLink = calResult.meetLink;
-    } catch (calendarErr) {
-      console.error('[admin/appointments] Erreur création événement agenda:', calendarErr);
-    }
+  // waitUntil : promesse capturée par le runtime Netlify, exécutée APRÈS la
+  // réponse. `locals` n'est pas typé pour `netlify` — accès optionnel sûr.
+  const netlifyLocals = (locals as { netlify?: { context?: { waitUntil?: unknown } } } | undefined)?.netlify;
+  const waitUntil = netlifyLocals?.context?.waitUntil;
+  if (typeof waitUntil === 'function') {
+    (waitUntil as (p: Promise<unknown>) => void)(sideEffects);
+  } else {
+    // Repli inline best-effort (dev / hors Netlify) — NON attendu avant 201.
+    void sideEffects;
   }
 
-  // 9. Paiement Stripe + envoi email
-  // ----------------------------------------------------------------
-  // Video + montant dû > 0  → lien Stripe pour le SOLDE (final_price - credit_applied).
-  // Video + montant dû = 0  → aucun Stripe (avoir couvre tout), confirmation directe.
-  // In-person               → confirmation directe (jamais de paiement en ligne).
-  if (shouldSendEmail) {
-    const origin = new URL(request.url).origin;
-    const successUrl = import.meta.env.STRIPE_SUCCESS_URL ?? `${origin}/rdv/merci/?source=payment-success`;
-
-    if (isVideo && amountDueCents > 0) {
-      // Créer le lien Stripe (pour le solde dû) et envoyer une demande de paiement
-      try {
-        const paymentLink = await createAppointmentPaymentLink({
-          appointmentId: appointment.id,
-          patientEmail: appointment.patient_email,
-          patientName: appointment.patient_name,
-          amount: amountDueCents,
-          description: `Séance de thérapie — ${new Date(appointment.scheduled_at).toLocaleDateString('fr-FR')}`,
-          successUrl,
-        });
-
-        await supabaseAdmin
-          .from('appointments')
-          .update({ stripe_payment_link_id: paymentLink.id, stripe_payment_link_url: paymentLink.url })
-          .eq('id', appointment.id);
-
-        const emailResult = await sendEmail({
-          to: appointment.patient_email,
-          threadKey: `appointment:${appointment.id}:patient`,
-          subject: buildAppointmentConversationSubject(
-            `Prépaiement de votre séance — ${new Date(appointment.scheduled_at).toLocaleDateString('fr-FR')}`,
-            appointment.id,
-          ),
-          react: createElement(PaymentRequest, {
-            patientName: appointment.patient_name,
-            scheduledAt: appointment.scheduled_at,
-            appointmentType: appointment.appointment_type,
-            duration: appointment.duration,
-            finalPrice: amountDueCents,
-            stripePaymentUrl: paymentLink.url,
-          }),
-        });
-        if (!emailResult.success) {
-          console.error('[admin/appointments] email PaymentRequest error:', emailResult.error);
-        } else {
-          // L2: invitation délivrée (set-once) — pas de flag si l'envoi échoue,
-          // le futur sweep rattrapera.
-          await markInvitationSent(appointment.id);
-        }
-      } catch (e) {
-        console.error('[admin/appointments] Stripe error (non-bloquant):', e);
-      }
-    } else if (isVideo && amountDueCents === 0) {
-      // Avoir couvre l'intégralité : envoyer une confirmation (séance réglée par avoir).
-      try {
-        const start = new Date(appointment.scheduled_at);
-        const end = new Date(start.getTime() + appointment.duration * 60 * 1000);
-        const calendarEvent = {
-          uid: appointment.id,
-          summary: 'Séance de thérapie — OMF Therapie',
-          description: `Patient: ${appointment.patient_name}\nMode: Téléconsultation`,
-          location: resolvedVideoLink ?? undefined,
-          url: resolvedVideoLink ?? undefined,
-          start,
-          end,
-          organizerName: 'Oriane Montabonnet — OMF Thérapie',
-          organizerEmail: import.meta.env.RESEND_FROM_EMAIL ?? 'contact@omf-therapie.fr',
-        };
-        const gcalLink = generateGoogleCalendarLink(calendarEvent);
-        const outlookLink = generateOutlookCalendarLink(calendarEvent);
-        const baseUrl = import.meta.env.BETTER_AUTH_URL ?? new URL(request.url).origin;
-        const inviteToken = createSecureLinkToken({
-          appointmentId: appointment.id,
-          purpose: 'ics-invite',
-          expiresInSeconds: 60 * 60 * 24 * 180,
-          nonce: appointment.scheduled_at,
-        });
-        const appleLink = generateAppleCalendarInviteLink(baseUrl, appointment.id, inviteToken);
-
-        const emailResult = await sendEmail({
-          to: appointment.patient_email,
-          threadKey: `appointment:${appointment.id}:patient`,
-          subject: buildAppointmentConversationSubject(
-            `Votre rendez-vous est confirmé — ${new Date(appointment.scheduled_at).toLocaleDateString('fr-FR')}`,
-            appointment.id,
-          ),
-          react: createElement(AppointmentConfirmed, {
-            patientName: appointment.patient_name,
-            appointmentType: appointment.appointment_type,
-            appointmentMode: appointment.appointment_mode,
-            scheduledAt: appointment.scheduled_at,
-            duration: appointment.duration,
-            finalPrice: appointment.final_price,
-            videoLink: resolvedVideoLink,
-            googleCalendarLink: gcalLink,
-            appleCalendarLink: appleLink,
-            outlookCalendarLink: outlookLink,
-          }),
-        });
-        if (emailResult.success) {
-          // L2: séance réglée par avoir → l'invitation EST la confirmation.
-          // Un seul update pose les deux drapeaux (set-once).
-          await markInvitationSent(appointment.id, { confirmation_sent_at: new Date().toISOString() });
-        }
-      } catch (e) {
-        console.error('[admin/appointments] email confirmation (avoir) error (non-bloquant):', e);
-      }
-    } else {
-      // In-person : confirmer directement et envoyer l'email de confirmation
-      const start = new Date(appointment.scheduled_at);
-      const end = new Date(start.getTime() + appointment.duration * 60 * 1000);
-      const calendarEvent = {
-        uid: appointment.id,
-        summary: 'Séance de thérapie — OMF Therapie',
-        description: `Patient: ${appointment.patient_name}\nMode: ${appointment.appointment_mode === 'video' ? 'Téléconsultation' : 'Présentiel'}`,
-        location: appointment.appointment_mode === 'in-person' ? CABINET_ADDRESS : (resolvedVideoLink ?? undefined),
-        url: resolvedVideoLink ?? undefined,
-        start,
-        end,
-        organizerName: 'Oriane Montabonnet — OMF Thérapie',
-        organizerEmail: import.meta.env.RESEND_FROM_EMAIL ?? 'contact@omf-therapie.fr',
-      };
-      const gcalLink = generateGoogleCalendarLink(calendarEvent);
-      const outlookCalendarLink = generateOutlookCalendarLink(calendarEvent);
-      const baseUrl = import.meta.env.BETTER_AUTH_URL ?? new URL(request.url).origin;
-      const inviteToken = createSecureLinkToken({
-        appointmentId: appointment.id,
-        purpose: 'ics-invite',
-        expiresInSeconds: 60 * 60 * 24 * 180,
-        nonce: appointment.scheduled_at,
-      });
-      const appleCalendarLink = generateAppleCalendarInviteLink(baseUrl, appointment.id, inviteToken);
-
-      const emailResult = await sendEmail({
-        to: appointment.patient_email,
-        threadKey: `appointment:${appointment.id}:patient`,
-        subject: buildAppointmentConversationSubject(
-          `Votre rendez-vous est confirmé — ${new Date(appointment.scheduled_at).toLocaleDateString('fr-FR')}`,
-          appointment.id,
-        ),
-        react: createElement(AppointmentConfirmed, {
-          patientName: appointment.patient_name,
-          appointmentType: appointment.appointment_type,
-          appointmentMode: appointment.appointment_mode,
-          scheduledAt: appointment.scheduled_at,
-          duration: appointment.duration,
-          finalPrice: appointment.final_price,
-          googleCalendarLink: gcalLink,
-          appleCalendarLink,
-          outlookCalendarLink,
-          cabinetAddress: CABINET_ADDRESS,
-        }),
-      });
-      if (!emailResult.success) {
-        console.error('[admin/appointments] email AppointmentConfirmed error:', emailResult.error);
-      } else {
-        // L2: invitation (confirmation présentiel) délivrée — set-once.
-        await markInvitationSent(appointment.id);
-      }
-    }
-  }
-
-  // Refetch to include any calendar event ID set after the initial insert
-  const { data: finalAppointment } = await supabaseAdmin
-    .from('appointments')
-    .select('*')
-    .eq('id', appointment.id)
-    .single();
-
-  return new Response(JSON.stringify({ appointment: finalAppointment ?? appointment }), {
+  // 10. 201 immédiat — ligne insérée telle quelle (pas de re-fetch : les champs
+  // agenda/Stripe ne sont pas encore produits ; le client admin recharge la page).
+  return new Response(JSON.stringify({ appointment }), {
     status: 201,
     headers: { 'Content-Type': 'application/json' },
   });

--- a/src/pages/api/admin/appointments/index.ts
+++ b/src/pages/api/admin/appointments/index.ts
@@ -375,7 +375,12 @@ export const POST: APIRoute = async ({ request, locals }) => {
               import.meta.env.BETTER_AUTH_URL ?? new URL(request.url).origin,
           });
         })
-        .then(resolve, resolve);
+        // La valeur de chaîne ({ flagsSet } | undefined) est ignorée : le
+        // contrat externe reste Promise<void>, résolu quoi qu'il arrive.
+        .then(
+          () => resolve(),
+          () => resolve(),
+        );
     });
   });
 

--- a/src/pages/api/admin/appointments/index.ts
+++ b/src/pages/api/admin/appointments/index.ts
@@ -37,6 +37,30 @@ function errorResponse(status: number, message: string, field?: string): Respons
 }
 
 // ---------------------------------------------------------------------------
+// L2 flag helpers (issue #126) — set-once, never reset, non-fatal
+// ---------------------------------------------------------------------------
+
+/**
+ * Mark the invitation email as delivered. `WHERE invitation_sent_at IS NULL`
+ * keeps the write set-once (a future cron sweep relies on NULL = "to retry").
+ * Failure is logged and swallowed: a flag write must never fail a creation.
+ */
+async function markInvitationSent(appointmentId: string, extra?: Record<string, string>): Promise<void> {
+  try {
+    const { error } = await supabaseAdmin
+      .from('appointments')
+      .update({ invitation_sent_at: new Date().toISOString(), ...extra })
+      .eq('id', appointmentId)
+      .is('invitation_sent_at', null);
+    if (error) {
+      console.error('[admin/appointments] invitation_sent_at write failed:', error);
+    }
+  } catch (flagErr) {
+    console.error('[admin/appointments] invitation_sent_at write failed:', flagErr);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // POST — création manuelle d'un rendez-vous par l'admin
 // ---------------------------------------------------------------------------
 
@@ -209,6 +233,9 @@ export const POST: APIRoute = async ({ request }) => {
       final_price: finalPriceCents,
       credit_applied: creditApplied,
       video_link: isVideo ? (video_link ?? null) : null,
+      // send_email:false → aucun email ne partira jamais : on pose le flag L2
+      // dès l'insert pour que le futur sweep ne tente pas d'envoi de rattrapage.
+      ...(shouldSendEmail ? {} : { invitation_sent_at: new Date().toISOString() }),
     })
     .select()
     .single();
@@ -313,6 +340,10 @@ export const POST: APIRoute = async ({ request }) => {
         });
         if (!emailResult.success) {
           console.error('[admin/appointments] email PaymentRequest error:', emailResult.error);
+        } else {
+          // L2: invitation délivrée (set-once) — pas de flag si l'envoi échoue,
+          // le futur sweep rattrapera.
+          await markInvitationSent(appointment.id);
         }
       } catch (e) {
         console.error('[admin/appointments] Stripe error (non-bloquant):', e);
@@ -344,7 +375,7 @@ export const POST: APIRoute = async ({ request }) => {
         });
         const appleLink = generateAppleCalendarInviteLink(baseUrl, appointment.id, inviteToken);
 
-        await sendEmail({
+        const emailResult = await sendEmail({
           to: appointment.patient_email,
           threadKey: `appointment:${appointment.id}:patient`,
           subject: buildAppointmentConversationSubject(
@@ -364,6 +395,11 @@ export const POST: APIRoute = async ({ request }) => {
             outlookCalendarLink: outlookLink,
           }),
         });
+        if (emailResult.success) {
+          // L2: séance réglée par avoir → l'invitation EST la confirmation.
+          // Un seul update pose les deux drapeaux (set-once).
+          await markInvitationSent(appointment.id, { confirmation_sent_at: new Date().toISOString() });
+        }
       } catch (e) {
         console.error('[admin/appointments] email confirmation (avoir) error (non-bloquant):', e);
       }
@@ -415,6 +451,9 @@ export const POST: APIRoute = async ({ request }) => {
       });
       if (!emailResult.success) {
         console.error('[admin/appointments] email AppointmentConfirmed error:', emailResult.error);
+      } else {
+        // L2: invitation (confirmation présentiel) délivrée — set-once.
+        await markInvitationSent(appointment.id);
       }
     }
   }

--- a/src/pages/api/appointments/[id].ts
+++ b/src/pages/api/appointments/[id].ts
@@ -10,7 +10,7 @@ import { sendEmail, buildAppointmentConversationSubject } from '../../../lib/res
 import { generateGoogleCalendarLink, generateOutlookCalendarLink, generateAppleCalendarInviteLink, CABINET_ADDRESS } from '../../../lib/ics';
 import { createSecureLinkToken, verifySecureLinkToken } from '../../../lib/secure-links';
 import { getTypeLabel, getModeLabel, calculatePrice } from '../../../lib/pricing';
-import { stripe, createAppointmentPaymentLink } from '../../../lib/stripe';
+import { createAppointmentPaymentLink, getStripe } from '../../../lib/stripe';
 import { createCalendarEvent, updateCalendarEvent, deleteCalendarEvent } from '../../../lib/google-calendar';
 import { hasAppointmentConflict } from '../../../lib/appointment-conflicts';
 import { isCabinetEligibleSlot } from '../../../lib/appointment-eligibility';
@@ -662,7 +662,7 @@ export const PATCH: APIRoute = async ({ request, params }) => {
     // Expire l'ancien Payment Link Stripe s'il existe (évite le double-paiement)
     if (appointment.stripe_payment_link_id) {
       try {
-        await stripe.paymentLinks.update(appointment.stripe_payment_link_id, { active: false });
+        await getStripe()?.paymentLinks.update(appointment.stripe_payment_link_id, { active: false });
       } catch (stripeErr) {
         logger.error('appointments/patch: Stripe Payment Link expiry failed (reschedule)', { appointmentId: id, stripePaymentLinkId: appointment.stripe_payment_link_id }, stripeErr);
         // Non-bloquant : on continue, le lien expiré est préférable à bloquer le report

--- a/src/pages/api/appointments/[id].ts
+++ b/src/pages/api/appointments/[id].ts
@@ -48,6 +48,29 @@ function onCacheInvalidateError(err: unknown): void {
   logger.error('appointments/patch: availability cache invalidation failed', {}, err);
 }
 
+/**
+ * Pose le drapeau L2 `invitation_sent_at` (set-once, issue #126) après un
+ * envoi d'email patient réussi par cette voie (confirm / accept_reschedule).
+ * Sans lui, le sweep `reconcile-invitations` verrait la ligne
+ * `invitation_sent_at IS NULL` et re-mailerait le patient (email dupliqué +
+ * clé d'idempotence L1 différente).
+ * Non fatal : si l'update échoue, on loggue et on continue — la réponse HTTP
+ * prime, le cron de rattrapage reprend le relais (même patron que le POST admin).
+ */
+async function markInvitationSent(appointmentId: string, emailSent: boolean): Promise<void> {
+  if (!emailSent) return;
+  try {
+    const { error } = await supabaseAdmin
+      .from('appointments')
+      .update({ invitation_sent_at: new Date().toISOString() })
+      .eq('id', appointmentId)
+      .is('invitation_sent_at', null);
+    if (error) throw error;
+  } catch (err) {
+    logger.error('appointments/patch: invitation_sent_at set-once update failed', { appointmentId }, err);
+  }
+}
+
 /** Construit l'événement ICS pour un rendez-vous confirmé */
 function buildICSEvent(appt: Appointment) {
   const start = new Date(appt.scheduled_at);
@@ -288,7 +311,7 @@ export const PATCH: APIRoute = async ({ request, params }) => {
 
     // Envoyer email de demande de paiement si payment_pending (séance vidéo)
     if (newStatus === 'payment_pending' && updatedAppt.stripe_payment_link_url) {
-      await sendEmail({
+      const emailResult = await sendEmail({
         to: updatedAppt.patient_email,
         threadKey: `appointment:${updatedAppt.id}:patient`,
         subject: buildAppointmentConversationSubject(
@@ -306,6 +329,8 @@ export const PATCH: APIRoute = async ({ request, params }) => {
           stripePaymentUrl: updatedAppt.stripe_payment_link_url,
         }),
       });
+      // C5 : invitation partie par cette voie — drapeau L2 set-once (non fatal).
+      await markInvitationSent(id, emailResult.success === true);
     }
 
     // Envoyer confirmation seulement si status final = confirmed (pas payment_pending)
@@ -321,7 +346,7 @@ export const PATCH: APIRoute = async ({ request, params }) => {
       });
       const appleCalendarLink = generateAppleCalendarInviteLink(baseUrl, updatedAppt.id, inviteToken);
 
-      await sendEmail({
+      const emailResult = await sendEmail({
         to: updatedAppt.patient_email,
         threadKey: `appointment:${updatedAppt.id}:patient`,
         subject: buildAppointmentConversationSubject(
@@ -344,6 +369,8 @@ export const PATCH: APIRoute = async ({ request, params }) => {
           cabinetAddress: updatedAppt.appointment_mode === 'in-person' ? CABINET_ADDRESS : undefined,
         }),
       });
+      // C5 : invitation partie par cette voie — drapeau L2 set-once (non fatal).
+      await markInvitationSent(id, emailResult.success === true);
     }
 
     return jsonResponse({ appointment: updatedAppt, message: newStatus === 'confirmed' ? 'Rendez-vous confirmé.' : 'Lien de paiement à envoyer au patient.' });
@@ -907,7 +934,7 @@ export const PATCH: APIRoute = async ({ request, params }) => {
 
     // Email : demande de paiement pour les séances vidéo
     if (newStatus === 'payment_pending' && updatedAppt.stripe_payment_link_url) {
-      await sendEmail({
+      const emailResult = await sendEmail({
         to: updatedAppt.patient_email,
         threadKey: `appointment:${updatedAppt.id}:patient`,
         subject: buildAppointmentConversationSubject(
@@ -925,6 +952,8 @@ export const PATCH: APIRoute = async ({ request, params }) => {
           stripePaymentUrl: updatedAppt.stripe_payment_link_url,
         }),
       });
+      // C5 : invitation partie par cette voie — drapeau L2 set-once (non fatal).
+      await markInvitationSent(id, emailResult.success === true);
     }
 
     // Email : confirmation pour les séances en présentiel
@@ -940,7 +969,7 @@ export const PATCH: APIRoute = async ({ request, params }) => {
       });
       const appleCalendarLink = generateAppleCalendarInviteLink(baseUrl, updatedAppt.id, inviteToken);
 
-      await sendEmail({
+      const emailResult = await sendEmail({
         to: updatedAppt.patient_email,
         threadKey: `appointment:${updatedAppt.id}:patient`,
         subject: buildAppointmentConversationSubject(
@@ -963,6 +992,8 @@ export const PATCH: APIRoute = async ({ request, params }) => {
           cabinetAddress: updatedAppt.appointment_mode === 'in-person' ? CABINET_ADDRESS : undefined,
         }),
       });
+      // C5 : invitation partie par cette voie — drapeau L2 set-once (non fatal).
+      await markInvitationSent(id, emailResult.success === true);
     }
 
     return jsonResponse({

--- a/src/pages/api/stripe-webhook.ts
+++ b/src/pages/api/stripe-webhook.ts
@@ -385,9 +385,14 @@ export async function handlePaymentSucceeded(appointmentId: string, paymentInten
     throw new Error(`Échec envoi email patient pour ${appointmentId}`);
   }
 
+  const now = new Date().toISOString();
   const { error: confirmUpdateErr } = await supabaseAdmin
     .from('appointments')
-    .update({ confirmation_sent_at: new Date().toISOString() })
+    // C5 (issue #126) : l'email de confirmation post-paiement vaut AUSSI
+    // invitation — les DEUX drapeaux partent dans le MÊME update (set-once).
+    // Sans invitation_sent_at, le sweep `reconcile-invitations` verrait la
+    // ligne invitation_sent_at IS NULL et re-mailerait le patient.
+    .update({ confirmation_sent_at: now, invitation_sent_at: now })
     .eq('id', appointmentId)
     .is('confirmation_sent_at', null);
 

--- a/src/pages/api/stripe-webhook.ts
+++ b/src/pages/api/stripe-webhook.ts
@@ -2,7 +2,7 @@ export const prerender = false;
 
 import type { APIRoute } from 'astro';
 import type Stripe from 'stripe';
-import { stripe } from '../../lib/stripe';
+import { getStripe } from '../../lib/stripe';
 import { supabaseAdmin } from '../../lib/supabase';
 import { logger } from '../../lib/logger';
 import { getTypeLabel, getModeLabel } from '../../lib/pricing';
@@ -21,8 +21,8 @@ async function resolveAppointmentIdFromCheckoutSession(session: Stripe.Checkout.
 
   if (paymentIntentId) {
     try {
-      const paymentIntent = await stripe.paymentIntents.retrieve(paymentIntentId);
-      const fromPaymentIntent = paymentIntent.metadata?.appointment_id;
+      const paymentIntent = await getStripe()?.paymentIntents.retrieve(paymentIntentId);
+      const fromPaymentIntent = paymentIntent?.metadata?.appointment_id;
       if (fromPaymentIntent) return fromPaymentIntent;
     } catch (err) {
       logger.error('stripe-webhook: failed to retrieve PaymentIntent to resolve appointment_id', { paymentIntentId }, err);
@@ -73,9 +73,14 @@ export const POST: APIRoute = async ({ request }) => {
   }
 
   // 2. Vérifier la signature
+  const stripeClient = getStripe();
+  if (!stripeClient) {
+    logger.error('stripe-webhook: STRIPE_SECRET_KEY missing — webhooks disabled');
+    return new Response('Configuration Stripe manquante', { status: 500 });
+  }
   let event: Stripe.Event;
   try {
-    event = stripe.webhooks.constructEvent(
+    event = stripeClient.webhooks.constructEvent(
       rawBody,
       signature,
       webhookSecret,

--- a/src/types/appointment.ts
+++ b/src/types/appointment.ts
@@ -75,6 +75,14 @@ export interface Appointment {
    */
   confirmation_sent_at: string | null;
 
+  /**
+   * Horodatage de l'envoi de l'email d'invitation (rattrapage auto).
+   * NULL = en attente (reconcile-invitations retentera).
+   * Drapeau durable d'idempotence L2 (issue #126) : positionné UNIQUEMENT après
+   * succès complet de l'envoi. Jamais reset.
+   */
+  invitation_sent_at: string | null;
+
   // Google Meet (renseigné manuellement par la thérapeute)
   video_link: string | null;
 

--- a/supabase/migrations/012_credits_grants.sql
+++ b/supabase/migrations/012_credits_grants.sql
@@ -1,0 +1,20 @@
+-- ===========================================================================
+-- Migration 012 — Missing service_role grants on credits / credit_usages
+-- ===========================================================================
+-- 008_credits.sql created the credits tables but omitted the explicit GRANT
+-- required since 006_explicit_grants.sql revoked the implicit default
+-- privileges ("les nouvelles tables devront inclure un GRANT explicite dans
+-- leur migration"). As a result, every supabaseAdmin query on these tables
+-- failed in production with:
+--   42501 permission denied for table credits
+--
+-- Impact: getAvailableCredit / getCreditBalance silently returned 0, so the
+-- admin appointment-creation flow and the credits page ignored existing
+-- avoirs. The SECURITY DEFINER RPCs (consume_credits / restore_credits) were
+-- unaffected — only direct table access was broken.
+--
+-- Idempotent: re-running a GRANT is a no-op.
+-- ===========================================================================
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.credits        TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.credit_usages  TO service_role;

--- a/supabase/migrations/013_invitation_sent_at.sql
+++ b/supabase/migrations/013_invitation_sent_at.sql
@@ -14,7 +14,12 @@
 --          -- directly as payment_received and their invitation email can
 --          -- fail just like any other (required by SC3).
 --   AND invitation_sent_at IS NULL
---   AND created_at > now() - 48h         -- reconciliation window
+--   AND created_at > now() - 24h         -- reconciliation window (W3 review
+--          -- fix: bounded to the ~24h TTL of the Resend L1 idempotency key
+--          -- `invite:{id}:patient` — beyond that window a replayed pass would
+--          -- no longer be deduplicated by Resend and could re-send the
+--          -- invitation. Past that window, either the email was delivered
+--          -- (case covered) or it is in chronic failure, visible in the logs.
 --   AND scheduled_at > now()              -- still upcoming
 --
 -- Canonical predicate: netlify/functions/reconcile-invitations.ts.

--- a/supabase/migrations/013_invitation_sent_at.sql
+++ b/supabase/migrations/013_invitation_sent_at.sql
@@ -8,11 +8,16 @@
 --   non-NULL = invitation sent; stop retrying.
 --   Set ONLY after full side-effect success. NEVER reset to NULL.
 --
--- The upcoming reconcile-invitations sweep scans appointments that are
---   status IN ('confirmed', 'payment_pending')
+-- The reconcile-invitations sweep scans appointments that are
+--   status IN ('confirmed', 'payment_pending', 'payment_received')
+--          -- approved deviation from spec §5: avoir-paid rows are inserted
+--          -- directly as payment_received and their invitation email can
+--          -- fail just like any other (required by SC3).
 --   AND invitation_sent_at IS NULL
---   AND created_at < now() - 48h          -- grace period
+--   AND created_at > now() - 48h         -- reconciliation window
 --   AND scheduled_at > now()              -- still upcoming
+--
+-- Canonical predicate: netlify/functions/reconcile-invitations.ts.
 --
 -- Backfill: ALL existing rows are set to invitation_sent_at = now() with NO
 -- filter — deliberately. Historical appointments must NEVER be swept by

--- a/supabase/migrations/013_invitation_sent_at.sql
+++ b/supabase/migrations/013_invitation_sent_at.sql
@@ -1,0 +1,49 @@
+-- ===========================================================================
+-- Migration 013 — Durable "invitation sent" flag (L2 idempotency)
+-- Issue #126 (T1): automatic invitation catch-up via reconcile-invitations.
+--
+-- Semantics (mirrors confirmation_sent_at from 011):
+--   NULL     = invitation email not yet sent; the reconcile-invitations
+--              sweep will retry.
+--   non-NULL = invitation sent; stop retrying.
+--   Set ONLY after full side-effect success. NEVER reset to NULL.
+--
+-- The upcoming reconcile-invitations sweep scans appointments that are
+--   status IN ('confirmed', 'payment_pending')
+--   AND invitation_sent_at IS NULL
+--   AND created_at < now() - 48h          -- grace period
+--   AND scheduled_at > now()              -- still upcoming
+--
+-- Backfill: ALL existing rows are set to invitation_sent_at = now() with NO
+-- filter — deliberately. Historical appointments must NEVER be swept by
+-- reconcile-invitations (they predate the flag; re-sending invitations to
+-- past customers would be a side-effect regression).
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS, backfill guarded by IS NULL,
+-- index uses IF NOT EXISTS.
+-- ===========================================================================
+
+-- ---------------------------------------------------------------------------
+-- COLUMN : invitation_sent_at — L2 idempotency flag.
+-- Mirrors the reminder_sent_at idiom from 001_init.sql: nullable TIMESTAMPTZ,
+-- NULL until the side-effect succeeds.
+-- ---------------------------------------------------------------------------
+ALTER TABLE appointments
+  ADD COLUMN IF NOT EXISTS invitation_sent_at TIMESTAMPTZ;
+
+-- ---------------------------------------------------------------------------
+-- BACKFILL : unfiltered — every existing row is marked as invited. See header:
+-- historical appointments must never be swept by reconcile-invitations.
+-- ---------------------------------------------------------------------------
+UPDATE appointments
+SET invitation_sent_at = now()
+WHERE invitation_sent_at IS NULL;
+
+-- ---------------------------------------------------------------------------
+-- INDEX : fast sweep scans. reconcile-invitations sorts candidates by
+-- created_at (oldest first), so the partial index covers the "not yet invited
+-- and not soft-deleted" predicate ordered by created_at.
+-- ---------------------------------------------------------------------------
+CREATE INDEX IF NOT EXISTS idx_appointments_invitation_pending
+  ON appointments (created_at)
+  WHERE invitation_sent_at IS NULL AND deleted_at IS NULL;

--- a/supabase/migrations/014_invitation_claim_at.sql
+++ b/supabase/migrations/014_invitation_claim_at.sql
@@ -1,0 +1,41 @@
+-- ===========================================================================
+-- Migration 014 — Durable invitation processing claim (L2 concurrency bail)
+-- Issue #126 (W2): atomic claim between the admin POST waitUntil pipeline
+-- and the reconcile-invitations sweep.
+--
+-- Semantics (CONTRAST with 013's invitation_sent_at — they are NOT alike):
+--   NULL     = no worker currently owns the row's side-effect processing.
+--   non-NULL = a worker claimed the row. This is a LEASE, not a completion
+--              marker: any worker may re-claim once
+--              `invitation_claimed_at < now() - 10 min` (automatic recovery
+--              after a crash, a function timeout kill or a deploy restart).
+--   COMPLETION REMAINS `invitation_sent_at` (013). A claimed row whose
+--   pipeline failed still has invitation_sent_at NULL and is re-swept as
+--   soon as its lease expires.
+--
+-- Rationale: without an atomic claim, the post-response pipeline
+-- (waitUntil in POST /api/admin/appointments/) and the hourly sweep can
+-- start the SAME row concurrently while invitation_sent_at is still NULL —
+-- producing duplicate Google `events.insert` and duplicate Stripe Payment
+-- Links (the final set-once flag guard only deduplicates email/flag, too
+-- late for the external side effects).
+--
+-- No GRANT needed: the `appointments` table is already covered by the
+-- explicit service_role grants of 006_explicit_grants.sql (a column addition
+-- on an existing table inherits the table-level grants).
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS. No backfill (NULL = unclaimed is the
+-- correct initial state for every existing row), no index (the claim
+-- predicate targets a single row by primary key).
+-- ===========================================================================
+
+-- ---------------------------------------------------------------------------
+-- COLUMN : invitation_claimed_at — processing lease bail (W2).
+-- Updated atomically via
+--   UPDATE appointments SET invitation_claimed_at = now()
+--   WHERE id = $1
+--     AND (invitation_claimed_at IS NULL OR invitation_claimed_at < now() - interval '10 minutes')
+-- (see claimInvitationProcessing in src/lib/notifications.ts).
+-- ---------------------------------------------------------------------------
+ALTER TABLE appointments
+  ADD COLUMN IF NOT EXISTS invitation_claimed_at TIMESTAMPTZ;

--- a/tests/unit/admin-appointment-side-effects.test.ts
+++ b/tests/unit/admin-appointment-side-effects.test.ts
@@ -9,7 +9,7 @@
  *
  * Contract enforced below (T6 must implement identically):
  *
- *   processAppointmentSideEffects(appt, opts): Promise<void>
+ *   processAppointmentSideEffects(appt, opts): Promise<{ flagsSet: boolean }>
  *
  *   appt (inserted appointment row + execution context):
  *     - id: string
@@ -46,7 +46,17 @@
  *                 `invite:{appt.id}:patient` (Resend L1, ~24h TTL).
  *   flags (L2)  : set-once UPDATE ... .is('invitation_sent_at', null), plus
  *                 confirmation_sent_at in the SAME update when the email was
- *                 the confirmation (status 'payment_received').
+ *                 the confirmation (status 'payment_received'). W1 policy:
+ *                 written ONLY when EVERY step S1/S2/S3 is ok or skipped —
+ *                 ANY step error (API OR persistence) leaves the flags NULL
+ *                 so the sweep retries the row.
+ *   W4          : a calendar result WITHOUT an eventId (e.g. sweep no-op
+ *                 mock) is a calendar skip WITHOUT persistence.
+ *   claim (W2)  : claimInvitationProcessing(supabase, id, {leaseMs?}) —
+ *                 atomic bail: update guarded by `.or('invitation_claimed_at
+ *                 .is.null,invitation_claimed_at.lt.<cutoff ~ now − 10 min>')`
+ *                 returning `.select('id')`; true only when a row matched;
+ *                 fail-closed (false) on error.
  *
  * Per-step observability — exactly one log per step:
  *   console.info('[side-effects]', { step, appointmentId, ms, status })
@@ -60,16 +70,23 @@ import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 const h = vi.hoisted(() => {
   /**
    * Supabase-like stub for the L2 flag writes: chainable, CAPTURES update
-   * payloads and the set-once `.is()` guards. Awaitable at the terminal link
-   * (thenable resolving `{ data: null, error: null }`).
+   * payloads and the set-once `.is()` / bail `.or()` guards. Awaitable at the
+   * terminal link (thenable resolving `{ data, error }`).
    *
    * C7: `failOnUpdates` makes the update at the given INDICES resolve with a
    * non-null `error` (persistence failure) — every other update succeeds.
+   *
+   * W2: `updateData` provides per-update-index `data` resolutions (e.g. the
+   * claim SELECT `[{ id }]`); defaults to null.
    */
-  const makeSupabaseLike = (failOnUpdates: number[] = []) => {
+  const makeSupabaseLike = (
+    failOnUpdates: number[] = [],
+    updateData: unknown[] = [],
+  ) => {
     const updates: Record<string, unknown>[] = [];
     const isCalls: { column: string; value: unknown }[] = [];
     const eqCalls: { column: string; value: unknown }[] = [];
+    const orCalls: string[] = [];
     let currentUpdateIndex = -1;
     const chain: Record<string, unknown> = {
       update: (payload: Record<string, unknown>) => {
@@ -86,11 +103,16 @@ const h = vi.hoisted(() => {
         isCalls.push({ column, value });
         return chain;
       },
+      or: (filter: string) => {
+        orCalls.push(filter);
+        return chain;
+      },
       then: (resolve: unknown, reject: unknown) => {
         const error = failOnUpdates.includes(currentUpdateIndex)
           ? { message: `mock update failure at index ${currentUpdateIndex}` }
           : null;
-        Promise.resolve({ data: null, error }).then(
+        const data = error ? null : (updateData[currentUpdateIndex] ?? null);
+        Promise.resolve({ data, error }).then(
           resolve as never,
           reject as never,
         );
@@ -102,18 +124,17 @@ const h = vi.hoisted(() => {
       updates,
       isCalls,
       eqCalls,
+      orCalls,
     };
   };
 
   return {
     makeSupabaseLike,
     sb: makeSupabaseLike(),
-    createCalendarEvent: vi
-      .fn()
-      .mockResolvedValue({
-        eventId: 'gcal_mock',
-        meetLink: 'https://meet.example/x',
-      }),
+    createCalendarEvent: vi.fn().mockResolvedValue({
+      eventId: 'gcal_mock',
+      meetLink: 'https://meet.example/x',
+    }),
     createAppointmentPaymentLink: vi
       .fn()
       .mockResolvedValue({ id: 'pl_mock', url: 'https://pay.example/pl' }),
@@ -148,7 +169,10 @@ vi.mock('@/emails/PaymentReceivedNotification', () => ({
 
 // --- Import the REAL module under test (missing export → RED) ----------------
 
-import { processAppointmentSideEffects } from '@/lib/notifications';
+import {
+  claimInvitationProcessing,
+  processAppointmentSideEffects,
+} from '@/lib/notifications';
 // C2: spied module mock — assert the signingSecret DI seam reaches the HMAC
 // signer (the real createSecureLinkToken throws in pure Node without a secret).
 import { createSecureLinkToken } from '@/lib/secure-links';
@@ -330,27 +354,52 @@ describe('processAppointmentSideEffects (issue #126 / T6)', () => {
   });
 
   // -------------------------------------------------------------------------
-  // Step isolation — calendar failure never blocks stripe/email/flags
+  // Step isolation + W1 — a failing step runs the rest of the pipeline but
+  // leaves the L2 flags NULL so the sweep retries the row
   // -------------------------------------------------------------------------
-  it('continues with stripe, email and flags when the calendar step throws', async () => {
-    // Arrange
+  it('leaves L2 flags NULL when the calendar step fails so the sweep retries (W1)', async () => {
+    // Arrange — calendar API error (distinct from a persistence error: no
+    // update is even attempted).
     h.createCalendarEvent.mockRejectedValue(new Error('gcal down'));
 
-    // Act — must not reject.
+    // Act — must not reject; W1 policy flip: stripe + email still run, but
+    // the flags are NEVER written (the old policy — flags set as long as the
+    // email was delivered — left the row permanently un-swept and thus
+    // permanently without a Google event, contradicting SC3).
     await expect(
       processAppointmentSideEffects({ ...baseAppointment }, makeOpts()),
-    ).resolves.toBeUndefined();
+    ).resolves.toEqual({ flagsSet: false });
 
-    // Assert — calendar logged as error, the rest of the pipeline ran anyway.
+    // Assert — calendar logged as error, the rest of the pipeline ran anyway…
     const logs = sideEffectLogs();
     expect(logs.find(l => l.step === 'calendar')?.status).toBe('error');
     expect(logs.find(l => l.step === 'stripe')?.status).toBe('ok');
     expect(logs.find(l => l.step === 'email')?.status).toBe('ok');
     expect(h.createAppointmentPaymentLink).toHaveBeenCalledTimes(1);
     expect(h.sendEmail).toHaveBeenCalledTimes(1);
-    // The cron sweep relies on the set-once flag being written.
-    const flagged = h.sb.updates.filter(u => !!u.invitation_sent_at);
-    expect(flagged.length).toBeGreaterThan(0);
+    // …but NO flag update is issued — the sweep must complete the calendar.
+    expect(logs.find(l => l.step === 'flags')?.status).toBe('skipped');
+    expect(h.sb.updates.filter(u => 'invitation_sent_at' in u)).toHaveLength(0);
+  });
+
+  it('leaves L2 flags NULL when the stripe step fails so the sweep retries (W1)', async () => {
+    // Arrange — Stripe API error: no paymentLinkUrl → the PaymentRequest
+    // email cannot leave either (video RDV with a balance due).
+    h.createAppointmentPaymentLink.mockRejectedValue(new Error('stripe down'));
+
+    // Act — must not reject.
+    await expect(
+      processAppointmentSideEffects({ ...baseAppointment }, makeOpts()),
+    ).resolves.toEqual({ flagsSet: false });
+
+    // Assert — stripe error cascades to the email (link unavailable), and the
+    // flags stay NULL for the sweep.
+    const logs = sideEffectLogs();
+    expect(logs.find(l => l.step === 'calendar')?.status).toBe('ok');
+    expect(logs.find(l => l.step === 'stripe')?.status).toBe('error');
+    expect(logs.find(l => l.step === 'email')?.status).toBe('error');
+    expect(logs.find(l => l.step === 'flags')?.status).toBe('skipped');
+    expect(h.sb.updates.filter(u => 'invitation_sent_at' in u)).toHaveLength(0);
   });
 
   // -------------------------------------------------------------------------
@@ -451,7 +500,7 @@ describe('processAppointmentSideEffects (issue #126 / T6)', () => {
     // Act — must resolve (runStep isolates the throw).
     await expect(
       processAppointmentSideEffects({ ...baseAppointment }, makeOpts()),
-    ).resolves.toBeUndefined();
+    ).resolves.toEqual({ flagsSet: false });
 
     // Assert — calendar logs error, the pipeline continues (stripe + email
     // still run)…
@@ -462,9 +511,7 @@ describe('processAppointmentSideEffects (issue #126 / T6)', () => {
     // …but NO flag update is issued afterwards — the cron sweep must retry
     // the row (otherwise the event id would be lost forever).
     expect(logs.find(l => l.step === 'flags')?.status).toBe('skipped');
-    expect(
-      h.sb.updates.filter(u => 'invitation_sent_at' in u),
-    ).toHaveLength(0);
+    expect(h.sb.updates.filter(u => 'invitation_sent_at' in u)).toHaveLength(0);
   });
 
   it('logs the stripe step as error and leaves L2 flags NULL when the S2 persistence update fails (C7)', async () => {
@@ -474,7 +521,7 @@ describe('processAppointmentSideEffects (issue #126 / T6)', () => {
     // Act — must resolve.
     await expect(
       processAppointmentSideEffects({ ...baseAppointment }, makeOpts()),
-    ).resolves.toBeUndefined();
+    ).resolves.toEqual({ flagsSet: false });
 
     // Assert — stripe persistence failed → no paymentLinkUrl → the
     // PaymentRequest email cannot leave → email error → flags skipped.
@@ -482,8 +529,127 @@ describe('processAppointmentSideEffects (issue #126 / T6)', () => {
     expect(logs.find(l => l.step === 'stripe')?.status).toBe('error');
     expect(logs.find(l => l.step === 'email')?.status).toBe('error');
     expect(logs.find(l => l.step === 'flags')?.status).toBe('skipped');
+    expect(h.sb.updates.filter(u => 'invitation_sent_at' in u)).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // W3 — email SUCCESS but the flag WRITE fails: the write error is logged,
+  // invitation_sent_at stays NULL (the 24h sweep window re-runs the row; the
+  // replayed email is deduplicated by the Resend L1 key invite:{id}:patient)
+  // -------------------------------------------------------------------------
+  it('keeps invitation_sent_at NULL (flags step error) when the flag write fails after a delivered email (W3)', async () => {
+    // Arrange — update #0 = S1 persistence, #1 = S2 persistence, #2 = flags.
+    h.sb = h.makeSupabaseLike([2]);
+
+    // Act — must resolve; the failing flag write is isolated like any step.
+    await expect(
+      processAppointmentSideEffects({ ...baseAppointment }, makeOpts()),
+    ).resolves.toEqual({ flagsSet: false });
+
+    // Assert — email delivered, flags update ATTEMPTED (payload emitted) but
+    // errored: in the database invitation_sent_at remains NULL and the
+    // observable contract is the `flags: 'error'` step status.
+    const logs = sideEffectLogs();
+    expect(logs.find(l => l.step === 'email')?.status).toBe('ok');
+    expect(logs.find(l => l.step === 'flags')?.status).toBe('error');
+    expect(h.sb.updates.filter(u => 'invitation_sent_at' in u)).toHaveLength(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // W4 — calendar result WITHOUT eventId = skip without persistence
+  // -------------------------------------------------------------------------
+  it('treats a calendar result without eventId as a skip without persistence (W4)', async () => {
+    // Arrange — e.g. the sweep's GOOGLE_CALENDAR_MOCK no-op fn.
+    h.createCalendarEvent.mockResolvedValue({
+      eventId: null,
+      meetLink: undefined,
+    });
+
+    // Act
+    await expect(
+      processAppointmentSideEffects({ ...baseAppointment }, makeOpts()),
+    ).resolves.toEqual({ flagsSet: true });
+
+    // Assert — calendar step logged as skipped…
+    const logs = sideEffectLogs();
+    expect(logs.find(l => l.step === 'calendar')?.status).toBe('skipped');
+    // …NO update carries a google_calendar_event_id (nothing exploitable to
+    // persist — a fake persisted id would lock the S1 skip forever)…
     expect(
-      h.sb.updates.filter(u => 'invitation_sent_at' in u),
+      h.sb.updates.filter(u => 'google_calendar_event_id' in u),
     ).toHaveLength(0);
+    // …and the rest of the pipeline is normal (stripe, email, flags set).
+    expect(logs.find(l => l.step === 'stripe')?.status).toBe('ok');
+    expect(logs.find(l => l.step === 'email')?.status).toBe('ok');
+    expect(logs.find(l => l.step === 'flags')?.status).toBe('ok');
+    expect(h.sendEmail).toHaveBeenCalledTimes(1);
+    expect(
+      h.sb.updates.filter(u => !!u.invitation_sent_at).length,
+    ).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// W2 — claimInvitationProcessing: atomic bail (waitUntil ↔ sweep)
+// ---------------------------------------------------------------------------
+describe('claimInvitationProcessing (W2 — atomic bail)', () => {
+  it('claims via an update guarded by invitation_claimed_at.is.null OR a ~10 min lease cutoff', async () => {
+    // Arrange — the claim update returns one claimed row.
+    h.sb = h.makeSupabaseLike([], [[{ id: 'appt_side_001' }]]);
+    const before = Date.now();
+
+    // Act
+    const claimed = await claimInvitationProcessing(h.sb, 'appt_side_001');
+
+    // Assert — one row matched → claim granted.
+    const after = Date.now();
+    expect(claimed).toBe(true);
+    expect(h.sb.updates[0]).toMatchObject({
+      invitation_claimed_at: expect.any(String),
+    });
+    expect(h.sb.eqCalls).toContainEqual({
+      column: 'id',
+      value: 'appt_side_001',
+    });
+    // The `.or` guard: free bail (NULL) OR expired bail (cutoff now − 10 min).
+    expect(h.sb.orCalls).toHaveLength(1);
+    const orFilter = h.sb.orCalls[0];
+    expect(orFilter).toContain('invitation_claimed_at.is.null');
+    expect(orFilter).toContain('invitation_claimed_at.lt.');
+    const cutoff = new Date(
+      orFilter.split('invitation_claimed_at.lt.')[1],
+    ).getTime();
+    expect(cutoff).toBeGreaterThanOrEqual(before - 10 * 60_000 - 5_000);
+    expect(cutoff).toBeLessThanOrEqual(after - 10 * 60_000 + 5_000);
+  });
+
+  it('returns false when no row matched (row already claimed within the lease)', async () => {
+    h.sb = h.makeSupabaseLike([], [[]]);
+
+    await expect(
+      claimInvitationProcessing(h.sb, 'appt_side_001'),
+    ).resolves.toBe(false);
+  });
+
+  it('returns false (fail-closed) when the claim update errors', async () => {
+    h.sb = h.makeSupabaseLike([0]);
+
+    await expect(
+      claimInvitationProcessing(h.sb, 'appt_side_001'),
+    ).resolves.toBe(false);
+  });
+
+  it('honours opts.leaseMs when computing the cutoff', async () => {
+    h.sb = h.makeSupabaseLike([], [[{ id: 'appt_side_001' }]]);
+    const before = Date.now();
+
+    await claimInvitationProcessing(h.sb, 'appt_side_001', { leaseMs: 60_000 });
+
+    const cutoff = new Date(
+      h.sb.orCalls[0].split('invitation_claimed_at.lt.')[1],
+    ).getTime();
+    const after = Date.now();
+    expect(cutoff).toBeGreaterThanOrEqual(before - 60_000 - 5_000);
+    expect(cutoff).toBeLessThanOrEqual(after - 60_000 + 5_000);
   });
 });

--- a/tests/unit/admin-appointment-side-effects.test.ts
+++ b/tests/unit/admin-appointment-side-effects.test.ts
@@ -62,13 +62,18 @@ const h = vi.hoisted(() => {
    * Supabase-like stub for the L2 flag writes: chainable, CAPTURES update
    * payloads and the set-once `.is()` guards. Awaitable at the terminal link
    * (thenable resolving `{ data: null, error: null }`).
+   *
+   * C7: `failOnUpdates` makes the update at the given INDICES resolve with a
+   * non-null `error` (persistence failure) — every other update succeeds.
    */
-  const makeSupabaseLike = () => {
+  const makeSupabaseLike = (failOnUpdates: number[] = []) => {
     const updates: Record<string, unknown>[] = [];
     const isCalls: { column: string; value: unknown }[] = [];
     const eqCalls: { column: string; value: unknown }[] = [];
+    let currentUpdateIndex = -1;
     const chain: Record<string, unknown> = {
       update: (payload: Record<string, unknown>) => {
+        currentUpdateIndex = updates.length;
         updates.push(payload);
         return chain;
       },
@@ -81,11 +86,15 @@ const h = vi.hoisted(() => {
         isCalls.push({ column, value });
         return chain;
       },
-      then: (resolve: unknown, reject: unknown) =>
-        Promise.resolve({ data: null, error: null }).then(
+      then: (resolve: unknown, reject: unknown) => {
+        const error = failOnUpdates.includes(currentUpdateIndex)
+          ? { message: `mock update failure at index ${currentUpdateIndex}` }
+          : null;
+        Promise.resolve({ data: null, error }).then(
           resolve as never,
           reject as never,
-        ),
+        );
+      },
     };
     return {
       from: (_table: string) => chain,
@@ -140,6 +149,9 @@ vi.mock('@/emails/PaymentReceivedNotification', () => ({
 // --- Import the REAL module under test (missing export → RED) ----------------
 
 import { processAppointmentSideEffects } from '@/lib/notifications';
+// C2: spied module mock — assert the signingSecret DI seam reaches the HMAC
+// signer (the real createSecureLinkToken throws in pure Node without a secret).
+import { createSecureLinkToken } from '@/lib/secure-links';
 
 // --- Fixtures ----------------------------------------------------------------
 
@@ -366,5 +378,112 @@ describe('processAppointmentSideEffects (issue #126 / T6)', () => {
       column: 'invitation_sent_at',
       value: null,
     });
+  });
+
+  // -------------------------------------------------------------------------
+  // C2 — signingSecret DI seam reaches the .ics HMAC signer (cron runtime)
+  // -------------------------------------------------------------------------
+  it('forwards opts.signingSecret to createSecureLinkToken for the .ics invite (C2)', async () => {
+    const secret = 'x'.repeat(44);
+    await processAppointmentSideEffects(
+      { ...baseAppointment, status: 'payment_received' },
+      makeOpts({ sendEmail: true, amountDueCents: 0, signingSecret: secret }),
+    );
+
+    // The AppointmentConfirmed branch signs an .ics invite token. Without the
+    // seam, createSecureLinkToken reads import.meta.env (absent in the cron
+    // runtime) and THROWS — killing the email step of every swept row.
+    expect(h.sendEmail).toHaveBeenCalledTimes(1);
+    const callArg = vi.mocked(createSecureLinkToken).mock.calls[0][0];
+    expect(callArg.secret).toBe(secret);
+  });
+
+  it('omits the secret key entirely when signingSecret is not provided (Astro runtime)', async () => {
+    await processAppointmentSideEffects(
+      { ...baseAppointment, status: 'payment_received' },
+      makeOpts({ sendEmail: true, amountDueCents: 0 }),
+    );
+
+    const callArg = vi.mocked(createSecureLinkToken).mock.calls[0][0];
+    expect('secret' in callArg).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // C4 — S2 idempotency: an existing stripe_payment_link_url is REUSED
+  // -------------------------------------------------------------------------
+  it('never creates a second payment link when stripe_payment_link_url already exists (C4)', async () => {
+    // Act — video RDV with a balance due BUT an existing payment link.
+    await processAppointmentSideEffects(
+      {
+        ...baseAppointment,
+        stripe_payment_link_id: 'pl_existing',
+        stripe_payment_link_url: 'https://pay.example/existing',
+      },
+      makeOpts(),
+    );
+
+    // Assert — no second Stripe link (cascade), step logged as skipped…
+    expect(h.createAppointmentPaymentLink).not.toHaveBeenCalled();
+    expect(sideEffectLogs().find(l => l.step === 'stripe')?.status).toBe(
+      'skipped',
+    );
+    // …the email leaves with the EXISTING URL…
+    expect(h.sendEmail).toHaveBeenCalledTimes(1);
+    const params = h.sendEmail.mock.calls[0][0] as {
+      react?: { props?: { stripePaymentUrl?: string } };
+    };
+    expect(params.react?.props?.stripePaymentUrl).toBe(
+      'https://pay.example/existing',
+    );
+    // …and the L2 flags are still written (email delivered).
+    expect(
+      h.sb.updates.filter(u => !!u.invitation_sent_at).length,
+    ).toBeGreaterThan(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // C7 — S1/S2 persistence failures: step error observable, flags stay NULL
+  // -------------------------------------------------------------------------
+  it('logs the calendar step as error and leaves L2 flags NULL when the S1 persistence update fails (C7)', async () => {
+    // Arrange — update #0 is the S1 google_calendar_event_id persistence write.
+    h.sb = h.makeSupabaseLike([0]);
+
+    // Act — must resolve (runStep isolates the throw).
+    await expect(
+      processAppointmentSideEffects({ ...baseAppointment }, makeOpts()),
+    ).resolves.toBeUndefined();
+
+    // Assert — calendar logs error, the pipeline continues (stripe + email
+    // still run)…
+    const logs = sideEffectLogs();
+    expect(logs.find(l => l.step === 'calendar')?.status).toBe('error');
+    expect(logs.find(l => l.step === 'stripe')?.status).toBe('ok');
+    expect(logs.find(l => l.step === 'email')?.status).toBe('ok');
+    // …but NO flag update is issued afterwards — the cron sweep must retry
+    // the row (otherwise the event id would be lost forever).
+    expect(logs.find(l => l.step === 'flags')?.status).toBe('skipped');
+    expect(
+      h.sb.updates.filter(u => 'invitation_sent_at' in u),
+    ).toHaveLength(0);
+  });
+
+  it('logs the stripe step as error and leaves L2 flags NULL when the S2 persistence update fails (C7)', async () => {
+    // Arrange — update #1 is the S2 stripe_payment_link_{id,url} write.
+    h.sb = h.makeSupabaseLike([1]);
+
+    // Act — must resolve.
+    await expect(
+      processAppointmentSideEffects({ ...baseAppointment }, makeOpts()),
+    ).resolves.toBeUndefined();
+
+    // Assert — stripe persistence failed → no paymentLinkUrl → the
+    // PaymentRequest email cannot leave → email error → flags skipped.
+    const logs = sideEffectLogs();
+    expect(logs.find(l => l.step === 'stripe')?.status).toBe('error');
+    expect(logs.find(l => l.step === 'email')?.status).toBe('error');
+    expect(logs.find(l => l.step === 'flags')?.status).toBe('skipped');
+    expect(
+      h.sb.updates.filter(u => 'invitation_sent_at' in u),
+    ).toHaveLength(0);
   });
 });

--- a/tests/unit/admin-appointment-side-effects.test.ts
+++ b/tests/unit/admin-appointment-side-effects.test.ts
@@ -82,16 +82,32 @@ const h = vi.hoisted(() => {
         return chain;
       },
       then: (resolve: unknown, reject: unknown) =>
-        Promise.resolve({ data: null, error: null }).then(resolve as never, reject as never),
+        Promise.resolve({ data: null, error: null }).then(
+          resolve as never,
+          reject as never,
+        ),
     };
-    return { from: (_table: string) => chain, chain, updates, isCalls, eqCalls };
+    return {
+      from: (_table: string) => chain,
+      chain,
+      updates,
+      isCalls,
+      eqCalls,
+    };
   };
 
   return {
     makeSupabaseLike,
     sb: makeSupabaseLike(),
-    createCalendarEvent: vi.fn().mockResolvedValue({ eventId: 'gcal_mock', meetLink: 'https://meet.example/x' }),
-    createAppointmentPaymentLink: vi.fn().mockResolvedValue({ id: 'pl_mock', url: 'https://pay.example/pl' }),
+    createCalendarEvent: vi
+      .fn()
+      .mockResolvedValue({
+        eventId: 'gcal_mock',
+        meetLink: 'https://meet.example/x',
+      }),
+    createAppointmentPaymentLink: vi
+      .fn()
+      .mockResolvedValue({ id: 'pl_mock', url: 'https://pay.example/pl' }),
     sendEmail: vi.fn().mockResolvedValue({ success: true }),
   };
 });
@@ -102,7 +118,8 @@ vi.mock('@/lib/google-calendar', () => ({
   createCalendarEvent: (...a: unknown[]) => h.createCalendarEvent(...a),
 }));
 vi.mock('@/lib/stripe', () => ({
-  createAppointmentPaymentLink: (...a: unknown[]) => h.createAppointmentPaymentLink(...a),
+  createAppointmentPaymentLink: (...a: unknown[]) =>
+    h.createAppointmentPaymentLink(...a),
 }));
 vi.mock('@/lib/resend', () => ({
   sendEmail: (...a: unknown[]) => h.sendEmail(...a),
@@ -111,10 +128,14 @@ vi.mock('@/lib/resend', () => ({
 vi.mock('@/lib/supabase', () => ({
   supabaseAdmin: { from: (table: string) => h.sb.from(table) },
 }));
-vi.mock('@/lib/secure-links', () => ({ createSecureLinkToken: vi.fn(() => 'tok_mock') }));
+vi.mock('@/lib/secure-links', () => ({
+  createSecureLinkToken: vi.fn(() => 'tok_mock'),
+}));
 vi.mock('@/emails/AppointmentConfirmed', () => ({ default: () => null }));
 vi.mock('@/emails/PaymentRequest', () => ({ default: () => null }));
-vi.mock('@/emails/PaymentReceivedNotification', () => ({ default: () => null }));
+vi.mock('@/emails/PaymentReceivedNotification', () => ({
+  default: () => null,
+}));
 
 // --- Import the REAL module under test (missing export → RED) ----------------
 
@@ -136,7 +157,9 @@ const baseAppointment = {
   google_calendar_event_id: null,
 };
 
-function makeOpts(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+function makeOpts(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
   return {
     sendEmail: true,
     amountDueCents: 6000,
@@ -152,8 +175,14 @@ let infoSpy: ReturnType<typeof vi.spyOn>;
 beforeEach(() => {
   vi.clearAllMocks();
   h.sb = h.makeSupabaseLike();
-  h.createCalendarEvent.mockResolvedValue({ eventId: 'gcal_mock', meetLink: 'https://meet.example/x' });
-  h.createAppointmentPaymentLink.mockResolvedValue({ id: 'pl_mock', url: 'https://pay.example/pl' });
+  h.createCalendarEvent.mockResolvedValue({
+    eventId: 'gcal_mock',
+    meetLink: 'https://meet.example/x',
+  });
+  h.createAppointmentPaymentLink.mockResolvedValue({
+    id: 'pl_mock',
+    url: 'https://pay.example/pl',
+  });
   h.sendEmail.mockResolvedValue({ success: true });
   infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
   vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -164,10 +193,23 @@ afterEach(() => {
 });
 
 /** Side-effect logs only: console.info('[side-effects]', {...}). */
-function sideEffectLogs(): { step: string; appointmentId: string; ms: number; status: string }[] {
+function sideEffectLogs(): {
+  step: string;
+  appointmentId: string;
+  ms: number;
+  status: string;
+}[] {
   return infoSpy.mock.calls
-    .filter((call) => call[0] === '[side-effects]')
-    .map((call) => call[1] as { step: string; appointmentId: string; ms: number; status: string });
+    .filter(call => call[0] === '[side-effects]')
+    .map(
+      call =>
+        call[1] as {
+          step: string;
+          appointmentId: string;
+          ms: number;
+          status: string;
+        },
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -199,13 +241,18 @@ describe('processAppointmentSideEffects (issue #126 / T6)', () => {
     // One structured log per step + the flags step, in order, with the
     // documented fields ({ step, appointmentId, ms, status }).
     const logs = sideEffectLogs();
-    expect(logs.map((l) => l.step)).toEqual(['calendar', 'stripe', 'email', 'flags']);
+    expect(logs.map(l => l.step)).toEqual([
+      'calendar',
+      'stripe',
+      'email',
+      'flags',
+    ]);
     for (const log of logs) {
       expect(log.appointmentId).toBe('appt_side_001');
       expect(typeof log.ms).toBe('number');
       expect(['ok', 'skipped', 'error']).toContain(log.status);
     }
-    expect(logs.map((l) => l.status)).toEqual(['ok', 'ok', 'ok', 'ok']);
+    expect(logs.map(l => l.status)).toEqual(['ok', 'ok', 'ok', 'ok']);
   });
 
   // -------------------------------------------------------------------------
@@ -225,13 +272,16 @@ describe('processAppointmentSideEffects (issue #126 / T6)', () => {
     expect(h.sendEmail).not.toHaveBeenCalled();
     // …email logged as skipped, other steps ok…
     const logs = sideEffectLogs();
-    expect(logs.find((l) => l.step === 'email')?.status).toBe('skipped');
-    expect(logs.find((l) => l.step === 'calendar')?.status).toBe('ok');
-    expect(logs.find((l) => l.step === 'stripe')?.status).toBe('ok');
+    expect(logs.find(l => l.step === 'email')?.status).toBe('skipped');
+    expect(logs.find(l => l.step === 'calendar')?.status).toBe('ok');
+    expect(logs.find(l => l.step === 'stripe')?.status).toBe('ok');
     // …and the L2 flag is still written set-once (invitation_sent_at IS NULL).
-    const flagged = h.sb.updates.filter((u) => !!u.invitation_sent_at);
+    const flagged = h.sb.updates.filter(u => !!u.invitation_sent_at);
     expect(flagged.length).toBeGreaterThan(0);
-    expect(h.sb.isCalls).toContainEqual({ column: 'invitation_sent_at', value: null });
+    expect(h.sb.isCalls).toContainEqual({
+      column: 'invitation_sent_at',
+      value: null,
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -253,13 +303,18 @@ describe('processAppointmentSideEffects (issue #126 / T6)', () => {
   it('still creates a standard calendar event without Meet when video_link is already set', async () => {
     // Act
     await processAppointmentSideEffects(
-      { ...baseAppointment, video_link: 'https://meet.google.com/pre-existing' },
+      {
+        ...baseAppointment,
+        video_link: 'https://meet.google.com/pre-existing',
+      },
       makeOpts(),
     );
 
     // Assert — S1 runs, but withMeet:false (no second Meet link).
     expect(h.createCalendarEvent).toHaveBeenCalledTimes(1);
-    expect(h.createCalendarEvent.mock.calls[0][0]).toMatchObject({ withMeet: false });
+    expect(h.createCalendarEvent.mock.calls[0][0]).toMatchObject({
+      withMeet: false,
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -276,13 +331,13 @@ describe('processAppointmentSideEffects (issue #126 / T6)', () => {
 
     // Assert — calendar logged as error, the rest of the pipeline ran anyway.
     const logs = sideEffectLogs();
-    expect(logs.find((l) => l.step === 'calendar')?.status).toBe('error');
-    expect(logs.find((l) => l.step === 'stripe')?.status).toBe('ok');
-    expect(logs.find((l) => l.step === 'email')?.status).toBe('ok');
+    expect(logs.find(l => l.step === 'calendar')?.status).toBe('error');
+    expect(logs.find(l => l.step === 'stripe')?.status).toBe('ok');
+    expect(logs.find(l => l.step === 'email')?.status).toBe('ok');
     expect(h.createAppointmentPaymentLink).toHaveBeenCalledTimes(1);
     expect(h.sendEmail).toHaveBeenCalledTimes(1);
     // The cron sweep relies on the set-once flag being written.
-    const flagged = h.sb.updates.filter((u) => !!u.invitation_sent_at);
+    const flagged = h.sb.updates.filter(u => !!u.invitation_sent_at);
     expect(flagged.length).toBeGreaterThan(0);
   });
 
@@ -304,9 +359,12 @@ describe('processAppointmentSideEffects (issue #126 / T6)', () => {
     expect(h.createAppointmentPaymentLink).not.toHaveBeenCalled();
     expect(h.sendEmail).toHaveBeenCalledTimes(1);
     const flagged = h.sb.updates.filter(
-      (u) => !!u.invitation_sent_at && !!u.confirmation_sent_at,
+      u => !!u.invitation_sent_at && !!u.confirmation_sent_at,
     );
     expect(flagged.length).toBeGreaterThan(0);
-    expect(h.sb.isCalls).toContainEqual({ column: 'invitation_sent_at', value: null });
+    expect(h.sb.isCalls).toContainEqual({
+      column: 'invitation_sent_at',
+      value: null,
+    });
   });
 });

--- a/tests/unit/admin-appointment-side-effects.test.ts
+++ b/tests/unit/admin-appointment-side-effects.test.ts
@@ -1,0 +1,312 @@
+/**
+ * RED tests (test-first, issue #126 / T5) defining the CONTRACT of
+ * `processAppointmentSideEffects(appt, opts)` — the post-response pipeline
+ * extracted from POST /api/admin/appointments/ (T6) and deferred via
+ * `locals.netlify.context.waitUntil` by T7.
+ *
+ * These tests are RED today: the export does not exist in
+ * `src/lib/notifications.ts` yet. They must turn GREEN after T6.
+ *
+ * Contract enforced below (T6 must implement identically):
+ *
+ *   processAppointmentSideEffects(appt, opts): Promise<void>
+ *
+ *   appt (inserted appointment row + execution context):
+ *     - id: string
+ *     - status: string ('payment_pending' | 'payment_received' | 'confirmed' | ...)
+ *     - appointment_type: string
+ *     - appointment_mode: 'video' | 'in-person'
+ *     - duration: number                        // minutes
+ *     - scheduled_at: string                    // ISO
+ *     - patient_name: string
+ *     - patient_email: string
+ *     - final_price: number                     // cents
+ *     - video_link?: string | null
+ *     - google_calendar_event_id?: string | null
+ *
+ *   opts (DI — defaults = the app's real modules):
+ *     - sendEmail: boolean                      // S3 gate
+ *     - amountDueCents: number                  // S2 gate: video && > 0
+ *     - successUrl?: string                     // Stripe success_url
+ *     - baseUrl?: string                        // links base (DI like BuildAndSendOptions)
+ *     - adminEmail?: string
+ *     - createCalendarEvent?: typeof createCalendarEvent
+ *     - createAppointmentPaymentLink?: typeof createAppointmentPaymentLink
+ *     - sendFn?: typeof sendEmail
+ *     - supabase?: { from(table): chainable update/eq/is }   // L2 flag writes
+ *
+ * Steps, in order, each isolated (an error is logged and does NOT stop the
+ * pipeline):
+ *   S1 calendar : createCalendarEvent (skip Meet creation when appt.video_link
+ *                 is already set — withMeet:false — but still create the
+ *                 standard event); persist event id (+ video_link if Meet).
+ *   S2 stripe   : only when mode === 'video' && amountDueCents > 0 → payment
+ *                 link + persisted stripe_payment_link_{id,url}.
+ *   S3 email    : only when opts.sendEmail → sendFn with idempotencyKey
+ *                 `invite:{appt.id}:patient` (Resend L1, ~24h TTL).
+ *   flags (L2)  : set-once UPDATE ... .is('invitation_sent_at', null), plus
+ *                 confirmation_sent_at in the SAME update when the email was
+ *                 the confirmation (status 'payment_received').
+ *
+ * Per-step observability — exactly one log per step:
+ *   console.info('[side-effects]', { step, appointmentId, ms, status })
+ *   step ∈ 'calendar' | 'stripe' | 'email' | 'flags'
+ *   status ∈ 'ok' | 'skipped' | 'error'
+ */
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+// --- Hoisted shared state (mock factories need it at hoist time) ------------
+
+const h = vi.hoisted(() => {
+  /**
+   * Supabase-like stub for the L2 flag writes: chainable, CAPTURES update
+   * payloads and the set-once `.is()` guards. Awaitable at the terminal link
+   * (thenable resolving `{ data: null, error: null }`).
+   */
+  const makeSupabaseLike = () => {
+    const updates: Record<string, unknown>[] = [];
+    const isCalls: { column: string; value: unknown }[] = [];
+    const eqCalls: { column: string; value: unknown }[] = [];
+    const chain: Record<string, unknown> = {
+      update: (payload: Record<string, unknown>) => {
+        updates.push(payload);
+        return chain;
+      },
+      select: () => chain,
+      eq: (column: string, value: unknown) => {
+        eqCalls.push({ column, value });
+        return chain;
+      },
+      is: (column: string, value: unknown) => {
+        isCalls.push({ column, value });
+        return chain;
+      },
+      then: (resolve: unknown, reject: unknown) =>
+        Promise.resolve({ data: null, error: null }).then(resolve as never, reject as never),
+    };
+    return { from: (_table: string) => chain, chain, updates, isCalls, eqCalls };
+  };
+
+  return {
+    makeSupabaseLike,
+    sb: makeSupabaseLike(),
+    createCalendarEvent: vi.fn().mockResolvedValue({ eventId: 'gcal_mock', meetLink: 'https://meet.example/x' }),
+    createAppointmentPaymentLink: vi.fn().mockResolvedValue({ id: 'pl_mock', url: 'https://pay.example/pl' }),
+    sendEmail: vi.fn().mockResolvedValue({ success: true }),
+  };
+});
+
+// --- Mock the DEPENDENCIES (never the module under test) ---------------------
+
+vi.mock('@/lib/google-calendar', () => ({
+  createCalendarEvent: (...a: unknown[]) => h.createCalendarEvent(...a),
+}));
+vi.mock('@/lib/stripe', () => ({
+  createAppointmentPaymentLink: (...a: unknown[]) => h.createAppointmentPaymentLink(...a),
+}));
+vi.mock('@/lib/resend', () => ({
+  sendEmail: (...a: unknown[]) => h.sendEmail(...a),
+  buildAppointmentConversationSubject: vi.fn((base: string) => base),
+}));
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: { from: (table: string) => h.sb.from(table) },
+}));
+vi.mock('@/lib/secure-links', () => ({ createSecureLinkToken: vi.fn(() => 'tok_mock') }));
+vi.mock('@/emails/AppointmentConfirmed', () => ({ default: () => null }));
+vi.mock('@/emails/PaymentRequest', () => ({ default: () => null }));
+vi.mock('@/emails/PaymentReceivedNotification', () => ({ default: () => null }));
+
+// --- Import the REAL module under test (missing export → RED) ----------------
+
+import { processAppointmentSideEffects } from '@/lib/notifications';
+
+// --- Fixtures ----------------------------------------------------------------
+
+const baseAppointment = {
+  id: 'appt_side_001',
+  status: 'payment_pending',
+  appointment_type: 'individual',
+  appointment_mode: 'video',
+  duration: 60,
+  scheduled_at: new Date(Date.now() + 86_400_000).toISOString(),
+  patient_name: 'Jeanne Dupont',
+  patient_email: 'jeanne.dupont@example.com',
+  final_price: 6000,
+  video_link: null,
+  google_calendar_event_id: null,
+};
+
+function makeOpts(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    sendEmail: true,
+    amountDueCents: 6000,
+    successUrl: 'https://omf-therapie.fr/rdv/merci/?source=payment-success',
+    baseUrl: 'https://omf-therapie.fr',
+    supabase: h.sb,
+    ...overrides,
+  };
+}
+
+let infoSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.sb = h.makeSupabaseLike();
+  h.createCalendarEvent.mockResolvedValue({ eventId: 'gcal_mock', meetLink: 'https://meet.example/x' });
+  h.createAppointmentPaymentLink.mockResolvedValue({ id: 'pl_mock', url: 'https://pay.example/pl' });
+  h.sendEmail.mockResolvedValue({ success: true });
+  infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/** Side-effect logs only: console.info('[side-effects]', {...}). */
+function sideEffectLogs(): { step: string; appointmentId: string; ms: number; status: string }[] {
+  return infoSpy.mock.calls
+    .filter((call) => call[0] === '[side-effects]')
+    .map((call) => call[1] as { step: string; appointmentId: string; ms: number; status: string });
+}
+
+// ---------------------------------------------------------------------------
+// S1 → S2 → S3 ordering + per-step logs
+// ---------------------------------------------------------------------------
+describe('processAppointmentSideEffects (issue #126 / T6)', () => {
+  it('runs calendar, then stripe, then email in order for a video appointment with a balance due', async () => {
+    // Arrange — shared order recorder pushed by each external call.
+    const order: string[] = [];
+    h.createCalendarEvent.mockImplementation(async () => {
+      order.push('calendar');
+      return { eventId: 'gcal_1', meetLink: 'https://meet.example/1' };
+    });
+    h.createAppointmentPaymentLink.mockImplementation(async () => {
+      order.push('stripe');
+      return { id: 'pl_1', url: 'https://pay.example/1' };
+    });
+    h.sendEmail.mockImplementation(async () => {
+      order.push('email');
+      return { success: true };
+    });
+
+    // Act
+    await processAppointmentSideEffects({ ...baseAppointment }, makeOpts());
+
+    // Assert — strict S1 → S2 → S3 ordering.
+    expect(order).toEqual(['calendar', 'stripe', 'email']);
+
+    // One structured log per step + the flags step, in order, with the
+    // documented fields ({ step, appointmentId, ms, status }).
+    const logs = sideEffectLogs();
+    expect(logs.map((l) => l.step)).toEqual(['calendar', 'stripe', 'email', 'flags']);
+    for (const log of logs) {
+      expect(log.appointmentId).toBe('appt_side_001');
+      expect(typeof log.ms).toBe('number');
+      expect(['ok', 'skipped', 'error']).toContain(log.status);
+    }
+    expect(logs.map((l) => l.status)).toEqual(['ok', 'ok', 'ok', 'ok']);
+  });
+
+  // -------------------------------------------------------------------------
+  // sendEmail: false → S1 + S2 still run, S3 never does, flags still set
+  // -------------------------------------------------------------------------
+  it('skips the email but still runs calendar and stripe when sendEmail is false', async () => {
+    // Act
+    await processAppointmentSideEffects(
+      { ...baseAppointment },
+      makeOpts({ sendEmail: false }),
+    );
+
+    // Assert — S1 and S2 executed…
+    expect(h.createCalendarEvent).toHaveBeenCalledTimes(1);
+    expect(h.createAppointmentPaymentLink).toHaveBeenCalledTimes(1);
+    // …S3 NEVER (no email provider contact)…
+    expect(h.sendEmail).not.toHaveBeenCalled();
+    // …email logged as skipped, other steps ok…
+    const logs = sideEffectLogs();
+    expect(logs.find((l) => l.step === 'email')?.status).toBe('skipped');
+    expect(logs.find((l) => l.step === 'calendar')?.status).toBe('ok');
+    expect(logs.find((l) => l.step === 'stripe')?.status).toBe('ok');
+    // …and the L2 flag is still written set-once (invitation_sent_at IS NULL).
+    const flagged = h.sb.updates.filter((u) => !!u.invitation_sent_at);
+    expect(flagged.length).toBeGreaterThan(0);
+    expect(h.sb.isCalls).toContainEqual({ column: 'invitation_sent_at', value: null });
+  });
+
+  // -------------------------------------------------------------------------
+  // Idempotence L1 — `invite:{id}:patient` passed to sendFn
+  // -------------------------------------------------------------------------
+  it('passes the idempotency key invite:{id}:patient to the email send function', async () => {
+    // Act
+    await processAppointmentSideEffects({ ...baseAppointment }, makeOpts());
+
+    // Assert — exact Resend idempotencyKey option (src/lib/resend.ts field).
+    expect(h.sendEmail).toHaveBeenCalledTimes(1);
+    const params = h.sendEmail.mock.calls[0][0] as { idempotencyKey?: string };
+    expect(params.idempotencyKey).toBe('invite:appt_side_001:patient');
+  });
+
+  // -------------------------------------------------------------------------
+  // video_link already provided → no Meet creation, but standard event kept
+  // -------------------------------------------------------------------------
+  it('still creates a standard calendar event without Meet when video_link is already set', async () => {
+    // Act
+    await processAppointmentSideEffects(
+      { ...baseAppointment, video_link: 'https://meet.google.com/pre-existing' },
+      makeOpts(),
+    );
+
+    // Assert — S1 runs, but withMeet:false (no second Meet link).
+    expect(h.createCalendarEvent).toHaveBeenCalledTimes(1);
+    expect(h.createCalendarEvent.mock.calls[0][0]).toMatchObject({ withMeet: false });
+  });
+
+  // -------------------------------------------------------------------------
+  // Step isolation — calendar failure never blocks stripe/email/flags
+  // -------------------------------------------------------------------------
+  it('continues with stripe, email and flags when the calendar step throws', async () => {
+    // Arrange
+    h.createCalendarEvent.mockRejectedValue(new Error('gcal down'));
+
+    // Act — must not reject.
+    await expect(
+      processAppointmentSideEffects({ ...baseAppointment }, makeOpts()),
+    ).resolves.toBeUndefined();
+
+    // Assert — calendar logged as error, the rest of the pipeline ran anyway.
+    const logs = sideEffectLogs();
+    expect(logs.find((l) => l.step === 'calendar')?.status).toBe('error');
+    expect(logs.find((l) => l.step === 'stripe')?.status).toBe('ok');
+    expect(logs.find((l) => l.step === 'email')?.status).toBe('ok');
+    expect(h.createAppointmentPaymentLink).toHaveBeenCalledTimes(1);
+    expect(h.sendEmail).toHaveBeenCalledTimes(1);
+    // The cron sweep relies on the set-once flag being written.
+    const flagged = h.sb.updates.filter((u) => !!u.invitation_sent_at);
+    expect(flagged.length).toBeGreaterThan(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // payment_received → single set-once update carries BOTH L2 flags
+  // -------------------------------------------------------------------------
+  it('sets invitation_sent_at and confirmation_sent_at together when status is payment_received', async () => {
+    // Arrange — video RDV fully covered by credit: nothing due, already paid.
+    // The invitation email IS the confirmation.
+    const opts = makeOpts({ sendEmail: true, amountDueCents: 0 });
+
+    // Act
+    await processAppointmentSideEffects(
+      { ...baseAppointment, status: 'payment_received' },
+      opts,
+    );
+
+    // Assert — no Stripe (nothing due), email sent, ONE update with both flags.
+    expect(h.createAppointmentPaymentLink).not.toHaveBeenCalled();
+    expect(h.sendEmail).toHaveBeenCalledTimes(1);
+    const flagged = h.sb.updates.filter(
+      (u) => !!u.invitation_sent_at && !!u.confirmation_sent_at,
+    );
+    expect(flagged.length).toBeGreaterThan(0);
+    expect(h.sb.isCalls).toContainEqual({ column: 'invitation_sent_at', value: null });
+  });
+});

--- a/tests/unit/admin-appointments-post.test.ts
+++ b/tests/unit/admin-appointments-post.test.ts
@@ -141,6 +141,39 @@ import { POST } from '@/pages/api/admin/appointments';
 
 // --- Helpers -----------------------------------------------------------------
 
+/**
+ * Builds an APIRoute-like context whose `locals.netlify.context.waitUntil`
+ * CAPTURES the promises handed to it (post-response background work, issue
+ * #126 V2) instead of awaiting them. `flushSideEffects` then drains them so
+ * tests can assert on the deferred pipeline (calendar → Stripe → email → L2
+ * flags) exactly like the Netlify runtime would after the response is sent.
+ */
+function makeContext(request: Request): {
+  context: Record<string, unknown>;
+  captured: Promise<unknown>[];
+} {
+  const captured: Promise<unknown>[] = [];
+  const context = {
+    request,
+    url: request.url,
+    locals: {
+      netlify: {
+        context: {
+          waitUntil: (promise: Promise<unknown>) => {
+            captured.push(promise);
+          },
+        },
+      },
+    },
+  };
+  return { context, captured };
+}
+
+/** Drains the promises captured by waitUntil (no-op until T7 wires them). */
+async function flushSideEffects(captured: Promise<unknown>[]): Promise<void> {
+  await Promise.all(captured);
+}
+
 function makeRequest(payload: Record<string, unknown>): Request {
   return new Request('http://localhost/api/admin/appointments/', {
     method: 'POST',
@@ -176,12 +209,12 @@ describe('POST /api/admin/appointments/ — invitation_sent_at flags (issue #126
   it('sets invitation_sent_at via an UPDATE after sendEmail succeeds when send_email is true', async () => {
     // Arrange
     const request = makeRequest({ send_email: true });
+    const { context, captured } = makeContext(request);
 
     // Act
-    const response = await POST({ request, url: request.url } as never);
+    const response = await POST(context as never);
     expect(response.status).toBe(201);
-
-    // Assert — the email was sent AND an UPDATE carried a non-null
+    await flushSideEffects(captured);
     // invitation_sent_at (mark-delivered after the successful send).
     expect(h.sendEmail).toHaveBeenCalledTimes(1);
     const flagged = h.sb.updates.filter((u) => !!u.invitation_sent_at);
@@ -202,11 +235,13 @@ describe('POST /api/admin/appointments/ — invitation_sent_at flags (issue #126
     });
     h.getAvailableCredit.mockResolvedValue(6000);
     h.consumeCredits.mockResolvedValue({ consumed: 6000 });
+    const { context, captured } = makeContext(request);
 
     // Act
-    const response = await POST({ request, url: request.url } as never);
+    const response = await POST(context as never);
     expect(response.status).toBe(201);
     expect(h.sb.inserts[0].status).toBe('payment_received');
+    await flushSideEffects(captured);
 
     // Assert — one UPDATE sets BOTH L2 flags (séance réglée par avoir).
     const flagged = h.sb.updates.filter(
@@ -223,15 +258,63 @@ describe('POST /api/admin/appointments/ — invitation_sent_at flags (issue #126
   it('sets invitation_sent_at in the INSERT payload and never calls sendEmail when send_email is false', async () => {
     // Arrange
     const request = makeRequest({ send_email: false });
+    const { context, captured } = makeContext(request);
 
     // Act
-    const response = await POST({ request, url: request.url } as never);
+    const response = await POST(context as never);
     expect(response.status).toBe(201);
+    await flushSideEffects(captured);
 
     // Assert — the flag is carried by the INSERT (no email will ever be sent)
     // and the email provider is never contacted.
     expect(h.sb.inserts.length).toBeGreaterThan(0);
     expect(typeof h.sb.inserts[0].invitation_sent_at).toBe('string');
     expect(h.sendEmail).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // (a) [RED until T7] 201 must leave BEFORE any external call — the pipeline
+  // (calendar → Stripe → email) is deferred via locals.netlify.context.waitUntil
+  // -------------------------------------------------------------------------
+  it('responds 201 without touching calendar/stripe/email, then runs the pipeline via waitUntil (issue #126 V2)', async () => {
+    // Arrange — video RDV with a balance due (Stripe path), email requested.
+    const request = makeRequest({ appointment_mode: 'video', send_email: true });
+    const { context, captured } = makeContext(request);
+    h.createAppointmentPaymentLink.mockResolvedValue({ id: 'pl_mock', url: 'https://pay.example/pl' });
+
+    // Act — the critical path must only INSERT and respond.
+    const response = await POST(context as never);
+
+    // Assert — 201 immediate, ZERO external call at response time.
+    expect(response.status).toBe(201);
+    expect(h.createCalendarEvent).not.toHaveBeenCalled();
+    expect(h.createAppointmentPaymentLink).not.toHaveBeenCalled();
+    expect(h.sendEmail).not.toHaveBeenCalled();
+
+    // The deferred pipeline was handed to waitUntil, and draining it runs the
+    // full chain: payment link → patient email → L2 flag.
+    expect(captured.length).toBeGreaterThan(0);
+    await flushSideEffects(captured);
+    expect(h.sendEmail).toHaveBeenCalledTimes(1);
+    const flagged = h.sb.updates.filter((u) => !!u.invitation_sent_at);
+    expect(flagged.length).toBeGreaterThan(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // (e) [RED until T7] No locals.netlify in the context → inline non-blocking
+  // fallback: still 201, never throws
+  // -------------------------------------------------------------------------
+  it('still responds 201 without throwing when locals.netlify is absent (inline fallback)', async () => {
+    // Arrange — bare context, no Netlify decorator at all.
+    const request = makeRequest({ appointment_mode: 'video', send_email: true });
+    h.createAppointmentPaymentLink.mockResolvedValue({ id: 'pl_mock', url: 'https://pay.example/pl' });
+
+    // Act / Assert — the handler must not throw and must answer 201.
+    const response = await POST({ request, url: request.url } as never);
+    expect(response.status).toBe(201);
+    // The inline fallback is fire-and-forget: flush the microtask queue before
+    // asserting the deferred pipeline ran (201 was already sent, unblocked).
+    await new Promise((r) => setImmediate(r));
+    expect(h.sendEmail).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/admin-appointments-post.test.ts
+++ b/tests/unit/admin-appointments-post.test.ts
@@ -22,6 +22,10 @@ const h = vi.hoisted(() => {
   /**
    * Factory: chainable supabaseAdmin mock that CAPTURES insert/update payloads.
    * Kept reusable for the V2/V3 test waves (set-once WHERE ... IS NULL guards).
+   *
+   * W2: update-chains (the deferred pipeline's atomic claim + L2 writes) are
+   * thenable and resolve `{ data: claimRows, error: null }`. Mutating
+   * `claimRows` (e.g. `length = 0`) makes the claim fail — see the W2 test.
    */
   const makeSupabaseMock = (appointment: Record<string, unknown> = {}) => {
     const row = {
@@ -39,6 +43,7 @@ const h = vi.hoisted(() => {
     };
     const inserts: Record<string, unknown>[] = [];
     const updates: Record<string, unknown>[] = [];
+    const claimRows: unknown[] = [{ id: 'appt_test_001' }];
     const chain = {
       insert: (payload: Record<string, unknown>) => {
         inserts.push(payload);
@@ -53,10 +58,14 @@ const h = vi.hoisted(() => {
       eq: () => chain,
       in: () => chain,
       is: () => chain,
+      or: () => chain,
       // Terminal calls must resolve like PostgrestBuilder.
       limit: () => Promise.resolve({ data: [], error: null }),
       single: () => Promise.resolve({ data: row, error: null }),
       maybeSingle: () => Promise.resolve({ data: row, error: null }),
+      // Update-chains awaited directly (claim + pipeline L2 writes).
+      then: (resolve: (v: unknown) => void, reject: (e: unknown) => void) =>
+        Promise.resolve({ data: claimRows, error: null }).then(resolve, reject),
     };
     return {
       supabaseAdmin: { from: vi.fn(() => chain) },
@@ -64,6 +73,7 @@ const h = vi.hoisted(() => {
       inserts,
       updates,
       row,
+      claimRows,
     };
   };
 
@@ -369,5 +379,43 @@ describe('POST /api/admin/appointments/ — invitation_sent_at flags (issue #126
     // asserting the deferred pipeline ran (201 was already sent, unblocked).
     await new Promise(r => setImmediate(r));
     expect(h.sendEmail).toHaveBeenCalledTimes(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // (W2) Claim failure → the deferred pipeline NEVER runs (atomic bail with
+  // the reconcile-invitations sweep)
+  // -------------------------------------------------------------------------
+  it('never runs the deferred pipeline when the claim returns no row (W2 — already claimed)', async () => {
+    // Arrange — the claim update matches ZERO rows: the sweep (or another
+    // worker) already owns the 10 min lease. Two concurrent pipelines would
+    // create a duplicate Google event + Stripe Payment Link.
+    const request = makeRequest({
+      appointment_mode: 'video',
+      send_email: true,
+    });
+    h.sb.claimRows.length = 0;
+    h.createAppointmentPaymentLink.mockResolvedValue({
+      id: 'pl_mock',
+      url: 'https://pay.example/pl',
+    });
+    const { context, captured } = makeContext(request);
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+    // Act
+    const response = await POST(context as never);
+    expect(response.status).toBe(201);
+    await flushSideEffects(captured);
+
+    // Assert — dispatch observable, then ZERO external call / pipeline write.
+    expect(infoSpy).toHaveBeenCalledWith(
+      '[side-effects] dispatch skipped — already claimed',
+      { appointmentId: 'appt_test_001' },
+    );
+    expect(h.createCalendarEvent).not.toHaveBeenCalled();
+    expect(h.createAppointmentPaymentLink).not.toHaveBeenCalled();
+    expect(h.sendEmail).not.toHaveBeenCalled();
+    expect(h.sb.updates.filter(u => 'invitation_sent_at' in u)).toHaveLength(0);
+
+    infoSpy.mockRestore();
   });
 });

--- a/tests/unit/admin-appointments-post.test.ts
+++ b/tests/unit/admin-appointments-post.test.ts
@@ -76,7 +76,9 @@ const h = vi.hoisted(() => {
     getAvailableCredit: vi.fn().mockResolvedValue(0),
     consumeCredits: vi.fn().mockResolvedValue(undefined),
     createAppointmentPaymentLink: vi.fn(),
-    createCalendarEvent: vi.fn().mockResolvedValue({ eventId: 'gcal_mock', meetLink: null }),
+    createCalendarEvent: vi
+      .fn()
+      .mockResolvedValue({ eventId: 'gcal_mock', meetLink: null }),
     hasAppointmentConflict: vi.fn().mockResolvedValue(false),
     isCabinetEligibleSlot: vi.fn().mockResolvedValue(true),
     invalidateAvailabilityCache: vi.fn().mockResolvedValue(undefined),
@@ -107,7 +109,8 @@ vi.mock('@/lib/resend', () => ({
   buildAppointmentConversationSubject: vi.fn((base: string) => base),
 }));
 vi.mock('@/lib/stripe', () => ({
-  createAppointmentPaymentLink: (...a: unknown[]) => h.createAppointmentPaymentLink(...a),
+  createAppointmentPaymentLink: (...a: unknown[]) =>
+    h.createAppointmentPaymentLink(...a),
 }));
 vi.mock('@/lib/google-calendar', () => ({
   createCalendarEvent: (...a: unknown[]) => h.createCalendarEvent(...a),
@@ -120,12 +123,16 @@ vi.mock('@/lib/appointment-eligibility', () => ({
 }));
 // The source imports with an explicit `.js` extension — mock BOTH specifiers.
 vi.mock('@/lib/calendar-cache', () => ({
-  invalidateAvailabilityCache: (...a: unknown[]) => h.invalidateAvailabilityCache(...a),
+  invalidateAvailabilityCache: (...a: unknown[]) =>
+    h.invalidateAvailabilityCache(...a),
 }));
 vi.mock('@/lib/calendar-cache.js', () => ({
-  invalidateAvailabilityCache: (...a: unknown[]) => h.invalidateAvailabilityCache(...a),
+  invalidateAvailabilityCache: (...a: unknown[]) =>
+    h.invalidateAvailabilityCache(...a),
 }));
-vi.mock('@/lib/secure-links', () => ({ createSecureLinkToken: vi.fn(() => 'tok_mock') }));
+vi.mock('@/lib/secure-links', () => ({
+  createSecureLinkToken: vi.fn(() => 'tok_mock'),
+}));
 vi.mock('@/lib/ics', () => ({
   generateGoogleCalendarLink: vi.fn(() => 'https://cal.example/g'),
   generateOutlookCalendarLink: vi.fn(() => 'https://cal.example/o'),
@@ -195,7 +202,9 @@ function makeRequest(payload: Record<string, unknown>): Request {
 beforeEach(() => {
   vi.clearAllMocks();
   h.sb = h.makeSupabaseMock();
-  h.getSession.mockResolvedValue({ user: { id: 'admin_001', email: 'pro@omf-therapie.fr' } });
+  h.getSession.mockResolvedValue({
+    user: { id: 'admin_001', email: 'pro@omf-therapie.fr' },
+  });
   h.isAdminSession.mockReturnValue(true);
   h.sendEmail.mockResolvedValue({ success: true });
   h.getAvailableCredit.mockResolvedValue(0);
@@ -217,7 +226,7 @@ describe('POST /api/admin/appointments/ — invitation_sent_at flags (issue #126
     await flushSideEffects(captured);
     // invitation_sent_at (mark-delivered after the successful send).
     expect(h.sendEmail).toHaveBeenCalledTimes(1);
-    const flagged = h.sb.updates.filter((u) => !!u.invitation_sent_at);
+    const flagged = h.sb.updates.filter(u => !!u.invitation_sent_at);
     expect(flagged.length).toBeGreaterThan(0);
     expect(typeof flagged[0].invitation_sent_at).toBe('string');
   });
@@ -245,7 +254,7 @@ describe('POST /api/admin/appointments/ — invitation_sent_at flags (issue #126
 
     // Assert — one UPDATE sets BOTH L2 flags (séance réglée par avoir).
     const flagged = h.sb.updates.filter(
-      (u) => !!u.invitation_sent_at && !!u.confirmation_sent_at,
+      u => !!u.invitation_sent_at && !!u.confirmation_sent_at,
     );
     expect(flagged.length).toBeGreaterThan(0);
     expect(typeof flagged[0].invitation_sent_at).toBe('string');
@@ -278,9 +287,15 @@ describe('POST /api/admin/appointments/ — invitation_sent_at flags (issue #126
   // -------------------------------------------------------------------------
   it('responds 201 without touching calendar/stripe/email, then runs the pipeline via waitUntil (issue #126 V2)', async () => {
     // Arrange — video RDV with a balance due (Stripe path), email requested.
-    const request = makeRequest({ appointment_mode: 'video', send_email: true });
+    const request = makeRequest({
+      appointment_mode: 'video',
+      send_email: true,
+    });
     const { context, captured } = makeContext(request);
-    h.createAppointmentPaymentLink.mockResolvedValue({ id: 'pl_mock', url: 'https://pay.example/pl' });
+    h.createAppointmentPaymentLink.mockResolvedValue({
+      id: 'pl_mock',
+      url: 'https://pay.example/pl',
+    });
 
     // Act — the critical path must only INSERT and respond.
     const response = await POST(context as never);
@@ -296,7 +311,7 @@ describe('POST /api/admin/appointments/ — invitation_sent_at flags (issue #126
     expect(captured.length).toBeGreaterThan(0);
     await flushSideEffects(captured);
     expect(h.sendEmail).toHaveBeenCalledTimes(1);
-    const flagged = h.sb.updates.filter((u) => !!u.invitation_sent_at);
+    const flagged = h.sb.updates.filter(u => !!u.invitation_sent_at);
     expect(flagged.length).toBeGreaterThan(0);
   });
 
@@ -306,15 +321,21 @@ describe('POST /api/admin/appointments/ — invitation_sent_at flags (issue #126
   // -------------------------------------------------------------------------
   it('still responds 201 without throwing when locals.netlify is absent (inline fallback)', async () => {
     // Arrange — bare context, no Netlify decorator at all.
-    const request = makeRequest({ appointment_mode: 'video', send_email: true });
-    h.createAppointmentPaymentLink.mockResolvedValue({ id: 'pl_mock', url: 'https://pay.example/pl' });
+    const request = makeRequest({
+      appointment_mode: 'video',
+      send_email: true,
+    });
+    h.createAppointmentPaymentLink.mockResolvedValue({
+      id: 'pl_mock',
+      url: 'https://pay.example/pl',
+    });
 
     // Act / Assert — the handler must not throw and must answer 201.
     const response = await POST({ request, url: request.url } as never);
     expect(response.status).toBe(201);
     // The inline fallback is fire-and-forget: flush the microtask queue before
     // asserting the deferred pipeline ran (201 was already sent, unblocked).
-    await new Promise((r) => setImmediate(r));
+    await new Promise(r => setImmediate(r));
     expect(h.sendEmail).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/admin-appointments-post.test.ts
+++ b/tests/unit/admin-appointments-post.test.ts
@@ -1,0 +1,237 @@
+/**
+ * RED tests (test-first, issue #126 / T2) for POST /api/admin/appointments/ —
+ * L2 `invitation_sent_at` flag-setting.
+ *
+ * Expected behaviour AFTER T3 (implementation):
+ *   (a) send_email:true + sendEmail resolves → an UPDATE sets
+ *       invitation_sent_at (non-null) after the email succeeds.
+ *   (b) payment_received via credit (use_credit covers the balance) → the same
+ *       UPDATE also sets confirmation_sent_at.
+ *   (c) send_email:false → invitation_sent_at is set directly in the INSERT
+ *       payload and sendEmail is never called.
+ *
+ * These tests are RED on the current code (no invitation_sent_at anywhere) and
+ * must turn GREEN after T3. All externals (DB, auth, email, Stripe, calendar)
+ * are mocked via vi.mock — the handler itself is the real module.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// --- Hoisted shared state (mock factories need it at hoist time) ------------
+
+const h = vi.hoisted(() => {
+  /**
+   * Factory: chainable supabaseAdmin mock that CAPTURES insert/update payloads.
+   * Kept reusable for the V2/V3 test waves (set-once WHERE ... IS NULL guards).
+   */
+  const makeSupabaseMock = (appointment: Record<string, unknown> = {}) => {
+    const row = {
+      id: 'appt_test_001',
+      patient_name: 'Jeanne Dupont',
+      patient_email: 'jeanne.dupont@example.com',
+      appointment_type: 'individual',
+      appointment_mode: 'in-person',
+      duration: 60,
+      final_price: 6000,
+      scheduled_at: new Date(Date.now() + 86_400_000).toISOString(),
+      video_link: null,
+      google_calendar_event_id: null,
+      ...appointment,
+    };
+    const inserts: Record<string, unknown>[] = [];
+    const updates: Record<string, unknown>[] = [];
+    const chain = {
+      insert: (payload: Record<string, unknown>) => {
+        inserts.push(payload);
+        return chain;
+      },
+      update: (payload: Record<string, unknown>) => {
+        updates.push(payload);
+        return chain;
+      },
+      delete: () => chain,
+      select: () => chain,
+      eq: () => chain,
+      in: () => chain,
+      is: () => chain,
+      // Terminal calls must resolve like PostgrestBuilder.
+      limit: () => Promise.resolve({ data: [], error: null }),
+      single: () => Promise.resolve({ data: row, error: null }),
+      maybeSingle: () => Promise.resolve({ data: row, error: null }),
+    };
+    return {
+      supabaseAdmin: { from: vi.fn(() => chain) },
+      chain,
+      inserts,
+      updates,
+      row,
+    };
+  };
+
+  return {
+    makeSupabaseMock,
+    sb: makeSupabaseMock(),
+    getSession: vi.fn(),
+    isAdminSession: vi.fn(() => true),
+    sendEmail: vi.fn(),
+    getAvailableCredit: vi.fn().mockResolvedValue(0),
+    consumeCredits: vi.fn().mockResolvedValue(undefined),
+    createAppointmentPaymentLink: vi.fn(),
+    createCalendarEvent: vi.fn().mockResolvedValue({ eventId: 'gcal_mock', meetLink: null }),
+    hasAppointmentConflict: vi.fn().mockResolvedValue(false),
+    isCabinetEligibleSlot: vi.fn().mockResolvedValue(true),
+    invalidateAvailabilityCache: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+// --- Mocks (hoisted before importing the handler) ---------------------------
+
+// Indirection: `h.sb` is swapped per-test in beforeEach, so resolve at call time.
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: { from: (table: string) => h.sb.supabaseAdmin.from(table) },
+}));
+vi.mock('@/lib/auth', () => ({
+  auth: { api: { getSession: (...a: unknown[]) => h.getSession(...a) } },
+}));
+vi.mock('@/lib/authz', () => ({
+  isAdminSession: (...a: unknown[]) => h.isAdminSession(...a),
+}));
+vi.mock('@/lib/pricing', () => ({
+  calculatePrice: vi.fn(() => ({ basePrice: 60, discount: 0, finalPrice: 60 })),
+}));
+vi.mock('@/lib/credits', () => ({
+  getAvailableCredit: (...a: unknown[]) => h.getAvailableCredit(...a),
+  consumeCredits: (...a: unknown[]) => h.consumeCredits(...a),
+}));
+vi.mock('@/lib/resend', () => ({
+  sendEmail: (...a: unknown[]) => h.sendEmail(...a),
+  buildAppointmentConversationSubject: vi.fn((base: string) => base),
+}));
+vi.mock('@/lib/stripe', () => ({
+  createAppointmentPaymentLink: (...a: unknown[]) => h.createAppointmentPaymentLink(...a),
+}));
+vi.mock('@/lib/google-calendar', () => ({
+  createCalendarEvent: (...a: unknown[]) => h.createCalendarEvent(...a),
+}));
+vi.mock('@/lib/appointment-conflicts', () => ({
+  hasAppointmentConflict: (...a: unknown[]) => h.hasAppointmentConflict(...a),
+}));
+vi.mock('@/lib/appointment-eligibility', () => ({
+  isCabinetEligibleSlot: (...a: unknown[]) => h.isCabinetEligibleSlot(...a),
+}));
+// The source imports with an explicit `.js` extension — mock BOTH specifiers.
+vi.mock('@/lib/calendar-cache', () => ({
+  invalidateAvailabilityCache: (...a: unknown[]) => h.invalidateAvailabilityCache(...a),
+}));
+vi.mock('@/lib/calendar-cache.js', () => ({
+  invalidateAvailabilityCache: (...a: unknown[]) => h.invalidateAvailabilityCache(...a),
+}));
+vi.mock('@/lib/secure-links', () => ({ createSecureLinkToken: vi.fn(() => 'tok_mock') }));
+vi.mock('@/lib/ics', () => ({
+  generateGoogleCalendarLink: vi.fn(() => 'https://cal.example/g'),
+  generateOutlookCalendarLink: vi.fn(() => 'https://cal.example/o'),
+  generateAppleCalendarInviteLink: vi.fn(() => 'https://cal.example/a'),
+  CABINET_ADDRESS: '1 rue du Cabinet, 75000 Paris',
+}));
+vi.mock('@/emails/AppointmentConfirmed', () => ({ default: () => null }));
+vi.mock('@/emails/PaymentRequest', () => ({ default: () => null }));
+
+// --- Import the handler AFTER mocks ------------------------------------------
+
+import { POST } from '@/pages/api/admin/appointments';
+
+// --- Helpers -----------------------------------------------------------------
+
+function makeRequest(payload: Record<string, unknown>): Request {
+  return new Request('http://localhost/api/admin/appointments/', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      patient_name: 'Jeanne Dupont',
+      patient_email: 'jeanne.dupont@example.com',
+      patient_phone: '0612345678',
+      appointment_type: 'individual',
+      appointment_mode: 'in-person',
+      duration: 60,
+      scheduled_at: new Date(Date.now() + 86_400_000).toISOString(),
+      patient_reason: 'Suivi',
+      ...payload,
+    }),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.sb = h.makeSupabaseMock();
+  h.getSession.mockResolvedValue({ user: { id: 'admin_001', email: 'pro@omf-therapie.fr' } });
+  h.isAdminSession.mockReturnValue(true);
+  h.sendEmail.mockResolvedValue({ success: true });
+  h.getAvailableCredit.mockResolvedValue(0);
+  h.consumeCredits.mockResolvedValue(undefined);
+});
+
+// ---------------------------------------------------------------------------
+// (a) send_email: true → UPDATE sets invitation_sent_at after email success
+// ---------------------------------------------------------------------------
+describe('POST /api/admin/appointments/ — invitation_sent_at flags (issue #126)', () => {
+  it('sets invitation_sent_at via an UPDATE after sendEmail succeeds when send_email is true', async () => {
+    // Arrange
+    const request = makeRequest({ send_email: true });
+
+    // Act
+    const response = await POST({ request, url: request.url } as never);
+    expect(response.status).toBe(201);
+
+    // Assert — the email was sent AND an UPDATE carried a non-null
+    // invitation_sent_at (mark-delivered after the successful send).
+    expect(h.sendEmail).toHaveBeenCalledTimes(1);
+    const flagged = h.sb.updates.filter((u) => !!u.invitation_sent_at);
+    expect(flagged.length).toBeGreaterThan(0);
+    expect(typeof flagged[0].invitation_sent_at).toBe('string');
+  });
+
+  // -------------------------------------------------------------------------
+  // (b) payment_received via avoir → same UPDATE also sets confirmation_sent_at
+  // -------------------------------------------------------------------------
+  it('sets both invitation_sent_at and confirmation_sent_at when a credit fully covers a video appointment', async () => {
+    // Arrange — video RDV, use_credit:true, available credit covers the full
+    // 6000 cents price → amount due 0 → status payment_received.
+    const request = makeRequest({
+      appointment_mode: 'video',
+      send_email: true,
+      use_credit: true,
+    });
+    h.getAvailableCredit.mockResolvedValue(6000);
+    h.consumeCredits.mockResolvedValue({ consumed: 6000 });
+
+    // Act
+    const response = await POST({ request, url: request.url } as never);
+    expect(response.status).toBe(201);
+    expect(h.sb.inserts[0].status).toBe('payment_received');
+
+    // Assert — one UPDATE sets BOTH L2 flags (séance réglée par avoir).
+    const flagged = h.sb.updates.filter(
+      (u) => !!u.invitation_sent_at && !!u.confirmation_sent_at,
+    );
+    expect(flagged.length).toBeGreaterThan(0);
+    expect(typeof flagged[0].invitation_sent_at).toBe('string');
+    expect(typeof flagged[0].confirmation_sent_at).toBe('string');
+  });
+
+  // -------------------------------------------------------------------------
+  // (c) send_email: false → invitation_sent_at in the INSERT, sendEmail never called
+  // -------------------------------------------------------------------------
+  it('sets invitation_sent_at in the INSERT payload and never calls sendEmail when send_email is false', async () => {
+    // Arrange
+    const request = makeRequest({ send_email: false });
+
+    // Act
+    const response = await POST({ request, url: request.url } as never);
+    expect(response.status).toBe(201);
+
+    // Assert — the flag is carried by the INSERT (no email will ever be sent)
+    // and the email provider is never contacted.
+    expect(h.sb.inserts.length).toBeGreaterThan(0);
+    expect(typeof h.sb.inserts[0].invitation_sent_at).toBe('string');
+    expect(h.sendEmail).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/admin-appointments-post.test.ts
+++ b/tests/unit/admin-appointments-post.test.ts
@@ -282,6 +282,38 @@ describe('POST /api/admin/appointments/ — invitation_sent_at flags (issue #126
   });
 
   // -------------------------------------------------------------------------
+  // (c-bis / C6) send_email: false + avoir couvrant → BOTH L2 flags at INSERT
+  // -------------------------------------------------------------------------
+  it('sets both invitation_sent_at and confirmation_sent_at in the INSERT when a credit fully covers and send_email is false (C6)', async () => {
+    // Arrange — video RDV, credit covers the full price → initial status
+    // payment_received, but send_email:false means the pipeline's set-once
+    // flags update can never fire (guarded `.is('invitation_sent_at', null)`,
+    // already set at INSERT). Without confirmation_sent_at in the INSERT too,
+    // the #98 sweep would send the confirmation email to a patient who opted
+    // out of emails.
+    const request = makeRequest({
+      appointment_mode: 'video',
+      send_email: false,
+      use_credit: true,
+    });
+    h.getAvailableCredit.mockResolvedValue(6000);
+    h.consumeCredits.mockResolvedValue({ consumed: 6000 });
+    const { context, captured } = makeContext(request);
+
+    // Act
+    const response = await POST(context as never);
+    expect(response.status).toBe(201);
+    await flushSideEffects(captured);
+
+    // Assert — the INSERT carries BOTH flags (séance réglée par avoir, aucun
+    // email jamais envoyé) and the email provider is never contacted.
+    expect(h.sb.inserts[0].status).toBe('payment_received');
+    expect(typeof h.sb.inserts[0].invitation_sent_at).toBe('string');
+    expect(typeof h.sb.inserts[0].confirmation_sent_at).toBe('string');
+    expect(h.sendEmail).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
   // (a) [RED until T7] 201 must leave BEFORE any external call — the pipeline
   // (calendar → Stripe → email) is deferred via locals.netlify.context.waitUntil
   // -------------------------------------------------------------------------

--- a/tests/unit/cron-schedule-source.test.ts
+++ b/tests/unit/cron-schedule-source.test.ts
@@ -114,6 +114,25 @@ describe('regression #113 — Netlify schedule extraction', () => {
     });
   });
 
+  describe('reconcile-invitations', () => {
+    // Sweep horaire des invitations (#126) — same Netlify static-extraction
+    // contract as the other crons: the `schedule:` literal must stay inline
+    // (zisi's parsePrimitive does not resolve Identifiers) and in phase with
+    // the SCHEDULE const consumed by Sentry.withMonitor.
+    const source = readCronSource('netlify/functions/reconcile-invitations.ts');
+
+    it('exports `config.schedule` as an inline string literal', () => {
+      const config = extractConfigBlock(source);
+      expect(config).toMatch(/schedule:\s*['"]/);
+      expect(config).not.toMatch(/schedule:\s*SCHEDULE\b/);
+    });
+
+    it('declares the expected hourly :20 UTC crontab', () => {
+      const config = extractConfigBlock(source);
+      expect(config).toMatch(/schedule:\s*['"]20 \* \* \* \*['"]/);
+    });
+  });
+
   describe('SCHEDULE const stays in sync with the inline literal', () => {
     // Defense against the DRY break introduced by this fix: the literal in
     // `config.schedule` and the `SCHEDULE` const (consumed by withMonitor)
@@ -140,6 +159,16 @@ describe('regression #113 — Netlify schedule extraction', () => {
 
     it('reconcile-confirmations: const SCHEDULE === config.schedule literal', () => {
       const source = readCronSource('netlify/functions/reconcile-confirmations.ts');
+      const constMatch = source.match(/const\s+SCHEDULE\s*=\s*['"]([^'"]+)['"]/);
+      const config = extractConfigBlock(source);
+      const literalMatch = config.match(/schedule:\s*['"]([^'"]+)['"]/);
+      expect(constMatch, 'const SCHEDULE declaration not found').not.toBeNull();
+      expect(literalMatch, 'inline schedule literal not found').not.toBeNull();
+      expect(constMatch![1]).toBe(literalMatch![1]);
+    });
+
+    it('reconcile-invitations: const SCHEDULE === config.schedule literal', () => {
+      const source = readCronSource('netlify/functions/reconcile-invitations.ts');
       const constMatch = source.match(/const\s+SCHEDULE\s*=\s*['"]([^'"]+)['"]/);
       const config = extractConfigBlock(source);
       const literalMatch = config.match(/schedule:\s*['"]([^'"]+)['"]/);

--- a/tests/unit/reconcile-invitations.test.ts
+++ b/tests/unit/reconcile-invitations.test.ts
@@ -473,12 +473,27 @@ describe('reconcile-invitations cron handler (T13 contract)', () => {
 
       await handler();
 
-      expect(notifications.processAppointmentSideEffects).toHaveBeenCalledTimes(
-        1,
-      );
+      const [, partialOpts] =
+        notifications.processAppointmentSideEffects.mock.calls[0];
+      expect(partialOpts.amountDueCents).toBe(4000);
+    });
+
+    it('clamps amountDueCents to 0 when credit_applied exceeds final_price (C3 — Math.max guard)', async () => {
+      // Guards the clamp: without Math.max(0, …) a sur-covered RDV would be
+      // delegated with a negative amount due (−2000).
+      const appt = makeAppt({
+        id: 'appt-surcovered-credit',
+        status: 'payment_pending',
+        final_price: 6000,
+        credit_applied: 8000,
+      });
+      supabaseState.selectResults.push({ ...EMPTY_RESULT, data: [appt] });
+
+      await handler();
+
       const [, calledOpts] =
         notifications.processAppointmentSideEffects.mock.calls[0];
-      expect(calledOpts.amountDueCents).toBe(4000);
+      expect(calledOpts.amountDueCents).toBe(0);
     });
 
     it('injects signingSecret (process.env.BETTER_AUTH_SECRET) into the delegation (C2)', async () => {
@@ -507,7 +522,23 @@ describe('reconcile-invitations cron handler (T13 contract)', () => {
 
       await handler();
 
-      expect(notifications.processAppointmentSideEffects).not.toHaveBeenCalled();
+      expect(
+        notifications.processAppointmentSideEffects,
+      ).not.toHaveBeenCalled();
+      errorSpy.mockRestore();
+    });
+
+    it('aborts as well when BETTER_AUTH_SECRET is present but shorter than 32 chars (C2)', async () => {
+      vi.stubEnv('BETTER_AUTH_SECRET', 'too-short');
+      const appt = makeAppt();
+      supabaseState.selectResults.push({ ...EMPTY_RESULT, data: [appt] });
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await handler();
+
+      expect(
+        notifications.processAppointmentSideEffects,
+      ).not.toHaveBeenCalled();
       errorSpy.mockRestore();
     });
   });

--- a/tests/unit/reconcile-invitations.test.ts
+++ b/tests/unit/reconcile-invitations.test.ts
@@ -1,0 +1,623 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// RED tests — T10 defines the CONTRACT of the T13 scheduled function
+// `netlify/functions/reconcile-invitations.ts` (issue #126, slice 3).
+//
+// The module does NOT exist yet: every test in this file is expected to FAIL
+// at import ("module not found") until T13 lands. Once implemented, these
+// tests pin down:
+//
+//   1. Exports: callable default `handler` + named `config` with literal
+//      schedule `'20 * * * *'` (offset from #98's `'5 * * * *'`).
+//   2. Sentry wiring: `initSentry()` BEFORE `Sentry.withMonitor(
+//      'reconcile-invitations', …, { checkInMargin: 5, maxRuntime: 10 })`
+//      (patterns #75/#113).
+//   3. Constants: DEADLINE_MS = 8500, BATCH_LIMIT = 25, 48 h created_at window.
+//   4. Eligibility query on `appointments` — every filter asserted on the
+//      mock query chain (see the payment_received deviation note below).
+//   5. Per-row DELEGATION to `processAppointmentSideEffects(appt, opts)` with
+//      `sendEmail: true` and `amountDueCents: 0` for payment_received (avoir)
+//      else `final_price` (cents).
+//   6. GOOGLE_CALENDAR_MOCK=true → injected no-op createCalendarEvent that
+//      console.warns; the real calendar module is never called; the rest of
+//      the per-row reconciliation continues.
+//   7. Poison-escape (makeSendFnWithCapture pattern #98): non-retryable Resend
+//      4xx on the patient email → the sweep itself sets `invitation_sent_at`
+//      (set-once `.is('invitation_sent_at', null)` guard) + error log;
+//      retryable 5xx → flag left NULL for the next hourly pass.
+//   8. Deadline: the loop stops at now() + DEADLINE_MS (remaining rows are
+//      deferred to the next hourly pass).
+//   9. Per-row isolation: one throwing row does not block the batch.
+//  10. Logs without PII (never the patient email address).
+//
+// Conventions mirror `tests/unit/cron-handlers.test.ts` (mock leaves, env
+// stubs, withMonitor passthrough mock) and the #98 sweep
+// `netlify/functions/reconcile-confirmations.ts`.
+// ---------------------------------------------------------------------------
+
+// --- Sentry passthrough mock (same contract as cron-handlers.test.ts) -------
+const sentry = vi.hoisted(() => ({
+  init: vi.fn(),
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+  addBreadcrumb: vi.fn(),
+  flush: vi.fn(async (_ms?: number) => true),
+  // withMonitor invokes the callback immediately and returns T (NOT a fn).
+  withMonitor: vi.fn(
+    <T>(_slug: string, callback: () => T, _opts?: unknown): T => callback(),
+  ),
+}));
+
+vi.mock('@sentry/node', () => ({
+  init: sentry.init,
+  captureException: sentry.captureException,
+  captureMessage: sentry.captureMessage,
+  addBreadcrumb: sentry.addBreadcrumb,
+  flush: sentry.flush,
+  withMonitor: sentry.withMonitor,
+}));
+
+// --- Supabase mock: chainable + thenable, records every filter call ---------
+
+const EMPTY_RESULT = {
+  data: null,
+  error: null,
+  count: null,
+  status: 200,
+  statusText: 'OK',
+} as const;
+
+interface RecordedUpdate {
+  payload: Record<string, unknown>;
+  eqs: Array<[string, unknown]>;
+  iss: Array<[string, unknown]>;
+}
+
+interface RecordedChain {
+  table: string;
+  select: unknown[];
+  inFilters: Array<[string, unknown[]]>;
+  isFilters: Array<[string, unknown]>;
+  gtFilters: Array<[string, unknown]>;
+  orders: Array<[string, { ascending: boolean }]>;
+  limits: number[];
+  updates: RecordedUpdate[];
+}
+
+const supabaseState = vi.hoisted(() => {
+  const state = {
+    chains: [] as RecordedChain[],
+    // Queue of PostgrestResponse payloads handed to SELECT-chain awaits
+    // (consumed FIFO by the thenable terminal; default = empty result).
+    selectResults: [] as unknown[],
+  };
+  return state;
+});
+
+const supabaseFrom = vi.fn((table: string) => {
+  const record: RecordedChain = {
+    table,
+    select: [],
+    inFilters: [],
+    isFilters: [],
+    gtFilters: [],
+    orders: [],
+    limits: [],
+    updates: [],
+  };
+  supabaseState.chains.push(record);
+
+  let isUpdateChain = false;
+  const chain: Record<string, unknown> = {};
+  const makeThenable = () => {
+    chain.then = (
+      resolve: (v: unknown) => void,
+      reject: (e: unknown) => void,
+    ) => {
+      const result = isUpdateChain
+        ? { ...EMPTY_RESULT }
+        : (supabaseState.selectResults.shift() ?? { ...EMPTY_RESULT });
+      Promise.resolve(result).then(resolve, reject);
+      return chain;
+    };
+  };
+
+  chain.select = vi.fn((...args: unknown[]) => {
+    record.select.push(...args);
+    return chain;
+  });
+  chain.insert = vi.fn(() => chain);
+  chain.update = vi.fn((payload: Record<string, unknown>) => {
+    isUpdateChain = true;
+    record.updates.push({ payload, eqs: [], iss: [] });
+    return chain;
+  });
+  chain.delete = vi.fn(() => chain);
+  chain.eq = vi.fn((col: string, value: unknown) => {
+    record.updates[record.updates.length - 1]?.eqs.push([col, value]);
+    return chain;
+  });
+  chain.neq = vi.fn(() => chain);
+  chain.gt = vi.fn((col: string, value: unknown) => {
+    record.gtFilters.push([col, value]);
+    return chain;
+  });
+  chain.gte = vi.fn(() => chain);
+  chain.lt = vi.fn(() => chain);
+  chain.lte = vi.fn(() => chain);
+  chain.in = vi.fn((col: string, values: unknown[]) => {
+    record.inFilters.push([col, values]);
+    return chain;
+  });
+  chain.is = vi.fn((col: string, value: unknown) => {
+    record.isFilters.push([col, value]);
+    record.updates[record.updates.length - 1]?.iss.push([col, value]);
+    return chain;
+  });
+  chain.order = vi.fn(
+    (col: string, opts: { ascending: boolean }) => {
+      record.orders.push([col, opts]);
+      return chain;
+    },
+  );
+  chain.limit = vi.fn((n: number) => {
+    record.limits.push(n);
+    return chain;
+  });
+  makeThenable();
+  // Re-arm the thenable after each await (the sweep awaits the chain once,
+  // but keep it thenable-safe like the cron-handlers mock).
+  const origThen = chain.then as unknown as (
+    resolve: (v: unknown) => void,
+    reject: (e: unknown) => void,
+  ) => unknown;
+  chain.then = (resolve: (v: unknown) => void, reject: (e: unknown) => void) =>
+    origThen(resolve, reject);
+
+  return chain;
+});
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({ from: supabaseFrom })),
+}));
+
+vi.mock('ws', () => ({ default: vi.fn(), __esModule: true }));
+
+// --- Resend mock (client instantiated from process.env by the sweep) --------
+const resendSend = vi.fn(async () => ({
+  data: { id: 're_123' },
+  error: null,
+}));
+vi.mock('resend', () => ({
+  Resend: class {
+    constructor(_apiKey: string) {}
+    emails = { send: resendSend };
+  },
+}));
+
+// --- notifications.ts mock — the sweep DELEGATES each row here (T6) --------
+const notifications = vi.hoisted(() => ({
+  processAppointmentSideEffects: vi.fn(
+    // Default behaviour-preserving stub: when called, exercise the injected
+    // sendFn exactly like the real S3 step would (so the sweep's capture
+    // wrapper sees the Resend error) and swallow it (the real pipeline never
+    // throws — the sweep must read the captured error, not a rejection).
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    async (appt: any, opts: any) => {
+      if (opts.sendEmail && typeof opts.sendFn === 'function') {
+        try {
+          await opts.sendFn({
+            to: appt.patient_email,
+            subject: '[test] invitation',
+            react: null,
+          });
+        } catch {
+          // Swallowed, mirroring runStep('email', ...) in notifications.ts.
+        }
+      }
+      if (typeof opts.createCalendarEvent === 'function') {
+        try {
+          await opts.createCalendarEvent({ appointmentId: appt.id });
+        } catch {
+          // Swallowed.
+        }
+      }
+    },
+  ),
+}));
+vi.mock('../../src/lib/notifications', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../src/lib/notifications')>();
+  return { ...actual, processAppointmentSideEffects: notifications.processAppointmentSideEffects };
+});
+
+// --- google-calendar mock — must NEVER be called (the sweep injects its own
+// calendar fn, real or no-op depending on GOOGLE_CALENDAR_MOCK) --------------
+const googleCalendar = vi.hoisted(() => ({
+  createCalendarEvent: vi.fn(async () => ({
+    eventId: 'evt_real',
+    meetLink: undefined,
+  })),
+}));
+vi.mock('../../src/lib/google-calendar', () => ({
+  createCalendarEvent: googleCalendar.createCalendarEvent,
+}));
+
+// Module under test — DOES NOT EXIST YET (T13). All tests are RED at import.
+import handler, { config } from '../../netlify/functions/reconcile-invitations';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeAppt(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'appt-1',
+    status: 'confirmed',
+    appointment_type: 'consultation',
+    appointment_mode: 'in-person',
+    duration: 60,
+    scheduled_at: new Date(Date.now() + 86_400_000).toISOString(),
+    created_at: new Date(Date.now() - 3_600_000).toISOString(),
+    patient_name: 'Patient Un',
+    patient_email: 'patient1@example.com',
+    final_price: 6000,
+    video_link: null,
+    google_calendar_event_id: null,
+    ...overrides,
+  };
+}
+
+/** Stubs every env var the sweep reads, so no env-guard early-return fires. */
+function stubEnv(): void {
+  vi.stubEnv('PUBLIC_SENTRY_DSN', 'https://example@sentry.io/1');
+  vi.stubEnv('SUPABASE_DATABASE_URL', 'https://test.supabase.co');
+  vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'test-service-role-key');
+  vi.stubEnv('RESEND_API_KEY', 're_test_key');
+  vi.stubEnv('RESEND_FROM_EMAIL', 'OMF <contact@omf-therapie.fr>');
+  vi.stubEnv('BETTER_AUTH_URL', 'https://omf-therapie.fr');
+  vi.stubEnv(
+    'BETTER_AUTH_SECRET',
+    'test-secret-that-is-long-enough-32-chars-min',
+  );
+}
+
+function resetMocks(): void {
+  sentry.flush.mockClear();
+  sentry.flush.mockImplementation(async () => true);
+  supabaseFrom.mockClear();
+  supabaseState.chains.length = 0;
+  supabaseState.selectResults.length = 0;
+  resendSend.mockClear();
+  resendSend.mockResolvedValue({ data: { id: 're_123' }, error: null });
+  notifications.processAppointmentSideEffects.mockClear();
+  // Keep the default delegation implementation unless a test overrides it.
+  notifications.processAppointmentSideEffects.mockImplementation(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    notifications.processAppointmentSideEffects.getMockImplementation()!,
+  );
+  googleCalendar.createCalendarEvent.mockClear();
+  // withMonitor intentionally NOT cleared (wiring recorded at invocation
+  // time; each wiring test clears it explicitly).
+}
+
+beforeEach(() => {
+  resetMocks();
+  stubEnv();
+  delete process.env.GOOGLE_CALENDAR_MOCK;
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.useRealTimers();
+});
+
+// ===========================================================================
+// Contract tests — all RED until T13 implements the module.
+// ===========================================================================
+
+describe('reconcile-invitations cron handler (T13 contract)', () => {
+  describe('default export contract', () => {
+    it('exports a callable handler (withMonitor returns T, not a function)', () => {
+      // Regression guard mirroring cron-handlers.test.ts / bug #75: the
+      // default export must be a function Netlify's bootstrap can invoke.
+      expect(typeof handler).toBe('function');
+    });
+
+    it("exports config with literal schedule '20 * * * *' (offset from #98's '5 * * * *')", () => {
+      // The Netlify bundler only resolves string LITERALS in the config
+      // export (regression #113/#114) — the schedule must be inline here.
+      expect(config.schedule).toBe('20 * * * *');
+    });
+  });
+
+  describe('Sentry monitor wiring', () => {
+    it("registers withMonitor('reconcile-invitations') with checkInMargin 5 and maxRuntime 10", async () => {
+      sentry.withMonitor.mockClear();
+      await handler();
+      expect(sentry.withMonitor).toHaveBeenCalledWith(
+        'reconcile-invitations',
+        expect.any(Function),
+        expect.objectContaining({
+          schedule: { type: 'crontab', value: '20 * * * *' },
+          checkInMargin: 5,
+          maxRuntime: 10,
+        }),
+      );
+    });
+
+    it('runs initSentry() BEFORE Sentry.withMonitor() (regression #113)', async () => {
+      // The in_progress check-in — the only one carrying monitor_config —
+      // requires an initialized client, so init must precede withMonitor.
+      sentry.init.mockClear();
+      sentry.withMonitor.mockClear();
+      await handler();
+      expect(sentry.init).toHaveBeenCalled();
+      expect(sentry.withMonitor).toHaveBeenCalled();
+      expect(sentry.init.mock.invocationCallOrder[0]).toBeLessThan(
+        sentry.withMonitor.mock.invocationCallOrder[0],
+      );
+    });
+
+    it('awaits Sentry.flush(2000) in the finally block on the empty-batch path', async () => {
+      // No seeded select results → empty batch → handler resolves → finally
+      // flush fires (PUBLIC_SENTRY_DSN is stubbed).
+      await handler();
+      expect(sentry.flush).toHaveBeenCalledWith(2000);
+    });
+  });
+
+  describe('eligibility query', () => {
+    it('filters on status/flags/window/future and bounds the batch', async () => {
+      supabaseState.selectResults.push({ ...EMPTY_RESULT, data: [] });
+      const before = Date.now();
+      await handler();
+      const after = Date.now();
+
+      const chain = supabaseState.chains.find(
+        (c) => c.select.length > 0 && c.updates.length === 0,
+      );
+      expect(chain).toBeDefined();
+      expect(chain!.table).toBe('appointments');
+
+      // status IN (…) — ÉCART ASSUMÉ vs spec §5: the spec lists only
+      // ('confirmed','payment_pending'), but SC3 ("aucun RDV à venir ne reste
+      // invitation_sent_at IS NULL") must also hold for avoir-paid RDVs whose
+      // email failed: `payment_received` is inserted directly at INSERT time
+      // (slice 1, step 2(d)) and its invitation email can equally fail, so it
+      // MUST be in the sweep's eligibility set.
+      expect(chain!.inFilters).toContainEqual([
+        'status',
+        ['confirmed', 'payment_pending', 'payment_received'],
+      ]);
+
+      // Set-once flag still NULL + soft-delete guard.
+      expect(chain!.isFilters).toContainEqual(['invitation_sent_at', null]);
+      expect(chain!.isFilters).toContainEqual(['deleted_at', null]);
+
+      // created_at > now − 48 h (tolerance for the awaited call duration).
+      const createdFilter = chain!.gtFilters.find(
+        ([col]) => col === 'created_at',
+      );
+      expect(createdFilter).toBeDefined();
+      const createdValue = new Date(createdFilter![1] as string).getTime();
+      expect(createdValue).toBeGreaterThanOrEqual(before - 48 * 3_600_000 - 5_000);
+      expect(createdValue).toBeLessThanOrEqual(after - 48 * 3_600_000 + 5_000);
+
+      // scheduled_at > now (only upcoming appointments).
+      const scheduledFilter = chain!.gtFilters.find(
+        ([col]) => col === 'scheduled_at',
+      );
+      expect(scheduledFilter).toBeDefined();
+      const scheduledValue = new Date(scheduledFilter![1] as string).getTime();
+      expect(scheduledValue).toBeGreaterThanOrEqual(before - 5_000);
+      expect(scheduledValue).toBeLessThanOrEqual(after + 5_000);
+
+      // Oldest first + bounded batch.
+      expect(chain!.orders).toContainEqual([
+        'created_at',
+        { ascending: true },
+      ]);
+      expect(chain!.limits).toContainEqual(25);
+    });
+  });
+
+  describe('per-row delegation to processAppointmentSideEffects', () => {
+    it('delegates each row with sendEmail:true and amountDueCents = final_price (cents)', async () => {
+      const appt = makeAppt({ id: 'appt-unpaid', status: 'payment_pending' });
+      supabaseState.selectResults.push({ ...EMPTY_RESULT, data: [appt] });
+
+      await handler();
+
+      expect(notifications.processAppointmentSideEffects).toHaveBeenCalledTimes(
+        1,
+      );
+      const [calledAppt, calledOpts] =
+        notifications.processAppointmentSideEffects.mock.calls[0];
+      expect(calledAppt).toEqual(appt);
+      // Eligible rows are exactly those whose email did NOT go out — so the
+      // sweep always re-runs the email step. send_email=false rows get the
+      // flag at INSERT time and are never eligible.
+      expect(calledOpts).toMatchObject({ sendEmail: true });
+      expect(calledOpts.amountDueCents).toBe(6000);
+    });
+
+    it("delegates payment_received (avoir) rows with amountDueCents: 0 — no re-charge", async () => {
+      const appt = makeAppt({ id: 'appt-avoir', status: 'payment_received' });
+      supabaseState.selectResults.push({ ...EMPTY_RESULT, data: [appt] });
+
+      await handler();
+
+      expect(notifications.processAppointmentSideEffects).toHaveBeenCalledTimes(
+        1,
+      );
+      const [, calledOpts] =
+        notifications.processAppointmentSideEffects.mock.calls[0];
+      // Already paid via internal credit → S2 (Stripe link) must be skipped
+      // by the delegated pipeline, which gates on amountDueCents > 0.
+      expect(calledOpts.amountDueCents).toBe(0);
+      expect(calledOpts.sendEmail).toBe(true);
+    });
+  });
+
+  describe('GOOGLE_CALENDAR_MOCK=true (dev-only calendar skip)', () => {
+    it('injects a console.warn-ing no-op calendar fn, never touches the real module, and still reconciles the row', async () => {
+      process.env.GOOGLE_CALENDAR_MOCK = 'true';
+      const appt = makeAppt();
+      supabaseState.selectResults.push({ ...EMPTY_RESULT, data: [appt] });
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      await handler();
+
+      expect(
+        notifications.processAppointmentSideEffects,
+      ).toHaveBeenCalledTimes(1);
+      const [, opts] =
+        notifications.processAppointmentSideEffects.mock.calls[0];
+      expect(typeof opts.createCalendarEvent).toBe('function');
+
+      // The injected fn warns (dev-only skip must be visible in logs)…
+      const calResult = await opts.createCalendarEvent({
+        appointmentId: appt.id,
+      });
+      expect(calResult).toBeDefined();
+      expect(warnSpy).toHaveBeenCalled();
+
+      // …and the REAL calendar module is never called.
+      expect(googleCalendar.createCalendarEvent).not.toHaveBeenCalled();
+
+      // The rest of the per-row reconciliation still ran (Stripe/email/flags
+      // are delegated through the same call — asserted via the email sendFn).
+      expect(resendSend).toHaveBeenCalled();
+
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe('poison-escape (makeSendFnWithCapture pattern)', () => {
+    it('sets invitation_sent_at itself (set-once guard) on a NON-retryable Resend 4xx', async () => {
+      const appt = makeAppt();
+      supabaseState.selectResults.push({ ...EMPTY_RESULT, data: [appt] });
+      // Resend returns a validation 4xx → isRetryableResendError === false →
+      // poison. processAppointmentSideEffects swallows it (mocked impl calls
+      // the injected sendFn), so the sweep must detect it via its capture
+      // wrapper and escape the retry loop itself.
+      resendSend.mockResolvedValue({
+        data: null,
+        error: {
+          name: 'validation_error',
+          statusCode: 422,
+          message: 'Invalid "to" address',
+        },
+      });
+
+      await handler();
+
+      const flagUpdate = supabaseState.chains
+        .flatMap((c) => c.updates.map((u) => ({ chain: c, update: u })))
+        .find(({ update }) => 'invitation_sent_at' in update.payload);
+      expect(flagUpdate).toBeDefined();
+      expect(flagUpdate!.update.eqs).toContainEqual(['id', appt.id]);
+      // Set-once write-race guard (mirrors #98 L2).
+      expect(flagUpdate!.update.iss).toContainEqual([
+        'invitation_sent_at',
+        null,
+      ]);
+    });
+
+    it('leaves invitation_sent_at NULL on a RETRYABLE Resend 5xx (next hourly pass retries)', async () => {
+      const appt = makeAppt();
+      supabaseState.selectResults.push({ ...EMPTY_RESULT, data: [appt] });
+      resendSend.mockResolvedValue({
+        data: null,
+        error: {
+          name: 'internal_server_error',
+          statusCode: 500,
+          message: 'Resend unavailable',
+        },
+      });
+
+      await handler();
+
+      const flagUpdate = supabaseState.chains
+        .flatMap((c) => c.updates.map((u) => u.payload))
+        .find((payload) => 'invitation_sent_at' in payload);
+      expect(flagUpdate).toBeUndefined();
+    });
+  });
+
+  describe('deadline (DEADLINE_MS = 8500)', () => {
+    it('stops the loop at the deadline — remaining rows deferred to the next pass', async () => {
+      const rows = [
+        makeAppt({ id: 'appt-a' }),
+        makeAppt({ id: 'appt-b' }),
+      ];
+      supabaseState.selectResults.push({ ...EMPTY_RESULT, data: rows });
+
+      // Fake the wall clock: while processing the FIRST row, time jumps past
+      // the 8.5 s budget (slow external call). Row B must not be attempted.
+      vi.useFakeTimers({ toFake: ['Date'] });
+      const t0 = Date.now();
+      notifications.processAppointmentSideEffects.mockImplementationOnce(
+        async () => {
+          vi.setSystemTime(t0 + 9000);
+        },
+      );
+
+      await handler();
+
+      expect(notifications.processAppointmentSideEffects).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(
+        notifications.processAppointmentSideEffects.mock.calls[0][0].id,
+      ).toBe('appt-a');
+    });
+  });
+
+  describe('per-row isolation', () => {
+    it('a throwing row does not prevent the following rows (handler resolves)', async () => {
+      const rows = [
+        makeAppt({ id: 'appt-poison' }),
+        makeAppt({ id: 'appt-next' }),
+      ];
+      supabaseState.selectResults.push({ ...EMPTY_RESULT, data: rows });
+      notifications.processAppointmentSideEffects
+        .mockRejectedValueOnce(new Error('row exploded'))
+        .mockResolvedValue(undefined);
+
+      // Must NOT reject — the failed row is logged + counted, the batch goes on.
+      await expect(handler()).resolves.toBeUndefined();
+      expect(notifications.processAppointmentSideEffects).toHaveBeenCalledTimes(
+        2,
+      );
+    });
+  });
+
+  describe('logs without PII', () => {
+    it('never logs the patient email address on the poison-escape error path', async () => {
+      const appt = makeAppt({ patient_email: 'secret-patient@example.com' });
+      supabaseState.selectResults.push({ ...EMPTY_RESULT, data: [appt] });
+      resendSend.mockResolvedValue({
+        data: null,
+        error: {
+          name: 'validation_error',
+          statusCode: 422,
+          message: 'Invalid "to" address',
+        },
+      });
+      const errorSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await handler();
+
+      for (const call of errorSpy.mock.calls) {
+        const serialized = JSON.stringify(call);
+        expect(serialized).not.toContain('secret-patient@example.com');
+      }
+      errorSpy.mockRestore();
+    });
+  });
+});

--- a/tests/unit/reconcile-invitations.test.ts
+++ b/tests/unit/reconcile-invitations.test.ts
@@ -458,6 +458,58 @@ describe('reconcile-invitations cron handler (T13 contract)', () => {
       expect(calledOpts.amountDueCents).toBe(0);
       expect(calledOpts.sendEmail).toBe(true);
     });
+
+    it('subtracts credit_applied from final_price on payment_pending rows (C3 — no over-billing)', async () => {
+      // Regression: a partially-covered RDV re-swept after a failed email was
+      // delegated with amountDueCents = final_price (6000) — re-charging the
+      // patient for the 2000 cents already covered by the avoir.
+      const appt = makeAppt({
+        id: 'appt-partial-credit',
+        status: 'payment_pending',
+        final_price: 6000,
+        credit_applied: 2000,
+      });
+      supabaseState.selectResults.push({ ...EMPTY_RESULT, data: [appt] });
+
+      await handler();
+
+      expect(notifications.processAppointmentSideEffects).toHaveBeenCalledTimes(
+        1,
+      );
+      const [, calledOpts] =
+        notifications.processAppointmentSideEffects.mock.calls[0];
+      expect(calledOpts.amountDueCents).toBe(4000);
+    });
+
+    it('injects signingSecret (process.env.BETTER_AUTH_SECRET) into the delegation (C2)', async () => {
+      // The pipeline's S3 signs an .ics invite token; in this pure-Node runtime
+      // createSecureLinkToken cannot fall back to import.meta.env — the sweep
+      // MUST hand over the secret or the email step throws for every row.
+      const appt = makeAppt();
+      supabaseState.selectResults.push({ ...EMPTY_RESULT, data: [appt] });
+
+      await handler();
+
+      const [, calledOpts] =
+        notifications.processAppointmentSideEffects.mock.calls[0];
+      expect(calledOpts.signingSecret).toBe(
+        'test-secret-that-is-long-enough-32-chars-min',
+      );
+    });
+
+    it('aborts without delegating when BETTER_AUTH_SECRET is missing or too short (C2)', async () => {
+      // Parity with reconcile-confirmations.ts: fail fast with a clear log
+      // rather than signing every swept row with a broken secret.
+      vi.stubEnv('BETTER_AUTH_SECRET', '');
+      const appt = makeAppt();
+      supabaseState.selectResults.push({ ...EMPTY_RESULT, data: [appt] });
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await handler();
+
+      expect(notifications.processAppointmentSideEffects).not.toHaveBeenCalled();
+      errorSpy.mockRestore();
+    });
   });
 
   describe('GOOGLE_CALENDAR_MOCK=true (dev-only calendar skip)', () => {

--- a/tests/unit/reconcile-invitations.test.ts
+++ b/tests/unit/reconcile-invitations.test.ts
@@ -13,12 +13,15 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 //   2. Sentry wiring: `initSentry()` BEFORE `Sentry.withMonitor(
 //      'reconcile-invitations', …, { checkInMargin: 5, maxRuntime: 10 })`
 //      (patterns #75/#113).
-//   3. Constants: DEADLINE_MS = 8500, BATCH_LIMIT = 25, 48 h created_at window.
+//   3. Constants: DEADLINE_MS = 8500, BATCH_LIMIT = 25, 24 h created_at window
+//      (W3: bounded to the ~24h TTL of the Resend L1 dedup key).
 //   4. Eligibility query on `appointments` — every filter asserted on the
 //      mock query chain (see the payment_received deviation note below).
-//   5. Per-row DELEGATION to `processAppointmentSideEffects(appt, opts)` with
-//      `sendEmail: true` and `amountDueCents: 0` for payment_received (avoir)
-//      else `final_price` (cents).
+//   5. Per-row ATOMIC CLAIM (W2, claimInvitationProcessing) then DELEGATION
+//      to `processAppointmentSideEffects(appt, opts)` with `sendEmail: true`
+//      and `amountDueCents: 0` for payment_received (avoir) else
+//      `final_price` (cents). A row whose claim returns no line is skipped
+//      (counted as `claimed`, neither reconciled nor failed).
 //   6. GOOGLE_CALENDAR_MOCK=true → injected no-op createCalendarEvent that
 //      console.warns; the real calendar module is never called; the rest of
 //      the per-row reconciliation continues.
@@ -80,6 +83,7 @@ interface RecordedChain {
   inFilters: Array<[string, unknown[]]>;
   isFilters: Array<[string, unknown]>;
   gtFilters: Array<[string, unknown]>;
+  orFilters: string[];
   orders: Array<[string, { ascending: boolean }]>;
   limits: number[];
   updates: RecordedUpdate[];
@@ -91,6 +95,10 @@ const supabaseState = vi.hoisted(() => {
     // Queue of PostgrestResponse payloads handed to SELECT-chain awaits
     // (consumed FIFO by the thenable terminal; default = empty result).
     selectResults: [] as unknown[],
+    // Queue of payloads handed to UPDATE-chain awaits (W2 claims, poison
+    // escapes…). Default = successful claim ({ data: [{ id }] }) so the
+    // per-row claim passes unless a test overrides it.
+    updateResults: [] as unknown[],
   };
   return state;
 });
@@ -102,6 +110,7 @@ const supabaseFrom = vi.fn((table: string) => {
     inFilters: [],
     isFilters: [],
     gtFilters: [],
+    orFilters: [],
     orders: [],
     limits: [],
     updates: [],
@@ -116,7 +125,10 @@ const supabaseFrom = vi.fn((table: string) => {
       reject: (e: unknown) => void,
     ) => {
       const result = isUpdateChain
-        ? { ...EMPTY_RESULT }
+        ? (supabaseState.updateResults.shift() ?? {
+            ...EMPTY_RESULT,
+            data: [{ id: 'claimed' }],
+          })
         : (supabaseState.selectResults.shift() ?? { ...EMPTY_RESULT });
       Promise.resolve(result).then(resolve, reject);
       return chain;
@@ -139,6 +151,11 @@ const supabaseFrom = vi.fn((table: string) => {
     return chain;
   });
   chain.neq = vi.fn(() => chain);
+  chain.or = vi.fn((filter: string) => {
+    // W2: the per-row claim guards its update with `.or('invitation_claimed_at.is.null,…')`.
+    record.orFilters.push(filter);
+    return chain;
+  });
   chain.gt = vi.fn((col: string, value: unknown) => {
     record.gtFilters.push([col, value]);
     return chain;
@@ -290,6 +307,7 @@ function resetMocks(): void {
   supabaseFrom.mockClear();
   supabaseState.chains.length = 0;
   supabaseState.selectResults.length = 0;
+  supabaseState.updateResults.length = 0;
   resendSend.mockClear();
   resendSend.mockResolvedValue({ data: { id: 're_123' }, error: null });
   notifications.processAppointmentSideEffects.mockClear();
@@ -396,16 +414,18 @@ describe('reconcile-invitations cron handler (T13 contract)', () => {
       expect(chain!.isFilters).toContainEqual(['invitation_sent_at', null]);
       expect(chain!.isFilters).toContainEqual(['deleted_at', null]);
 
-      // created_at > now − 48 h (tolerance for the awaited call duration).
+      // created_at > now − 24 h (W3: window bounded to the ~24h TTL of the
+      // Resend L1 idempotency key — beyond, a replay would not be deduplicated
+      // and could re-send the invitation). Tolerance for the awaited duration.
       const createdFilter = chain!.gtFilters.find(
         ([col]) => col === 'created_at',
       );
       expect(createdFilter).toBeDefined();
       const createdValue = new Date(createdFilter![1] as string).getTime();
       expect(createdValue).toBeGreaterThanOrEqual(
-        before - 48 * 3_600_000 - 5_000,
+        before - 24 * 3_600_000 - 5_000,
       );
-      expect(createdValue).toBeLessThanOrEqual(after - 48 * 3_600_000 + 5_000);
+      expect(createdValue).toBeLessThanOrEqual(after - 24 * 3_600_000 + 5_000);
 
       // scheduled_at > now (only upcoming appointments).
       const scheduledFilter = chain!.gtFilters.find(
@@ -423,6 +443,32 @@ describe('reconcile-invitations cron handler (T13 contract)', () => {
   });
 
   describe('per-row delegation to processAppointmentSideEffects', () => {
+    it('skips a row whose claim returns no line and continues with the batch (W2)', async () => {
+      // W2: the claim update returns ZERO rows for the first appointment
+      // (already claimed by the POST waitUntil pipeline within the 10 min
+      // lease) → NO delegation for that row (a second pipeline would create a
+      // duplicate Google event + Stripe Payment Link), and the batch moves on.
+      const rows = [
+        makeAppt({ id: 'appt-claimed' }),
+        makeAppt({ id: 'appt-free' }),
+      ];
+      supabaseState.selectResults.push({ ...EMPTY_RESULT, data: rows });
+      // Claim results, FIFO per row: row 1 already claimed, row 2 free.
+      supabaseState.updateResults.push(
+        { ...EMPTY_RESULT, data: [] },
+        { ...EMPTY_RESULT, data: [{ id: 'appt-free' }] },
+      );
+
+      await handler();
+
+      expect(notifications.processAppointmentSideEffects).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(
+        notifications.processAppointmentSideEffects.mock.calls[0][0].id,
+      ).toBe('appt-free');
+    });
+
     it('delegates each row with sendEmail:true and amountDueCents = final_price (cents)', async () => {
       const appt = makeAppt({ id: 'appt-unpaid', status: 'payment_pending' });
       supabaseState.selectResults.push({ ...EMPTY_RESULT, data: [appt] });
@@ -564,6 +610,10 @@ describe('reconcile-invitations cron handler (T13 contract)', () => {
         appointmentId: appt.id,
       });
       expect(calResult).toBeDefined();
+      // W4: the no-op produces NO exploitable eventId (the old
+      // `calendar-mock-${Date.now()}` contract is deliberately dropped — a
+      // fake persisted id locked the S1 skip forever).
+      expect(calResult.eventId).toBeNull();
       expect(warnSpy).toHaveBeenCalled();
 
       // …and the REAL calendar module is never called.
@@ -574,6 +624,51 @@ describe('reconcile-invitations cron handler (T13 contract)', () => {
       expect(resendSend).toHaveBeenCalled();
 
       warnSpy.mockRestore();
+    });
+
+    it('never persists a calendar event id in mock mode (W4 — no calendar-mock-* payloads)', async () => {
+      // End-to-end regression: delegate to the REAL pipeline so the actual
+      // S1 skip-without-persistence logic runs against the injected no-op.
+      process.env.GOOGLE_CALENDAR_MOCK = 'true';
+      const actual = await vi.importActual<
+        typeof import('../../src/lib/notifications')
+      >('../../src/lib/notifications');
+      notifications.processAppointmentSideEffects.mockImplementationOnce(
+        actual.processAppointmentSideEffects,
+      );
+      const appt = makeAppt();
+      supabaseState.selectResults.push({ ...EMPTY_RESULT, data: [appt] });
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await handler();
+
+      // No update payload carries a calendar event id (nor any calendar-mock-*
+      // value) — S1 treated the no-op result as a skip WITHOUT persistence.
+      const allUpdatePayloads = supabaseState.chains.flatMap(c =>
+        c.updates.map(u => u.payload),
+      );
+      expect(allUpdatePayloads.length).toBeGreaterThan(0); // claim + flags ran
+      for (const payload of allUpdatePayloads) {
+        expect(JSON.stringify(payload)).not.toMatch(/calendar-mock-/);
+        expect(payload).not.toHaveProperty('google_calendar_event_id');
+      }
+      // The real pipeline logged the calendar step as `skipped`…
+      const calLog = infoSpy.mock.calls
+        .filter(call => call[0] === '[side-effects]')
+        .map(call => call[1] as { step?: string; status?: string })
+        .find(entry => entry.step === 'calendar');
+      expect(calLog?.status).toBe('skipped');
+      // …and the row was still fully reconciled (email delivered, flags set).
+      expect(resendSend).toHaveBeenCalled();
+      expect(
+        allUpdatePayloads.filter(p => 'invitation_sent_at' in p),
+      ).toHaveLength(1);
+
+      warnSpy.mockRestore();
+      infoSpy.mockRestore();
+      errorSpy.mockRestore();
     });
   });
 

--- a/tests/unit/reconcile-invitations.test.ts
+++ b/tests/unit/reconcile-invitations.test.ts
@@ -294,7 +294,6 @@ function resetMocks(): void {
   notifications.processAppointmentSideEffects.mockClear();
   // Keep the default delegation implementation unless a test overrides it.
   notifications.processAppointmentSideEffects.mockImplementation(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     notifications.processAppointmentSideEffects.getMockImplementation()!,
   );
   googleCalendar.createCalendarEvent.mockClear();

--- a/tests/unit/reconcile-invitations.test.ts
+++ b/tests/unit/reconcile-invitations.test.ts
@@ -155,12 +155,10 @@ const supabaseFrom = vi.fn((table: string) => {
     record.updates[record.updates.length - 1]?.iss.push([col, value]);
     return chain;
   });
-  chain.order = vi.fn(
-    (col: string, opts: { ascending: boolean }) => {
-      record.orders.push([col, opts]);
-      return chain;
-    },
-  );
+  chain.order = vi.fn((col: string, opts: { ascending: boolean }) => {
+    record.orders.push([col, opts]);
+    return chain;
+  });
   chain.limit = vi.fn((n: number) => {
     record.limits.push(n);
     return chain;
@@ -226,10 +224,13 @@ const notifications = vi.hoisted(() => ({
     },
   ),
 }));
-vi.mock('../../src/lib/notifications', async (importOriginal) => {
+vi.mock('../../src/lib/notifications', async importOriginal => {
   const actual =
     await importOriginal<typeof import('../../src/lib/notifications')>();
-  return { ...actual, processAppointmentSideEffects: notifications.processAppointmentSideEffects };
+  return {
+    ...actual,
+    processAppointmentSideEffects: notifications.processAppointmentSideEffects,
+  };
 });
 
 // --- google-calendar mock — must NEVER be called (the sweep injects its own
@@ -375,7 +376,7 @@ describe('reconcile-invitations cron handler (T13 contract)', () => {
       const after = Date.now();
 
       const chain = supabaseState.chains.find(
-        (c) => c.select.length > 0 && c.updates.length === 0,
+        c => c.select.length > 0 && c.updates.length === 0,
       );
       expect(chain).toBeDefined();
       expect(chain!.table).toBe('appointments');
@@ -401,7 +402,9 @@ describe('reconcile-invitations cron handler (T13 contract)', () => {
       );
       expect(createdFilter).toBeDefined();
       const createdValue = new Date(createdFilter![1] as string).getTime();
-      expect(createdValue).toBeGreaterThanOrEqual(before - 48 * 3_600_000 - 5_000);
+      expect(createdValue).toBeGreaterThanOrEqual(
+        before - 48 * 3_600_000 - 5_000,
+      );
       expect(createdValue).toBeLessThanOrEqual(after - 48 * 3_600_000 + 5_000);
 
       // scheduled_at > now (only upcoming appointments).
@@ -414,10 +417,7 @@ describe('reconcile-invitations cron handler (T13 contract)', () => {
       expect(scheduledValue).toBeLessThanOrEqual(after + 5_000);
 
       // Oldest first + bounded batch.
-      expect(chain!.orders).toContainEqual([
-        'created_at',
-        { ascending: true },
-      ]);
+      expect(chain!.orders).toContainEqual(['created_at', { ascending: true }]);
       expect(chain!.limits).toContainEqual(25);
     });
   });
@@ -442,7 +442,7 @@ describe('reconcile-invitations cron handler (T13 contract)', () => {
       expect(calledOpts.amountDueCents).toBe(6000);
     });
 
-    it("delegates payment_received (avoir) rows with amountDueCents: 0 — no re-charge", async () => {
+    it('delegates payment_received (avoir) rows with amountDueCents: 0 — no re-charge', async () => {
       const appt = makeAppt({ id: 'appt-avoir', status: 'payment_received' });
       supabaseState.selectResults.push({ ...EMPTY_RESULT, data: [appt] });
 
@@ -469,9 +469,9 @@ describe('reconcile-invitations cron handler (T13 contract)', () => {
 
       await handler();
 
-      expect(
-        notifications.processAppointmentSideEffects,
-      ).toHaveBeenCalledTimes(1);
+      expect(notifications.processAppointmentSideEffects).toHaveBeenCalledTimes(
+        1,
+      );
       const [, opts] =
         notifications.processAppointmentSideEffects.mock.calls[0];
       expect(typeof opts.createCalendarEvent).toBe('function');
@@ -514,7 +514,7 @@ describe('reconcile-invitations cron handler (T13 contract)', () => {
       await handler();
 
       const flagUpdate = supabaseState.chains
-        .flatMap((c) => c.updates.map((u) => ({ chain: c, update: u })))
+        .flatMap(c => c.updates.map(u => ({ chain: c, update: u })))
         .find(({ update }) => 'invitation_sent_at' in update.payload);
       expect(flagUpdate).toBeDefined();
       expect(flagUpdate!.update.eqs).toContainEqual(['id', appt.id]);
@@ -540,18 +540,15 @@ describe('reconcile-invitations cron handler (T13 contract)', () => {
       await handler();
 
       const flagUpdate = supabaseState.chains
-        .flatMap((c) => c.updates.map((u) => u.payload))
-        .find((payload) => 'invitation_sent_at' in payload);
+        .flatMap(c => c.updates.map(u => u.payload))
+        .find(payload => 'invitation_sent_at' in payload);
       expect(flagUpdate).toBeUndefined();
     });
   });
 
   describe('deadline (DEADLINE_MS = 8500)', () => {
     it('stops the loop at the deadline — remaining rows deferred to the next pass', async () => {
-      const rows = [
-        makeAppt({ id: 'appt-a' }),
-        makeAppt({ id: 'appt-b' }),
-      ];
+      const rows = [makeAppt({ id: 'appt-a' }), makeAppt({ id: 'appt-b' })];
       supabaseState.selectResults.push({ ...EMPTY_RESULT, data: rows });
 
       // Fake the wall clock: while processing the FIRST row, time jumps past
@@ -606,9 +603,7 @@ describe('reconcile-invitations cron handler (T13 contract)', () => {
           message: 'Invalid "to" address',
         },
       });
-      const errorSpy = vi
-        .spyOn(console, 'error')
-        .mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
       await handler();
 

--- a/tests/unit/reconcile-invitations.test.ts
+++ b/tests/unit/reconcile-invitations.test.ts
@@ -589,6 +589,47 @@ describe('reconcile-invitations cron handler (T13 contract)', () => {
     });
   });
 
+  describe('admin BCC parity (makeSendFnWithCapture vs sendEmail)', () => {
+    // Recette 2026-08-30 : les emails de rattrapage partaient sans la copie
+    // thérapeute — le BCC ADMIN_EMAIL est un invariant de transport de
+    // sendEmail (resend.ts) que le wrapper DI doit répliquer.
+    it('BCCs ADMIN_EMAIL on rattrapage emails (parity with sendEmail)', async () => {
+      vi.stubEnv('ADMIN_EMAIL', 'therapeute@omf-therapie.fr');
+      const appt = makeAppt({ patient_email: 'patient@example.com' });
+      supabaseState.selectResults.push({ ...EMPTY_RESULT, data: [appt] });
+
+      await handler();
+
+      expect(resendSend).toHaveBeenCalledTimes(1);
+      const payload = resendSend.mock.calls[0][0];
+      expect(payload.to).toEqual(['patient@example.com']);
+      expect(payload.bcc).toEqual(['therapeute@omf-therapie.fr']);
+    });
+
+    it('adds no bcc when ADMIN_EMAIL is empty', async () => {
+      vi.stubEnv('ADMIN_EMAIL', '');
+      const appt = makeAppt({ patient_email: 'patient@example.com' });
+      supabaseState.selectResults.push({ ...EMPTY_RESULT, data: [appt] });
+
+      await handler();
+
+      const payload = resendSend.mock.calls[0][0];
+      expect(payload.bcc).toBeUndefined();
+    });
+
+    it('does not duplicate the admin when they are already the recipient', async () => {
+      vi.stubEnv('ADMIN_EMAIL', 'therapeute@omf-therapie.fr');
+      const appt = makeAppt({ patient_email: 'Therapeute@OMF-Therapie.fr' });
+      supabaseState.selectResults.push({ ...EMPTY_RESULT, data: [appt] });
+
+      await handler();
+
+      const payload = resendSend.mock.calls[0][0];
+      expect(payload.to).toEqual(['therapeute@omf-therapie.fr']);
+      expect(payload.bcc).toBeUndefined();
+    });
+  });
+
   describe('GOOGLE_CALENDAR_MOCK=true (dev-only calendar skip)', () => {
     it('injects a console.warn-ing no-op calendar fn, never touches the real module, and still reconciles the row', async () => {
       process.env.GOOGLE_CALENDAR_MOCK = 'true';

--- a/tests/unit/stripe-webhook.test.ts
+++ b/tests/unit/stripe-webhook.test.ts
@@ -53,7 +53,7 @@ vi.mock('@/lib/pricing', () => ({
 }));
 
 // Mock stripe (imported at module level but not used by handlePaymentSucceeded).
-vi.mock('@/lib/stripe', () => ({ stripe: {} }));
+vi.mock('@/lib/stripe', () => ({ getStripe: () => null }));
 
 // --- Import after mocks -----------------------------------------------------
 

--- a/tests/unit/stripe-webhook.test.ts
+++ b/tests/unit/stripe-webhook.test.ts
@@ -180,5 +180,19 @@ describe('handlePaymentSucceeded — mark delivered on success', () => {
     // The last .is() call should be the confirmation_sent_at IS NULL guard.
     const isCalls = mockSupabaseChain.is.mock.calls;
     expect(isCalls.some((call) => call[0] === 'confirmation_sent_at')).toBe(true);
+
+    // C5 (issue #126): the mark-delivered update carries BOTH flags in the
+    // SAME payload — the post-payment confirmation email doubles as the
+    // invitation, so invitation_sent_at must be set together with
+    // confirmation_sent_at or the reconcile-invitations sweep would re-mail
+    // the patient.
+    const flagPayloads = mockSupabaseChain.update.mock.calls
+      .map((call) => call[0] as Record<string, unknown>)
+      .filter((payload) => 'confirmation_sent_at' in payload);
+    expect(flagPayloads).toHaveLength(1);
+    expect(typeof flagPayloads[0]!.invitation_sent_at).toBe('string');
+    expect(flagPayloads[0]!.invitation_sent_at).toBe(
+      flagPayloads[0]!.confirmation_sent_at,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- `POST /api/admin/appointments/` répond **201 dès l'INSERT** (plus aucun appel Google/Stripe/Resend dans la fenêtre synchrone → fini les 504 Netlify à ~10 s) ; agenda → lien Stripe → email patient s'exécutent en post-réponse via `locals.netlify.context.waitUntil` (repli inline best-effort), avec log par étape `[side-effects] {step, appointmentId, ms, status}`.
- **Drapeaux L2 `invitation_sent_at`** (set-once `WHERE … IS NULL`) posés après l'email réussi (+ `confirmation_sent_at` si `payment_received` par avoir) ; `send_email=false` → flag posé à l'INSERT, aucun email jamais.
- **Backstop horaire** `reconcile-invitations` (`'20 * * * *'`, monitor Sentry dédié, deadline 8,5 s, batch 25) : rattrape ≤ 1 h tout RDV (fenêtre 48 h, à venir) dont le post-réponse a échoué — même clé L1 `invite:{id}:patient` que le POST (zéro doublon Resend), poison-escape 4xx, isolation par row, logs sans PII.
- Refactors requis par le runtime cron (Node pur, `process.env` seul) : `stripe.ts` lazy-init (miroir `resend.ts` #98), `google-calendar.ts` accesseurs env + seam DI.
- Modal admin : 5xx/erreur réseau → « La création a peut-être abouti — vérifiez la liste des rendez-vous avant de retenter. » (4xx inchangé).
- Migrations : `012_credits_grants.sql` (versionne le hotfix prod 42501 du 2026-08-28) et `013_invitation_sent_at.sql` (colonne + backfill **sans filtre** + index partiel).

**Écarts assumés** (documentés dans les tests) : `payment_received` ajouté à l'éligibilité du sweep (spec §5 listait `confirmed|payment_pending`) pour que SC3 tienne pour les RDV payés par avoir ; dispatch du pipeline via macrotask (`setImmediate`) pour garantir contractuellement zéro appel externe avant le 201.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #126: fix(admin): création RDV 504 — traitement post-INSERT + rattrapage automatique des invitations | OPEN |
| Spec | [126-admin-appointments-504-rework-spec.mdx](artifacts/specs/126-admin-appointments-504-rework-spec.mdx) | Present |
| Implementation | 11 commits sur `feat/126-admin-appointments-504-rework` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (25 nouveaux) Build ✅ | Passed |

## Test Plan
- [ ] **Runbook déploiement (ordre corrigé par la revue)** : appliquer **012, 013 puis 014 AVANT de déployer** (014 = colonne invitation_claimed_at, additive) (012 est un no-op — hotfix déjà appliqué en prod ; l'ordre inversé casserait `send_email=false` : l'INSERT référence `invitation_sent_at` → PGRST204 → 500). Juste APRÈS le déploiement, re-jouer le backfill 013 (`UPDATE … WHERE invitation_sent_at IS NULL`) pour couvrir la fenêtre migration→déploiement. Le backfill sans filtre garantit **zéro email de rattrapage** aux RDV existants. **Ne jamais reset les drapeaux** ; une écriture de flag en échec est non fatale (loggée).
- [ ] Créer un RDV vidéo admin → 201 rapide en modal, puis email patient + event agenda + lien Stripe (logs `[side-effects]` dans Netlify).
- [ ] Créer un RDV `send_email` décoché → aucun email jamais, `invitation_sent_at` posé à l'INSERT.
- [ ] Simuler un échec post-réponse (ex. couper `RESEND_API_KEY`) → le sweep :20 rattrape le RDV à l'heure suivante (monitor Sentry `reconcile-invitations`).
- [ ] 504 simulé (timeout) → modal affiche « La création a peut-être abouti… ».

## SC → Test Matrix

| SC | Test(s) | Status |
|----|---------|--------|
| SC1: 201 post-INSERT sans appel externe | `admin-appointments-post.test.ts :: responds 201 without touching calendar/stripe/email, then runs the pipeline via waitUntil` | ✓ proven |
| SC2: happy path — email reçu + event agenda | `admin-appointments-post.test.ts :: sets invitation_sent_at via an UPDATE after sendEmail succeeds`, `admin-appointment-side-effects.test.ts :: runs calendar, then stripe, then email in order` | ✓ proven |
| SC3: sweep complète le RDV, zéro doublon (L1 partagée + garde `IS NULL`) | `admin-appointment-side-effects.test.ts :: passes the idempotency key invite:{id}:patient`, `:: sets invitation_sent_at and confirmation_sent_at together`, `reconcile-invitations.test.ts :: delegation` | ✓ proven |
| SC4: aucun RDV à venir ne reste NULL ; `send_email=false` jamais emailé | `reconcile-invitations.test.ts :: filters on status/flags/window/future`, `admin-appointments-post.test.ts :: …never calls sendEmail when send_email is false` | ✓ proven |
| SC5: migrations 012/013 idempotentes, backfill sans filtre | — | ⚠ NO TEST — infra-not-wired (SQL non exécuté en CI ; revue + runbook) |
| SC6: log par étape + fonction séparée + monitor + deadline dédiés | `admin-appointment-side-effects.test.ts :: logs`, `reconcile-invitations.test.ts :: monitor wiring / deadline` | ✓ proven |
| SC7: modal « peut-être abouti » sur ≥500/réseau | — | ⚠ NO TEST — ui-manual-only |
| SC8: aucun email de rattrapage post-déploiement, flags non fatals | — | ⚠ NO TEST — out-of-scope (garanties runbook, vérifiées à la validation) |

Falsification (implémentation retirée → rouge, restaurée → vert, pour les 3 fichiers de tests) : endpoint POST, `notifications.ts`, fonction sweep — aucun test tautologique.

Fixes #126

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`


