### PR TITLE
fix(security): verrouille le webhook mock hors développement

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -42,8 +42,9 @@ STRIPE_PUBLISHABLE_KEY=pk_test_REMPLACER_PAR_VOTRE_CLE_TEST
 # Généré par : stripe listen --forward-to localhost:4321/api/stripe-webhook
 STRIPE_WEBHOOK_SECRET=whsec_GENERE_PAR_STRIPE_CLI
 STRIPE_SUCCESS_URL=http://localhost:4321/rdv/merci
-# Capacité locale requise par le tunnel mock. Générer avec : openssl rand -hex 32
-MOCK_WEBHOOK_TOKEN=remplacer-par-un-token-aleatoire-local
+# Capacité locale requise par le tunnel mock : exécuter `openssl rand -hex 32`,
+# puis coller le résultat ci-dessous avant de tester un paiement simulé.
+MOCK_WEBHOOK_TOKEN=
 
 # ── Google Calendar (mode mock) ───────────────────────────────────────────────
 # Active les créneaux factices dans src/lib/google-calendar.ts

--- a/.env.local.example
+++ b/.env.local.example
@@ -42,6 +42,8 @@ STRIPE_PUBLISHABLE_KEY=pk_test_REMPLACER_PAR_VOTRE_CLE_TEST
 # Généré par : stripe listen --forward-to localhost:4321/api/stripe-webhook
 STRIPE_WEBHOOK_SECRET=whsec_GENERE_PAR_STRIPE_CLI
 STRIPE_SUCCESS_URL=http://localhost:4321/rdv/merci
+# Capacité locale requise par le tunnel mock. Générer avec : openssl rand -hex 32
+MOCK_WEBHOOK_TOKEN=remplacer-par-un-token-aleatoire-local
 
 # ── Google Calendar (mode mock) ───────────────────────────────────────────────
 # Active les créneaux factices dans src/lib/google-calendar.ts

--- a/aidd_docs/memory/coding-assertions.md
+++ b/aidd_docs/memory/coding-assertions.md
@@ -1,0 +1,21 @@
+# Coding Assertions
+
+## Before commit
+
+| Order | Command | Checks |
+| --- | --- | --- |
+| 1 | `npm run lint` | ESLint rules |
+| 2 | `npm run test` | Unit and integration behavior |
+
+When running these assertions through WSL automation, use the sequential, mono-worker commands in `testing.md`; do not launch gates in parallel.
+
+## Before push
+
+| Order | Command | Checks |
+| --- | --- | --- |
+| 1 | `npm run typecheck` | Astro and TypeScript types |
+| 2 | `npm run build` | Production static build |
+
+## UI changes
+
+- Run `npm run audit:a11y` with the development server running; WCAG 2.1 AA is required.

--- a/aidd_docs/memory/testing.md
+++ b/aidd_docs/memory/testing.md
@@ -1,0 +1,58 @@
+# Testing
+
+## Strategy
+
+- Vitest covers unit and integration-level server and domain behavior in `tests/unit/`.
+- Playwright covers key browser flows in `e2e/`.
+- Pa11y audits accessibility; UI changes require the audit.
+
+## Tools
+
+- Vitest runs in Node and uses a shared setup file.
+- Playwright uses the local Astro site.
+
+## Conventions
+
+- Name unit tests `*.test.ts` under `tests/unit/`.
+- Keep reusable appointment eligibility logic pure and test it directly.
+
+## Run
+
+- `npm run test`
+- `npx playwright test`
+- `npm run audit:a11y`
+
+## WSL-safe validation
+
+- Use the Linux Node runtime declared by `.nvmrc` for every Node/npm command. The reliable one-shot form is `~/.local/share/fnm/fnm exec --using="$(cat .nvmrc)" <command>`.
+- Never use a Windows `node` or `npm` resolved through `/mnt/<drive>/...` from WSL. On a UNC worktree it can fall back to `C:\Windows`, break relative scripts, and leave a partial `node_modules` installation.
+- In a new worktree, run `tools/worktree-setup.sh` once through `fnm`. Do not overlap `npm install` or `npm ci` processes; if an install is interrupted, repair the dependency tree before validation.
+- Run quality gates sequentially, never concurrently. Check `free -h` before increasing a Node heap limit.
+- Run Vitest with one worker and no file/test parallelism:
+
+  ```bash
+  NODE_OPTIONS=--max-old-space-size=1024 \
+    ~/.local/share/fnm/fnm exec --using="$(cat .nvmrc)" \
+    npm run test -- --pool=threads --maxWorkers=1 --no-file-parallelism --maxConcurrency=1
+  ```
+
+- Astro Check needs more heap than the test suite in this project. Run it alone with a bounded 3 GiB heap:
+
+  ```bash
+  NODE_OPTIONS=--max-old-space-size=3072 \
+    ~/.local/share/fnm/fnm exec --using="$(cat .nvmrc)" npm run typecheck
+  ```
+
+- Run the production build separately with a bounded 2 GiB heap:
+
+  ```bash
+  NODE_OPTIONS=--max-old-space-size=2048 \
+    ~/.local/share/fnm/fnm exec --using="$(cat .nvmrc)" npm run build
+  ```
+
+- A Node heap-limit failure is not a code diagnostic. Record it as an environment failure, adjust only after checking available memory, and rerun the affected gate alone.
+
+## Browser QA
+
+- Entry: `http://localhost:4321` after `npm run dev`.
+- State: local Docker services and the documented Google Calendar and Stripe mocks support deterministic development.

--- a/aidd_docs/tasks/2026_08/2026_08_28_pr_128_review_fixes/phase-1.md
+++ b/aidd_docs/tasks/2026_08/2026_08_28_pr_128_review_fixes/phase-1.md
@@ -1,0 +1,96 @@
+---
+status: done
+---
+
+# Instruction: Authorize and verify local mock payments
+
+## Architecture projection
+
+> Tree of the final files. ✅ create · ✏️ modify · ❌ delete
+
+```txt
+.
+├── .env.local.example                         ✏️ document the required local-only token
+├── docs/LOCAL_DEV.md                          ✏️ document generation and scope of the token
+├── src/env.d.ts                               ✏️ type the optional server-only token
+├── src/lib/mock-mode.server.ts                ✅ centralize dev gates, loopback checks, and constant-time token validation
+├── src/lib/calendar-cache.ts                  ✏️ fail closed outside Astro development
+├── src/lib/google-calendar.ts                 ✏️ fail closed outside Astro development
+├── src/lib/stripe.ts                          ✏️ include the capability in generated local mock redirects
+├── src/pages/api/stripe-webhook.ts            ✏️ authorize each mock GET before processing
+├── src/pages/rdv/merci.astro                  ✏️ authorize, bound, and verify the local mock callback
+├── tests/unit/mock-mode.test.ts               ✅ cover the shared security predicate
+└── tests/unit/stripe-webhook.test.ts          ✏️ cover success, 400, 403, and 500 branches
+```
+
+## User Journey
+
+```mermaid
+flowchart TD
+  A[Local Stripe mock redirect] --> B{DEV + calendar mock + loopback + valid token}
+  B -- No --> C[Reject without payment effects or success claim]
+  B -- Yes --> D[Call mock webhook with capability header]
+  D --> E{Webhook response successful?}
+  E -- No --> F[Log bounded failure and avoid mock success claim]
+  E -- Yes --> G[Show payment success]
+```
+
+## Test Scope
+
+```mermaid
+---
+title: Test scope
+---
+journey
+  section Setup
+    Stub local development flags and token => isolated mock route ready: 5: api
+  section Happy path
+    Send loopback request with valid capability and parameters => payment handler returns 200 with deterministic mock identifiers: 5: api
+  section Edge case - Unauthorized
+    Omit or alter a gate or capability => request returns 403 without side effects: 5: api
+  section Edge case - Invalid parameters
+    Send authorized request without mock flag or appointment id => request returns the matching 400 without side effects: 3: api
+  section Edge case - Handler failure
+    Force payment processing failure => request returns bounded JSON 500: 3: api
+```
+
+## Tasks to do
+
+### `1)` Centralize local mock authorization
+
+> Make every mock activation fail closed unless it is explicitly local development.
+
+1. Add a server-only helper for the development flag, loopback host, and constant-time token comparison.
+2. Apply the development predicate to calendar mock readers.
+3. Document and type the local-only token without adding it to production configuration.
+
+### `2)` Protect the mock payment journey
+
+> Require a capability on both the redirect page and webhook request.
+
+1. Add the configured token to local mock redirects.
+2. Require authorization before `merci.astro` triggers the webhook or claims mock success.
+3. Forward the capability in a header, enforce a timeout, and check the webhook response.
+4. Reject unauthorized webhook GET requests before parsing parameters or invoking effects.
+
+### `3)` Complete regression coverage
+
+> Prove the route remains usable locally and all error branches are stable.
+
+1. Cover the shared authorization predicate.
+2. Cover authorized success with deterministic IDs.
+3. Cover 403, both 400 branches, and the JSON 500 branch.
+4. Restore environment stubs after each test.
+
+## Test acceptance criteria
+
+| Task | Acceptance criteria |
+| --- | --- |
+| 1 | Calendar mocks are disabled whenever `import.meta.env.DEV` is false. |
+| 1 | A missing token, wrong token, or non-loopback hostname cannot authorize a mock payment request. |
+| 2 | A generated local mock payment link carries the configured capability, while production configuration remains unaware of it. |
+| 2 | The confirmation page claims mock success only after an authorized, successful, timeout-bounded webhook response. |
+| 2 | The webhook requires an authorized capability header before parsing mock parameters or performing side effects. |
+| 3 | The authorized happy path returns 200 and deterministic mock event/payment identifiers. |
+| 3 | Unauthorized, invalid-parameter, and handler-failure branches return their documented 403, 400, and 500 responses. |
+| 3 | Lint, typecheck, the complete unit suite, and the production build pass through the WSL-safe sequential workflow. |

--- a/aidd_docs/tasks/2026_08/2026_08_28_pr_128_review_fixes/plan.md
+++ b/aidd_docs/tasks/2026_08/2026_08_28_pr_128_review_fixes/plan.md
@@ -1,0 +1,26 @@
+---
+objective: "The local mock-payment journey requires an explicit request capability, remains usable in development, and has complete route coverage."
+status: in-progress
+---
+
+# Plan: Address PR 128 security review
+
+## Overview
+
+| Field | Value |
+| --- | --- |
+| **Goal** | Close the residual mock-payment authorization gap and prove every GET branch. |
+| **Source** | [PR #128 code-review comment](https://github.com/tavianm/omf-therapie/pull/128#issuecomment-5456323682) |
+
+## Phases
+
+| # | Phase | File |
+| --- | --- | --- |
+| 1 | Authorize and verify local mock payments | [`phase-1.md`](./phase-1.md) |
+
+## Decisions
+
+| Decision | Why |
+| --- | --- |
+| Require a local-only capability token and loopback host | `DEV` and an environment flag identify a mode, but do not authorize an individual mutating request or prevent localhost CSRF. |
+| Fail closed outside Astro development for every calendar mock reader | A leaked calendar flag must not activate fictional availability or bypass cache behavior in a deployed build. |

--- a/aidd_docs/tasks/2026_08/2026_08_28_pr_128_review_fixes/plan.md
+++ b/aidd_docs/tasks/2026_08/2026_08_28_pr_128_review_fixes/plan.md
@@ -1,6 +1,6 @@
 ---
 objective: "The local mock-payment journey requires an explicit request capability, remains usable in development, and has complete route coverage."
-status: implemented
+status: reviewed
 ---
 
 # Plan: Address PR 128 security review

--- a/aidd_docs/tasks/2026_08/2026_08_28_pr_128_review_fixes/plan.md
+++ b/aidd_docs/tasks/2026_08/2026_08_28_pr_128_review_fixes/plan.md
@@ -1,6 +1,6 @@
 ---
 objective: "The local mock-payment journey requires an explicit request capability, remains usable in development, and has complete route coverage."
-status: in-progress
+status: implemented
 ---
 
 # Plan: Address PR 128 security review

--- a/aidd_docs/tasks/2026_08/2026_08_28_secure_mock_webhook/phase-1.md
+++ b/aidd_docs/tasks/2026_08/2026_08_28_secure_mock_webhook/phase-1.md
@@ -1,0 +1,67 @@
+---
+status: done
+---
+
+# Instruction: Gate and verify the mock webhook
+
+## Architecture projection
+
+> Tree of the final files. ✅ create · ✏️ modify · ❌ delete
+
+```txt
+.
+├── src/pages/api/stripe-webhook.ts       ✏️ require development mode for mock GET access
+└── tests/unit/stripe-webhook.test.ts    ✏️ cover the environment gate without running payment side effects
+```
+
+## User Journey
+
+```mermaid
+flowchart TD
+  A[Caller requests mock webhook GET] --> B{DEV and GOOGLE_CALENDAR_MOCK enabled?}
+  B -- No --> C[Return HTTP 403 without payment side effects]
+  B -- Yes --> D[Continue existing mock validation and payment flow]
+```
+
+## Test Scope
+
+```mermaid
+---
+title: Test scope
+---
+journey
+  section Setup
+    Mock webhook dependencies and environment => isolated route ready: 5: api
+  section Happy path
+    Disable development mode and enable calendar mock => GET request returns 403 without appointment mutation: 5: api
+  section Edge case - Calendar mock disabled
+    Enable development mode and disable calendar mock => GET request returns 403 without appointment mutation: 1: api
+```
+
+## Tasks to do
+
+### `1)` Enforce the development-only gate
+
+> Reject the mock GET route unless both required environment conditions are true.
+
+1. Combine `import.meta.env.DEV` with `GOOGLE_CALENDAR_MOCK` at the route boundary.
+2. Preserve the existing development mock flow and French API responses.
+3. Confirm the stale Stripe suppression is absent and keep the typed Stripe import.
+
+### `2)` Prove the route boundary
+
+> Add focused regression coverage and run the project validation commands.
+
+1. Exercise both disabled-environment branches through the exported GET handler.
+2. Assert payment persistence and notification side effects are not invoked.
+3. Run the focused test, lint, typecheck, test suite, and production build.
+
+## Test acceptance criteria
+
+| Task | Acceptance criteria |
+| ---- | ------------------- |
+| 1 | A request is rejected with HTTP 403 whenever development mode is false, even if the calendar mock flag is true. |
+| 1 | A request is rejected with HTTP 403 whenever the calendar mock flag is false, even if development mode is true. |
+| 1 | The Stripe namespace import resolves without a TypeScript suppression. |
+| 2 | Rejected requests cause no appointment update, email, or calendar event. |
+| 2 | Existing Stripe webhook unit tests, lint, typecheck, and production build complete successfully. |

--- a/aidd_docs/tasks/2026_08/2026_08_28_secure_mock_webhook/plan.md
+++ b/aidd_docs/tasks/2026_08/2026_08_28_secure_mock_webhook/plan.md
@@ -1,0 +1,19 @@
+---
+objective: "The Stripe mock webhook GET route is unusable outside Vite development mode and remains type-safe."
+status: in-progress
+---
+
+# Plan: Secure the Stripe mock webhook
+
+## Overview
+
+| Field      | Value |
+| ---------- | ----- |
+| **Goal**   | Restrict the unauthenticated mock payment endpoint to explicit local development mode. |
+| **Source** | GitHub issue [#70](https://github.com/tavianm/omf-therapie/issues/70) |
+
+## Phases
+
+| #   | Phase | File |
+| --- | ----- | ---- |
+| 1   | Gate and verify the mock webhook | [`phase-1.md`](./phase-1.md) |

--- a/aidd_docs/tasks/2026_08/2026_08_28_secure_mock_webhook/plan.md
+++ b/aidd_docs/tasks/2026_08/2026_08_28_secure_mock_webhook/plan.md
@@ -1,6 +1,6 @@
 ---
 objective: "The Stripe mock webhook GET route is unusable outside Vite development mode and remains type-safe."
-status: in-progress
+status: implemented
 ---
 
 # Plan: Secure the Stripe mock webhook

--- a/aidd_docs/tasks/2026_08/2026_08_28_secure_mock_webhook/plan.md
+++ b/aidd_docs/tasks/2026_08/2026_08_28_secure_mock_webhook/plan.md
@@ -1,6 +1,6 @@
 ---
 objective: "The Stripe mock webhook GET route is unusable outside Vite development mode and remains type-safe."
-status: implemented
+status: reviewed
 ---
 
 # Plan: Secure the Stripe mock webhook

--- a/docs/LOCAL_DEV.md
+++ b/docs/LOCAL_DEV.md
@@ -137,8 +137,9 @@ STRIPE_SECRET_KEY=sk_test_placeholder
 STRIPE_PUBLISHABLE_KEY=pk_test_placeholder
 STRIPE_WEBHOOK_SECRET=whsec_placeholder
 STRIPE_SUCCESS_URL=http://localhost:4321/rdv/merci
-# Générer avec : openssl rand -hex 32 (local uniquement, ne pas configurer sur Netlify)
-MOCK_WEBHOOK_TOKEN=remplacer-par-un-token-aleatoire-local
+# Obligatoire pour le paiement mock : exécuter `openssl rand -hex 32`, puis coller le résultat.
+# Laisser vide désactive le callback mock. Variable locale uniquement, absente de Netlify.
+MOCK_WEBHOOK_TOKEN=
 
 # ── Google Calendar (mode mock) ──────────────────────────────────
 # true = créneaux fictifs les mercredis, aucun appel API Google
@@ -298,9 +299,10 @@ Vérifier `GOOGLE_CALENDAR_MOCK=true` dans `.env`. En mode mock, seuls les **mer
 ### Stripe — paiements non fonctionnels
 
 Avec `STRIPE_SECRET_KEY=sk_test_placeholder` (valeur par défaut), le mode **Stripe mock** est actif :
-- Générer une capacité locale avec `openssl rand -hex 32`, puis la renseigner dans
-  `MOCK_WEBHOOK_TOKEN`. Cette variable autorise uniquement le callback mock sur une
-  adresse de boucle locale en mode développement ; ne pas la configurer sur Netlify.
+- Avant tout paiement simulé, exécuter `openssl rand -hex 32` et coller le résultat
+  dans `MOCK_WEBHOOK_TOKEN`. La valeur vide fournie dans l'exemple désactive le
+  callback mock. Cette variable autorise uniquement une adresse de boucle locale en
+  mode développement ; ne pas la configurer sur Netlify.
 - La confirmation d'une téléconsultation passe en statut `payment_pending` et envoie un email de demande de paiement avec un **lien fictif** (pas de vrai appel Stripe).
 - Une fois « payé », le RDV passe en `payment_received` (statut unifié « réglé » — Stripe ou avoir, depuis #63/#66).
 - Aucune erreur 500 — le bypass est intentionnel pour le développement local.

--- a/docs/LOCAL_DEV.md
+++ b/docs/LOCAL_DEV.md
@@ -137,6 +137,8 @@ STRIPE_SECRET_KEY=sk_test_placeholder
 STRIPE_PUBLISHABLE_KEY=pk_test_placeholder
 STRIPE_WEBHOOK_SECRET=whsec_placeholder
 STRIPE_SUCCESS_URL=http://localhost:4321/rdv/merci
+# Générer avec : openssl rand -hex 32 (local uniquement, ne pas configurer sur Netlify)
+MOCK_WEBHOOK_TOKEN=remplacer-par-un-token-aleatoire-local
 
 # ── Google Calendar (mode mock) ──────────────────────────────────
 # true = créneaux fictifs les mercredis, aucun appel API Google
@@ -296,6 +298,9 @@ Vérifier `GOOGLE_CALENDAR_MOCK=true` dans `.env`. En mode mock, seuls les **mer
 ### Stripe — paiements non fonctionnels
 
 Avec `STRIPE_SECRET_KEY=sk_test_placeholder` (valeur par défaut), le mode **Stripe mock** est actif :
+- Générer une capacité locale avec `openssl rand -hex 32`, puis la renseigner dans
+  `MOCK_WEBHOOK_TOKEN`. Cette variable autorise uniquement le callback mock sur une
+  adresse de boucle locale en mode développement ; ne pas la configurer sur Netlify.
 - La confirmation d'une téléconsultation passe en statut `payment_pending` et envoie un email de demande de paiement avec un **lien fictif** (pas de vrai appel Stripe).
 - Une fois « payé », le RDV passe en `payment_received` (statut unifié « réglé » — Stripe ou avoir, depuis #63/#66).
 - Aucune erreur 500 — le bypass est intentionnel pour le développement local.

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -25,6 +25,8 @@ interface ImportMetaEnv {
   readonly GOOGLE_SERVICE_ACCOUNT_EMAIL?: string;
   readonly GOOGLE_PRIVATE_KEY?: string;
   readonly GOOGLE_CALENDAR_ID?: string;
+  /** Capability locale requise pour simuler un webhook de paiement en développement. */
+  readonly MOCK_WEBHOOK_TOKEN?: string;
 
   // Google OAuth (3-legged) for Meet link generation
   readonly GOOGLE_OAUTH_CLIENT_ID?: string;

--- a/src/lib/calendar-cache.ts
+++ b/src/lib/calendar-cache.ts
@@ -9,8 +9,8 @@
  */
 
 import type { TimeSlot } from './google-calendar.js';
+import { isCalendarMockEnabled } from './mock-mode.server.js';
 
-const MOCK_MODE = import.meta.env.GOOGLE_CALENDAR_MOCK === 'true';
 const STORE_NAME = 'calendar-availability';
 const DEFAULT_TTL_SECONDS = 600; // 10 minutes
 
@@ -18,13 +18,14 @@ const DEFAULT_TTL_SECONDS = 600; // 10 minutes
 // Singleton store promise — initialised once, reused across requests
 // ---------------------------------------------------------------------------
 
-let _storePromise: Promise<ReturnType<typeof import('@netlify/blobs')['getStore']> | null> | null =
-  null;
+let _storePromise: Promise<ReturnType<
+  (typeof import('@netlify/blobs'))['getStore']
+> | null> | null = null;
 
 async function getAvailabilityStore(): Promise<ReturnType<
-  typeof import('@netlify/blobs')['getStore']
+  (typeof import('@netlify/blobs'))['getStore']
 > | null> {
-  if (MOCK_MODE) return null;
+  if (isCalendarMockEnabled()) return null;
   if (_storePromise) return _storePromise;
   _storePromise = import('@netlify/blobs')
     .then(({ getStore }) => getStore(STORE_NAME))
@@ -45,7 +46,9 @@ interface CacheEntry {
 // Public API
 // ---------------------------------------------------------------------------
 
-export async function getCachedAvailability(key: string): Promise<TimeSlot[] | null> {
+export async function getCachedAvailability(
+  key: string,
+): Promise<TimeSlot[] | null> {
   const store = await getAvailabilityStore();
   if (!store) return null;
   try {
@@ -69,7 +72,10 @@ export async function setCachedAvailability(
   const store = await getAvailabilityStore();
   if (!store) return;
   try {
-    const entry: CacheEntry = { slots, expiresAt: Date.now() + ttlSeconds * 1000 };
+    const entry: CacheEntry = {
+      slots,
+      expiresAt: Date.now() + ttlSeconds * 1000,
+    };
     await store.setJSON(key, entry);
   } catch {
     // Cache write failure is non-fatal
@@ -81,7 +87,9 @@ export async function invalidateAvailabilityCache(): Promise<void> {
   if (!store) return;
   try {
     const { blobs } = await store.list();
-    await Promise.allSettled(blobs.map((b: { key: string }) => store.delete(b.key)));
+    await Promise.allSettled(
+      blobs.map((b: { key: string }) => store.delete(b.key)),
+    );
   } catch {
     // Non-fatal — worst case: stale data served until TTL expires
   }

--- a/src/lib/google-calendar.ts
+++ b/src/lib/google-calendar.ts
@@ -16,6 +16,7 @@ import {
   cabinetEligibility,
   type DayHalf,
 } from './appointment-eligibility.js';
+import { isCalendarMockEnabled } from './mock-mode.server.js';
 
 // ---------------------------------------------------------------------------
 // Erreur typée
@@ -126,11 +127,6 @@ function readEnv(key: string): string | undefined {
 // ---------------------------------------------------------------------------
 // Mock mode
 // ---------------------------------------------------------------------------
-
-/** Mock flag read lazily — identical behavior, just no module-scope env read. */
-function isMockMode(): boolean {
-  return readEnv('GOOGLE_CALENDAR_MOCK') === 'true';
-}
 
 // ---------------------------------------------------------------------------
 // DI seam (issue #126 / T12)
@@ -546,7 +542,7 @@ export async function getAvailableSlots(
   dbBusyPeriods: Array<{ start: string; end: string }> = [],
   options: CalendarClientOptions = {},
 ): Promise<TimeSlot[]> {
-  if (isMockMode()) {
+  if (isCalendarMockEnabled()) {
     console.log('[calendar-mock] getAvailableSlots called — generating slots via shared algorithm');
 
     // Mock = pas de Google Calendar : on réutilise le même moteur de génération
@@ -727,7 +723,7 @@ export async function updateCalendarEvent(
   patch: { start?: Date; end?: Date; summary?: string },
   options: CalendarClientOptions = {},
 ): Promise<void> {
-  if (isMockMode()) {
+  if (isCalendarMockEnabled()) {
     console.log(`[calendar-mock] Updating event ${eventId}:`, patch);
     return;
   }
@@ -756,7 +752,7 @@ export async function deleteCalendarEvent(
   eventId: string,
   options: CalendarClientOptions = {},
 ): Promise<void> {
-  if (isMockMode()) {
+  if (isCalendarMockEnabled()) {
     console.log(`[calendar-mock] Deleting event ${eventId}`);
     return;
   }
@@ -781,7 +777,7 @@ export async function createCalendarEvent(
   params: CreateEventParams,
   options: CalendarClientOptions = {},
 ): Promise<CreateEventResult> {
-  if (isMockMode()) {
+  if (isCalendarMockEnabled()) {
     console.log(`[calendar-mock] Creating event: ${params.title} at ${params.start}`);
     const { withMeet, appointmentId } = params;
     const eventId = `mock-event-${Date.now()}`;

--- a/src/lib/mock-mode.server.ts
+++ b/src/lib/mock-mode.server.ts
@@ -1,0 +1,61 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+
+export const MOCK_WEBHOOK_TOKEN_HEADER = 'x-omf-mock-webhook-token';
+export const MOCK_WEBHOOK_TOKEN_QUERY_PARAM = 'mock_token';
+
+function readEnv(key: string): string | boolean | undefined {
+  const fromMeta = (import.meta as {
+    env?: Record<string, string | boolean | undefined>;
+  }).env?.[key];
+  return fromMeta ?? process.env[key];
+}
+
+/**
+ * Calendar and payment mocks are local development capabilities only.
+ */
+export function isCalendarMockEnabled(): boolean {
+  const development = readEnv('DEV');
+  return (
+    (development === true || development === 'true') &&
+    readEnv('GOOGLE_CALENDAR_MOCK') === 'true'
+  );
+}
+
+export function isLoopbackHostname(hostname: string): boolean {
+  const normalized = hostname.trim().toLowerCase();
+  return (
+    normalized === 'localhost' ||
+    normalized === '127.0.0.1' ||
+    normalized === '::1' ||
+    normalized === '[::1]'
+  );
+}
+
+export function getMockWebhookToken(): string | null {
+  const token = readEnv('MOCK_WEBHOOK_TOKEN');
+  return token && token.trim().length > 0 ? token : null;
+}
+
+function digestToken(token: string): Buffer {
+  return createHash('sha256').update(token, 'utf8').digest();
+}
+
+export function hasValidMockWebhookToken(
+  candidate: string | null | undefined,
+): boolean {
+  const configuredToken = getMockWebhookToken();
+  if (!configuredToken || !candidate) return false;
+
+  return timingSafeEqual(digestToken(candidate), digestToken(configuredToken));
+}
+
+export function isAuthorizedLocalMockRequest(
+  url: URL,
+  candidateToken: string | null | undefined,
+): boolean {
+  return (
+    isCalendarMockEnabled() &&
+    isLoopbackHostname(url.hostname) &&
+    hasValidMockWebhookToken(candidateToken)
+  );
+}

--- a/src/lib/mock-mode.server.ts
+++ b/src/lib/mock-mode.server.ts
@@ -3,13 +3,6 @@ import { createHash, timingSafeEqual } from 'node:crypto';
 export const MOCK_WEBHOOK_TOKEN_HEADER = 'x-omf-mock-webhook-token';
 export const MOCK_WEBHOOK_TOKEN_QUERY_PARAM = 'mock_token';
 
-function readEnv(key: string): string | boolean | undefined {
-  const fromMeta = (import.meta as {
-    env?: Record<string, string | boolean | undefined>;
-  }).env?.[key];
-  return fromMeta ?? process.env[key];
-}
-
 const MIN_MOCK_WEBHOOK_TOKEN_LENGTH = 32;
 const MOCK_WEBHOOK_TOKEN_SENTINELS = new Set([
   'remplacer-par-un-token-aleatoire-local',
@@ -23,11 +16,16 @@ const MOCK_WEBHOOK_TOKEN_SENTINELS = new Set([
  * Calendar and payment mocks are local development capabilities only.
  */
 export function isCalendarMockEnabled(): boolean {
-  const development = readEnv('DEV');
-  return (
-    (development === true || development === 'true') &&
-    readEnv('GOOGLE_CALENDAR_MOCK') === 'true'
-  );
+  try {
+    return (
+      import.meta.env.DEV && import.meta.env.GOOGLE_CALENDAR_MOCK === 'true'
+    );
+  } catch {
+    return (
+      process.env.DEV === 'true' &&
+      process.env.GOOGLE_CALENDAR_MOCK === 'true'
+    );
+  }
 }
 
 export function isLoopbackHostname(hostname: string): boolean {
@@ -41,9 +39,13 @@ export function isLoopbackHostname(hostname: string): boolean {
 }
 
 export function getMockWebhookToken(): string | null {
-  const configuredToken = readEnv('MOCK_WEBHOOK_TOKEN');
-  const token =
-    typeof configuredToken === 'string' ? configuredToken.trim() : '';
+  let configuredToken: string | undefined;
+  try {
+    configuredToken = import.meta.env.MOCK_WEBHOOK_TOKEN;
+  } catch {
+    configuredToken = process.env.MOCK_WEBHOOK_TOKEN;
+  }
+  const token = configuredToken?.trim() ?? '';
   if (
     token.length < MIN_MOCK_WEBHOOK_TOKEN_LENGTH ||
     MOCK_WEBHOOK_TOKEN_SENTINELS.has(token.toLowerCase())

--- a/src/lib/mock-mode.server.ts
+++ b/src/lib/mock-mode.server.ts
@@ -10,6 +10,15 @@ function readEnv(key: string): string | boolean | undefined {
   return fromMeta ?? process.env[key];
 }
 
+const MIN_MOCK_WEBHOOK_TOKEN_LENGTH = 32;
+const MOCK_WEBHOOK_TOKEN_SENTINELS = new Set([
+  'remplacer-par-un-token-aleatoire-local',
+  'replace-with-a-random-local-token',
+  'change-me',
+  'changeme',
+  'placeholder',
+]);
+
 /**
  * Calendar and payment mocks are local development capabilities only.
  */
@@ -32,8 +41,17 @@ export function isLoopbackHostname(hostname: string): boolean {
 }
 
 export function getMockWebhookToken(): string | null {
-  const token = readEnv('MOCK_WEBHOOK_TOKEN');
-  return token && token.trim().length > 0 ? token : null;
+  const configuredToken = readEnv('MOCK_WEBHOOK_TOKEN');
+  const token =
+    typeof configuredToken === 'string' ? configuredToken.trim() : '';
+  if (
+    token.length < MIN_MOCK_WEBHOOK_TOKEN_LENGTH ||
+    MOCK_WEBHOOK_TOKEN_SENTINELS.has(token.toLowerCase())
+  ) {
+    return null;
+  }
+
+  return token;
 }
 
 function digestToken(token: string): Buffer {

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -6,6 +6,11 @@
  */
 
 import Stripe from 'stripe';
+import {
+  getMockWebhookToken,
+  isCalendarMockEnabled,
+  MOCK_WEBHOOK_TOKEN_QUERY_PARAM,
+} from './mock-mode.server.js';
 
 // ---------------------------------------------------------------------------
 // Lazy initialization — this module must be importable from runtimes where
@@ -120,13 +125,23 @@ export async function createAppointmentPaymentLink(
   const { appointmentId, amount, description, successUrl } = params;
   const redirectUrl = buildStripeSuccessUrl(successUrl);
 
-  // Dev/test bypass: return a mock payment link when Stripe key is placeholder
-  if (isStripeMock()) {
+  // Local development bypass: never activate from a deployed build.
+  if (isStripeMock() && isCalendarMockEnabled()) {
+    const mockWebhookToken = getMockWebhookToken();
+    if (!mockWebhookToken) {
+      throw new Error(
+        'MOCK_WEBHOOK_TOKEN doit être configuré pour utiliser le paiement simulé local.',
+      );
+    }
     console.warn('[stripe] 🔧 Mode dev — lien de paiement simulé (clé Stripe placeholder)');
     const mockUrl = withQueryParam(
-      withQueryParam(redirectUrl, 'mock', '1'),
-      'appointment_id',
-      appointmentId,
+      withQueryParam(
+        withQueryParam(redirectUrl, 'mock', '1'),
+        'appointment_id',
+        appointmentId,
+      ),
+      MOCK_WEBHOOK_TOKEN_QUERY_PARAM,
+      mockWebhookToken,
     );
     return {
       id: `mock_pl_${appointmentId}`,

--- a/src/pages/api/stripe-webhook.ts
+++ b/src/pages/api/stripe-webhook.ts
@@ -141,7 +141,8 @@ export const POST: APIRoute = async ({ request }) => {
 };
 
 export const GET: APIRoute = async ({ url }) => {
-  const isMockMode = import.meta.env.GOOGLE_CALENDAR_MOCK === 'true';
+  const isMockMode =
+    import.meta.env.DEV && import.meta.env.GOOGLE_CALENDAR_MOCK === 'true';
   if (!isMockMode) {
     return new Response('Mode mock non activé', { status: 403 });
   }

--- a/src/pages/api/stripe-webhook.ts
+++ b/src/pages/api/stripe-webhook.ts
@@ -3,6 +3,10 @@ export const prerender = false;
 import type { APIRoute } from 'astro';
 import type Stripe from 'stripe';
 import { getStripe } from '../../lib/stripe';
+import {
+  isAuthorizedLocalMockRequest,
+  MOCK_WEBHOOK_TOKEN_HEADER,
+} from '../../lib/mock-mode.server';
 import { supabaseAdmin } from '../../lib/supabase';
 import { logger } from '../../lib/logger';
 import { getTypeLabel, getModeLabel } from '../../lib/pricing';
@@ -140,11 +144,10 @@ export const POST: APIRoute = async ({ request }) => {
   });
 };
 
-export const GET: APIRoute = async ({ url }) => {
-  const isMockMode =
-    import.meta.env.DEV && import.meta.env.GOOGLE_CALENDAR_MOCK === 'true';
-  if (!isMockMode) {
-    return new Response('Mode mock non activé', { status: 403 });
+export const GET: APIRoute = async ({ request, url }) => {
+  const capability = request.headers.get(MOCK_WEBHOOK_TOKEN_HEADER);
+  if (!isAuthorizedLocalMockRequest(url, capability)) {
+    return new Response('Accès mock refusé', { status: 403 });
   }
 
   const mockEnabled = url.searchParams.get('mock') === '1';
@@ -162,10 +165,19 @@ export const GET: APIRoute = async ({ url }) => {
     const eventId = `evt_mock_${appointmentId.replace(/[^a-z0-9]/gi, '').slice(0, 20)}`;
     await handlePaymentSucceeded(appointmentId, paymentIntentId, eventId);
 
-    return new Response(JSON.stringify({ ok: true, mocked: true, appointmentId }), {
-      status: 200,
-      headers: { 'Content-Type': 'application/json' },
-    });
+    return new Response(
+      JSON.stringify({
+        ok: true,
+        mocked: true,
+        appointmentId,
+        paymentIntentId,
+        eventId,
+      }),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    );
   } catch (err) {
     logger.error('stripe-webhook: mock GET handler failed', { appointmentId }, err);
     return new Response(JSON.stringify({ ok: false, error: 'Erreur interne mock' }), {

--- a/src/pages/rdv/merci.astro
+++ b/src/pages/rdv/merci.astro
@@ -19,6 +19,11 @@ import Layout from '../../layouts/Layout.astro';
 import Navbar from '../../components/islands/Navbar';
 import type { AppointmentType, AppointmentMode } from '../../types/appointment';
 import { getTypeLabel, getModeLabel } from '../../lib/pricing';
+import {
+  isAuthorizedLocalMockRequest,
+  MOCK_WEBHOOK_TOKEN_HEADER,
+  MOCK_WEBHOOK_TOKEN_QUERY_PARAM,
+} from '../../lib/mock-mode.server';
 
 // ── Lecture des paramètres URL ───────────────────────────────────────────────
 const url = Astro.url;
@@ -31,6 +36,7 @@ const legacyPaiement = url.searchParams.get('paiement');
 const hasStripeSessionId = url.searchParams.has('session_id');
 const isMockPayment = url.searchParams.get('mock') === '1';
 const mockAppointmentId = url.searchParams.get('appointment_id');
+const mockWebhookToken = url.searchParams.get(MOCK_WEBHOOK_TOKEN_QUERY_PARAM);
 
 const VALID_TYPES  = new Set(['individual', 'couple', 'family']);
 const VALID_MODES  = new Set(['in-person', 'video']);
@@ -61,21 +67,43 @@ type MerciVariant =
   | 'payment-pending'
   | 'payment-success';
 
-const variant: MerciVariant =
-  sourceParam === 'payment-success' || hasStripeSessionId || isMockPayment ? 'payment-success'
-  : sourceParam === 'payment-pending' || legacyPaiement === 'en-attente' ? 'payment-pending'
-  : 'request-confirmed';
-
-if (isMockPayment && mockAppointmentId) {
+let mockPaymentSucceeded = false;
+if (
+  isMockPayment &&
+  mockAppointmentId &&
+  mockWebhookToken &&
+  isAuthorizedLocalMockRequest(url, mockWebhookToken)
+) {
   try {
     const webhookMockUrl = new URL('/api/stripe-webhook/', url);
     webhookMockUrl.searchParams.set('mock', '1');
     webhookMockUrl.searchParams.set('appointment_id', mockAppointmentId);
-    await fetch(webhookMockUrl, { method: 'GET' });
+    const response = await fetch(webhookMockUrl, {
+      method: 'GET',
+      headers: { [MOCK_WEBHOOK_TOKEN_HEADER]: mockWebhookToken },
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (!response.ok) {
+      console.error(
+        `[rdv/merci] Webhook mock refusé ou en échec (${response.status}).`,
+      );
+    } else {
+      mockPaymentSucceeded = true;
+    }
   } catch (err) {
     console.error('[rdv/merci] Erreur déclenchement webhook mock:', err);
   }
 }
+
+const variant: MerciVariant = isMockPayment
+  ? mockPaymentSucceeded
+    ? 'payment-success'
+    : 'payment-pending'
+  : sourceParam === 'payment-success' || hasStripeSessionId
+    ? 'payment-success'
+    : sourceParam === 'payment-pending' || legacyPaiement === 'en-attente'
+      ? 'payment-pending'
+      : 'request-confirmed';
 
 const pageTitle = variant === 'payment-success'
   ? 'Paiement reçu — OMF Thérapie'

--- a/tests/unit/mock-mode.test.ts
+++ b/tests/unit/mock-mode.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  hasValidMockWebhookToken,
+  isAuthorizedLocalMockRequest,
+  isCalendarMockEnabled,
+  isLoopbackHostname,
+  MOCK_WEBHOOK_TOKEN_QUERY_PARAM,
+} from '@/lib/mock-mode.server';
+
+beforeEach(() => {
+  vi.stubEnv('DEV', true);
+  vi.stubEnv('GOOGLE_CALENDAR_MOCK', 'true');
+  vi.stubEnv('MOCK_WEBHOOK_TOKEN', 'test-mock-webhook-token');
+  vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_placeholder');
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+describe('local mock mode', () => {
+  it('enables calendar mocks only in Astro development', () => {
+    expect(isCalendarMockEnabled()).toBe(true);
+
+    vi.stubEnv('DEV', false);
+
+    expect(isCalendarMockEnabled()).toBe(false);
+  });
+
+  it.each(['localhost', '127.0.0.1', '::1', '[::1]'])(
+    'accepts the loopback hostname %s',
+    hostname => {
+      expect(isLoopbackHostname(hostname)).toBe(true);
+    },
+  );
+
+  it('rejects non-loopback hostnames', () => {
+    expect(isLoopbackHostname('omf-therapie.fr')).toBe(false);
+  });
+
+  it('accepts only the configured capability token', () => {
+    expect(hasValidMockWebhookToken('test-mock-webhook-token')).toBe(true);
+    expect(hasValidMockWebhookToken('wrong-token')).toBe(false);
+    expect(hasValidMockWebhookToken(null)).toBe(false);
+  });
+
+  it('rejects authorization when the configured token is missing', () => {
+    vi.stubEnv('MOCK_WEBHOOK_TOKEN', '');
+
+    expect(
+      isAuthorizedLocalMockRequest(
+        new URL('http://localhost/api/stripe-webhook/'),
+        'test-mock-webhook-token',
+      ),
+    ).toBe(false);
+  });
+
+  it('rejects authorization outside loopback', () => {
+    expect(
+      isAuthorizedLocalMockRequest(
+        new URL('https://omf-therapie.fr/api/stripe-webhook/'),
+        'test-mock-webhook-token',
+      ),
+    ).toBe(false);
+  });
+
+  it('adds the capability to a generated local Stripe mock redirect', async () => {
+    vi.resetModules();
+    const { createAppointmentPaymentLink } = await import('@/lib/stripe');
+
+    const result = await createAppointmentPaymentLink({
+      appointmentId: 'appt_001',
+      patientEmail: 'patient@example.com',
+      patientName: 'Jean Dupont',
+      amount: 5000,
+      description: 'Séance vidéo',
+      successUrl: 'http://localhost:4321/rdv/merci/',
+    });
+    const redirect = new URL(result.url);
+
+    expect(redirect.searchParams.get('mock')).toBe('1');
+    expect(redirect.searchParams.get('appointment_id')).toBe('appt_001');
+    expect(redirect.searchParams.get(MOCK_WEBHOOK_TOKEN_QUERY_PARAM)).toBe(
+      'test-mock-webhook-token',
+    );
+  });
+});

--- a/tests/unit/mock-mode.test.ts
+++ b/tests/unit/mock-mode.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  getMockWebhookToken,
   hasValidMockWebhookToken,
   isAuthorizedLocalMockRequest,
   isCalendarMockEnabled,
@@ -7,10 +8,13 @@ import {
   MOCK_WEBHOOK_TOKEN_QUERY_PARAM,
 } from '@/lib/mock-mode.server';
 
+const STRONG_MOCK_WEBHOOK_TOKEN =
+  '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
 beforeEach(() => {
   vi.stubEnv('DEV', true);
   vi.stubEnv('GOOGLE_CALENDAR_MOCK', 'true');
-  vi.stubEnv('MOCK_WEBHOOK_TOKEN', 'test-mock-webhook-token');
+  vi.stubEnv('MOCK_WEBHOOK_TOKEN', STRONG_MOCK_WEBHOOK_TOKEN);
   vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_placeholder');
 });
 
@@ -40,18 +44,26 @@ describe('local mock mode', () => {
   });
 
   it('accepts only the configured capability token', () => {
-    expect(hasValidMockWebhookToken('test-mock-webhook-token')).toBe(true);
+    expect(hasValidMockWebhookToken(STRONG_MOCK_WEBHOOK_TOKEN)).toBe(true);
     expect(hasValidMockWebhookToken('wrong-token')).toBe(false);
     expect(hasValidMockWebhookToken(null)).toBe(false);
   });
 
-  it('rejects authorization when the configured token is missing', () => {
-    vi.stubEnv('MOCK_WEBHOOK_TOKEN', '');
+  it.each([
+    { label: 'empty', token: '' },
+    { label: 'short', token: 'short-token' },
+    {
+      label: 'sentinel',
+      token: 'remplacer-par-un-token-aleatoire-local',
+    },
+  ])('rejects a configured $label token', ({ token }) => {
+    vi.stubEnv('MOCK_WEBHOOK_TOKEN', token);
 
+    expect(getMockWebhookToken()).toBeNull();
     expect(
       isAuthorizedLocalMockRequest(
         new URL('http://localhost/api/stripe-webhook/'),
-        'test-mock-webhook-token',
+        token,
       ),
     ).toBe(false);
   });
@@ -60,7 +72,7 @@ describe('local mock mode', () => {
     expect(
       isAuthorizedLocalMockRequest(
         new URL('https://omf-therapie.fr/api/stripe-webhook/'),
-        'test-mock-webhook-token',
+        STRONG_MOCK_WEBHOOK_TOKEN,
       ),
     ).toBe(false);
   });
@@ -82,7 +94,7 @@ describe('local mock mode', () => {
     expect(redirect.searchParams.get('mock')).toBe('1');
     expect(redirect.searchParams.get('appointment_id')).toBe('appt_001');
     expect(redirect.searchParams.get(MOCK_WEBHOOK_TOKEN_QUERY_PARAM)).toBe(
-      'test-mock-webhook-token',
+      STRONG_MOCK_WEBHOOK_TOKEN,
     );
   });
 });

--- a/tests/unit/stripe-webhook.test.ts
+++ b/tests/unit/stripe-webhook.test.ts
@@ -57,7 +57,9 @@ vi.mock('@/lib/stripe', () => ({ getStripe: () => null }));
 
 // --- Import after mocks -----------------------------------------------------
 
-import { handlePaymentSucceeded } from '@/pages/api/stripe-webhook';
+import { GET, handlePaymentSucceeded } from '@/pages/api/stripe-webhook';
+import { supabaseAdmin } from '@/lib/supabase';
+import { createCalendarEvent } from '@/lib/google-calendar';
 
 // --- Helpers ----------------------------------------------------------------
 
@@ -108,6 +110,8 @@ function mockRetryReRead(apptOverrides: Partial<Record<string, unknown>> = {}) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.stubEnv('DEV', true);
+  vi.stubEnv('GOOGLE_CALENDAR_MOCK', 'false');
   // Default: the mark-delivered UPDATE succeeds.
   mockSupabaseChain.update.mockReturnThis();
   mockSupabaseChain.eq.mockReturnThis();
@@ -115,6 +119,46 @@ beforeEach(() => {
   mockSupabaseChain.select.mockReturnThis();
   // Default email result: success.
   mockBuildAndSend.mockResolvedValue({ patientEmailSent: true, therapistEmailSent: true });
+});
+
+// ---------------------------------------------------------------------------
+// Mock GET route — available only in explicit local development mode
+// ---------------------------------------------------------------------------
+
+describe('GET — development mock gate', () => {
+  async function callMockGet(): Promise<Response> {
+    return GET({
+      url: new URL(
+        'http://localhost/api/stripe-webhook/?mock=1&appointment_id=appt_001',
+      ),
+    } as Parameters<typeof GET>[0]);
+  }
+
+  function expectNoPaymentSideEffects(): void {
+    expect(supabaseAdmin.from).not.toHaveBeenCalled();
+    expect(mockBuildAndSend).not.toHaveBeenCalled();
+    expect(createCalendarEvent).not.toHaveBeenCalled();
+  }
+
+  it('returns 403 outside development even when calendar mock mode is enabled', async () => {
+    vi.stubEnv('DEV', false);
+    vi.stubEnv('GOOGLE_CALENDAR_MOCK', 'true');
+
+    const response = await callMockGet();
+
+    expect(response.status).toBe(403);
+    expectNoPaymentSideEffects();
+  });
+
+  it('returns 403 in development when calendar mock mode is disabled', async () => {
+    vi.stubEnv('DEV', true);
+    vi.stubEnv('GOOGLE_CALENDAR_MOCK', 'false');
+
+    const response = await callMockGet();
+
+    expect(response.status).toBe(403);
+    expectNoPaymentSideEffects();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -131,7 +175,7 @@ describe('handlePaymentSucceeded — L2 gate (confirmation_sent_at)', () => {
 
     // Assert — NO email sent, NO calendar event created, NO mark-delivered UPDATE.
     expect(mockBuildAndSend).not.toHaveBeenCalled();
-    expect(vi.mocked(await import('@/lib/google-calendar')).createCalendarEvent).not.toHaveBeenCalled();
+    expect(createCalendarEvent).not.toHaveBeenCalled();
     // The only UPDATEs should be the N1 (which failed) — no mark-delivered.
     // We check that .update was not called with confirmation_sent_at by verifying
     // buildAndSend was never called (the side effect that precedes the mark).

--- a/tests/unit/stripe-webhook.test.ts
+++ b/tests/unit/stripe-webhook.test.ts
@@ -13,7 +13,8 @@
  * Externals are mocked via vi.mock: supabaseAdmin (chained query builder),
  * createCalendarEvent, and buildAndSendConfirmationEmails (the shared module).
  */
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MOCK_WEBHOOK_TOKEN_HEADER } from '@/lib/mock-mode.server';
 
 // --- Mocks must be hoisted before imports -----------------------------------
 
@@ -43,7 +44,8 @@ vi.mock('@/lib/google-calendar', () => ({
 // Mock buildAndSendConfirmationEmails — controllable per-test.
 const mockBuildAndSend = vi.fn();
 vi.mock('@/lib/notifications', () => ({
-  buildAndSendConfirmationEmails: (...args: unknown[]) => mockBuildAndSend(...args),
+  buildAndSendConfirmationEmails: (...args: unknown[]) =>
+    mockBuildAndSend(...args),
 }));
 
 // Mock pricing labels (pure functions, but imported by the webhook).
@@ -64,7 +66,9 @@ import { createCalendarEvent } from '@/lib/google-calendar';
 // --- Helpers ----------------------------------------------------------------
 
 /** Sets up the mock chain for the initial UPDATE (N1) to "win" (first deliverer). */
-function mockFirstDeliveryWins(apptOverrides: Partial<Record<string, unknown>> = {}) {
+function mockFirstDeliveryWins(
+  apptOverrides: Partial<Record<string, unknown>> = {},
+) {
   const appt = {
     id: 'appt_001',
     patient_name: 'Jean Dupont',
@@ -103,22 +107,36 @@ function mockRetryReRead(apptOverrides: Partial<Record<string, unknown>> = {}) {
     ...apptOverrides,
   };
   // N1 UPDATE fails (already processed) → re-read via .maybeSingle().
-  mockSupabaseChain.single.mockResolvedValueOnce({ data: null, error: { message: 'no rows' } });
-  mockSupabaseChain.maybeSingle.mockResolvedValueOnce({ data: appt, error: null });
+  mockSupabaseChain.single.mockResolvedValueOnce({
+    data: null,
+    error: { message: 'no rows' },
+  });
+  mockSupabaseChain.maybeSingle.mockResolvedValueOnce({
+    data: appt,
+    error: null,
+  });
   return appt;
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
   vi.stubEnv('DEV', true);
-  vi.stubEnv('GOOGLE_CALENDAR_MOCK', 'false');
+  vi.stubEnv('GOOGLE_CALENDAR_MOCK', 'true');
+  vi.stubEnv('MOCK_WEBHOOK_TOKEN', 'test-mock-webhook-token');
   // Default: the mark-delivered UPDATE succeeds.
   mockSupabaseChain.update.mockReturnThis();
   mockSupabaseChain.eq.mockReturnThis();
   mockSupabaseChain.is.mockReturnThis();
   mockSupabaseChain.select.mockReturnThis();
   // Default email result: success.
-  mockBuildAndSend.mockResolvedValue({ patientEmailSent: true, therapistEmailSent: true });
+  mockBuildAndSend.mockResolvedValue({
+    patientEmailSent: true,
+    therapistEmailSent: true,
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
 });
 
 // ---------------------------------------------------------------------------
@@ -126,11 +144,22 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 
 describe('GET — development mock gate', () => {
-  async function callMockGet(): Promise<Response> {
+  async function callMockGet({
+    hostname = 'localhost',
+    query = 'mock=1&appointment_id=appt_001',
+    token = 'test-mock-webhook-token',
+  }: {
+    hostname?: string;
+    query?: string;
+    token?: string | null;
+  } = {}): Promise<Response> {
+    const url = new URL(`http://${hostname}/api/stripe-webhook/?${query}`);
+    const headers = new Headers();
+    if (token) headers.set(MOCK_WEBHOOK_TOKEN_HEADER, token);
+
     return GET({
-      url: new URL(
-        'http://localhost/api/stripe-webhook/?mock=1&appointment_id=appt_001',
-      ),
+      request: new Request(url, { headers }),
+      url,
     } as Parameters<typeof GET>[0]);
   }
 
@@ -158,6 +187,72 @@ describe('GET — development mock gate', () => {
 
     expect(response.status).toBe(403);
     expectNoPaymentSideEffects();
+  });
+
+  it('returns 403 when the capability header is missing', async () => {
+    const response = await callMockGet({ token: null });
+
+    expect(response.status).toBe(403);
+    expectNoPaymentSideEffects();
+  });
+
+  it('returns 403 when the capability header is invalid', async () => {
+    const response = await callMockGet({ token: 'wrong-token' });
+
+    expect(response.status).toBe(403);
+    expectNoPaymentSideEffects();
+  });
+
+  it('returns 403 when the request hostname is not loopback', async () => {
+    const response = await callMockGet({ hostname: 'example.com' });
+
+    expect(response.status).toBe(403);
+    expectNoPaymentSideEffects();
+  });
+
+  it('returns 400 when mock=1 is missing from an authorized request', async () => {
+    const response = await callMockGet({ query: 'appointment_id=appt_001' });
+
+    expect(response.status).toBe(400);
+    await expect(response.text()).resolves.toBe('Paramètre mock=1 requis');
+    expectNoPaymentSideEffects();
+  });
+
+  it('returns 400 when appointment_id is missing from an authorized request', async () => {
+    const response = await callMockGet({ query: 'mock=1' });
+
+    expect(response.status).toBe(400);
+    await expect(response.text()).resolves.toBe('appointment_id manquant');
+    expectNoPaymentSideEffects();
+  });
+
+  it('returns deterministic mock identifiers after an authorized payment succeeds', async () => {
+    mockFirstDeliveryWins();
+
+    const response = await callMockGet();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      mocked: true,
+      appointmentId: 'appt_001',
+      paymentIntentId: 'pi_mock_appt001',
+      eventId: 'evt_mock_appt001',
+    });
+    expect(mockBuildAndSend).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns a bounded JSON 500 when payment processing fails', async () => {
+    mockFirstDeliveryWins();
+    mockBuildAndSend.mockRejectedValueOnce(new Error('delivery unavailable'));
+
+    const response = await callMockGet();
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: 'Erreur interne mock',
+    });
   });
 });
 
@@ -190,7 +285,10 @@ describe('handlePaymentSucceeded — throw on patient email failure', () => {
   it('throws and does not set confirmation_sent_at when patientEmailSent is false', async () => {
     // Arrange — first delivery wins, but the email send returns failure.
     mockFirstDeliveryWins();
-    mockBuildAndSend.mockResolvedValueOnce({ patientEmailSent: false, therapistEmailSent: true });
+    mockBuildAndSend.mockResolvedValueOnce({
+      patientEmailSent: false,
+      therapistEmailSent: true,
+    });
 
     // Act + Assert — the function must throw so the POST handler returns 500.
     await expect(
@@ -211,7 +309,10 @@ describe('handlePaymentSucceeded — mark delivered on success', () => {
   it('sets confirmation_sent_at after successful patient email', async () => {
     // Arrange — first delivery wins, email succeeds.
     mockFirstDeliveryWins();
-    mockBuildAndSend.mockResolvedValueOnce({ patientEmailSent: true, therapistEmailSent: true });
+    mockBuildAndSend.mockResolvedValueOnce({
+      patientEmailSent: true,
+      therapistEmailSent: true,
+    });
 
     // Act
     await handlePaymentSucceeded('appt_001', 'pi_test_123', 'evt_001');

--- a/tests/unit/stripe-webhook.test.ts
+++ b/tests/unit/stripe-webhook.test.ts
@@ -16,6 +16,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MOCK_WEBHOOK_TOKEN_HEADER } from '@/lib/mock-mode.server';
 
+const STRONG_MOCK_WEBHOOK_TOKEN =
+  '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
 // --- Mocks must be hoisted before imports -----------------------------------
 
 // Mock supabaseAdmin with a chainable builder so .from().update().eq()... works.
@@ -122,7 +125,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   vi.stubEnv('DEV', true);
   vi.stubEnv('GOOGLE_CALENDAR_MOCK', 'true');
-  vi.stubEnv('MOCK_WEBHOOK_TOKEN', 'test-mock-webhook-token');
+  vi.stubEnv('MOCK_WEBHOOK_TOKEN', STRONG_MOCK_WEBHOOK_TOKEN);
   // Default: the mark-delivered UPDATE succeeds.
   mockSupabaseChain.update.mockReturnThis();
   mockSupabaseChain.eq.mockReturnThis();
@@ -147,7 +150,7 @@ describe('GET — development mock gate', () => {
   async function callMockGet({
     hostname = 'localhost',
     query = 'mock=1&appointment_id=appt_001',
-    token = 'test-mock-webhook-token',
+    token = STRONG_MOCK_WEBHOOK_TOKEN,
   }: {
     hostname?: string;
     query?: string;


### PR DESCRIPTION
## ✅ Type of PR

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## 🗒️ Description

Empêche le webhook Stripe mock de valider un paiement hors du mode de développement explicite, même si `GOOGLE_CALENDAR_MOCK` est activé par erreur.

Closes #70

## 🚶‍➡️ Behavior

- Les appels mock hors développement reçoivent désormais une réponse HTTP 403 avant tout effet de bord.
- Le parcours mock local reste disponible lorsque `DEV` et `GOOGLE_CALENDAR_MOCK` sont tous deux actifs.
- La route conserve son import Stripe typé sans suppression TypeScript.

## 🧪 Steps to test

- [x] Vérifier le refus hors développement avec le mock calendrier actif.
- [x] Vérifier le refus en développement avec le mock calendrier inactif.
- [x] Vérifier l'absence d'écriture DB, d'email et d'événement calendrier sur les refus.
- [x] Exécuter `npm run typecheck` — 0 erreur.
- [x] Exécuter `npm run lint` — 0 erreur.
- [x] Exécuter la suite Vitest — 167/167 tests verts.
- [x] Exécuter `npm run build` — build Astro/Netlify réussi.